### PR TITLE
[ESSI-9] For holding location, use IUCAT API as authority

### DIFF
--- a/app/authorities/qa/authorities/iucat_libraries.rb
+++ b/app/authorities/qa/authorities/iucat_libraries.rb
@@ -1,0 +1,33 @@
+module Qa::Authorities
+  class IucatLibraries < Base
+    include WebServiceBase
+
+    def search(id)
+      all.select { |library| library[:code].match(id.to_s) }
+    end
+
+    def find(id)
+      data_for(id)[:library] || {}
+    end
+
+    def all
+      data_for('all')[:libraries] || []
+    end
+
+    private
+      def api_url
+        { development: 'http://iucat-feature-tadas.uits.iu.edu/api/library',
+          test: 'http://iucat-feature-tadas.uits.iu.edu/api/library',
+          production: 'http://iucat.iu.edu/api/library' }.with_indifferent_access[Rails.env]
+      end
+
+      def data_for(id)
+        begin 
+          result = json([api_url, id].join('/')).with_indifferent_access
+          result[:success] ? result[:data] : {}
+        rescue TypeError, JSON::ParserError, Faraday::ConnectionFailed
+          {}
+        end
+      end
+  end
+end

--- a/app/authorities/qa/authorities/iucat_libraries.rb
+++ b/app/authorities/qa/authorities/iucat_libraries.rb
@@ -15,15 +15,13 @@ module Qa::Authorities
     end
 
     private
-      def api_url
-        { development: 'http://iucat-feature-tadas.uits.iu.edu/api/library',
-          test: 'http://iucat-feature-tadas.uits.iu.edu/api/library',
-          production: 'http://iucat.iu.edu/api/library' }.with_indifferent_access[Rails.env]
+      def api_url(id)
+        [ESSI.config[:iucat_libraries][:url], id].join('/')
       end
 
       def data_for(id)
         begin 
-          result = json([api_url, id].join('/')).with_indifferent_access
+          result = json(api_url(id)).with_indifferent_access
           result[:success] ? result[:data] : {}
         rescue TypeError, JSON::ParserError, Faraday::ConnectionFailed
           {}

--- a/app/renderers/holding_location_attribute_renderer.rb
+++ b/app/renderers/holding_location_attribute_renderer.rb
@@ -18,14 +18,31 @@ class HoldingLocationAttributeRenderer < Hyrax::Renderers::AttributeRenderer
 
     def location_string(loc)
       return unless loc
-      contact_string = safe_join(['Contact at ',
-                                  content_tag(:a,
-                                              loc.fetch('contact_email'),
-                                              href: "mailto:#{loc.fetch('contact_email')}"),
-                                  ', ',
-                                  content_tag(:a,
-                                              loc.fetch('phone_number'),
-                                              href: "tel:#{loc.fetch('phone_number')}")])
-      safe_join([loc.fetch('term'), loc.fetch('address'), contact_string], tag(:br))
+      safe_join([label_string(loc), address_string(loc), contact_string(loc)].select(&:present?), tag(:br))
+    end
+
+    def label_string(loc)
+      loc.dig(:label)
+    end
+
+    def address_string(loc)
+      address_lines = [loc.dig(:address), loc.dig(:address2)]
+      address_lines << safe_join([safe_join([loc.dig(:city),
+                                            loc.dig(:state)].select(&:present?),
+                                           ', '),
+                                  loc.dig(:zip)].select(&:present?),
+                                  ' ')
+      safe_join(address_lines.select(&:present?), tag(:br))
+    end
+
+    def contact_string(loc)
+      safe_join(['Contact at ',
+                 content_tag(:a,
+                             loc.dig(:email),
+                             href: "mailto:#{loc.dig(:email)}"),
+                 ', ',
+                 content_tag(:a,
+                             loc.dig(:phone),
+                             href: "tel:#{loc.dig(:phone)}")])
     end
 end

--- a/app/services/holding_location_service.rb
+++ b/app/services/holding_location_service.rb
@@ -1,14 +1,14 @@
 module HoldingLocationService
   mattr_accessor :authority
-  self.authority = Qa::Authorities::Local.subauthority_for('holding_locations')
+  self.authority = Qa::Authorities::IucatLibraries.new
 
   def self.select_options
-    authority.all.map { |element| [element['label'], element['id']] }.sort
+    authority.all.map { |element| [element[:label], element[:code]] }.sort
   end
 
   def self.select_all_options
     authority.all.map do |element|
-      [element[:label], element[:id]]
+      [element[:label], element[:code]]
     end
   end
 

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -18,6 +18,8 @@ default: &default
     secret_key_base: 628b30efcdf28acbbd30a80e53e2b743d44f74bf393462badc49e0f5909ed109812ff12905e3a98bf4f81d3618fac5c061ad4e1ca5c91f9c1dce8226ca3cff25
   derivatives:
     path: <%= Rails.root.join("tmp/derivatives") %>
+  iucat_libraries:
+    url: http://iucat-feature-tadas.uits.iu.edu/api/library
   ldap:
     enabled: false
     host: ads.iu.edu

--- a/spec/authorities/qa/authorities/iucat_libraries_spec.rb
+++ b/spec/authorities/qa/authorities/iucat_libraries_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Qa::Authorities::IucatLibraries do
+  let(:authority) { described_class.new }
+  let(:matching_id) { 'B-WELLS' }
+  let(:nonmatching_id) { 'foobar' }
+
+  context 'with server response', vcr: { cassette_name: 'iucat_libraries_up', record: :new_episodes } do
+    describe '#all' do
+      let(:result) { authority.all }
+      it 'returns a populated Array' do
+        expect(result).to be_a Array
+        expect(result).not_to be_empty
+      end
+    end
+
+    describe '#find' do
+      context 'with a matching id' do
+        let(:result) { authority.find(matching_id) }
+        it 'returns a Hash' do
+          expect(result).to be_a Hash
+          expect(result).not_to be_empty
+        end
+      end
+      context 'with a non-matching id' do
+        let(:result) { authority.find(nonmatching_id) }
+        it 'returns an empty Hash' do
+          expect(result).to be_a Hash
+          expect(result).to be_empty
+        end
+      end
+    end
+
+    describe '#search' do
+      context 'with a matching id' do
+        let(:result) { authority.search(matching_id) }
+        it 'returns a populated Array' do
+          expect(result).to be_a Array
+          expect(result).not_to be_empty
+        end
+      end
+      context 'with a non-matching id' do
+        let(:result) { authority.search(nonmatching_id) }
+        it 'returns an empty Array' do
+          expect(result).to be_a Array
+          expect(result).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/iucat_libraries_up.yml
+++ b/spec/cassettes/iucat_libraries_up.yml
@@ -1,0 +1,222 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://iucat-feature-tadas.uits.iu.edu/api/library/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Dec 2018 23:22:08 GMT
+      Server:
+      - Apache/2.2.15 (Red Hat)
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - W/"81023d70065fb7cc5c9fb88c0ef39964"
+      X-Frame-Options:
+      - ALLOWALL
+      X-Runtime:
+      - '0.084241'
+      X-Request-Id:
+      - c3244fac-8fab-4ac3-8593-856f48425858
+      X-Powered-By:
+      - Phusion Passenger 5.1.3
+      Set-Cookie:
+      - _Blacklight5_session=9bf0de2d9de18207d7e2d5afd41ec325; path=/; HttpOnly
+      Status:
+      - 200 OK
+      Access-Control-Allow-Origin:
+      - "*"
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"data":{"libraries":[{"id":41,"code":"B-AAAMC","label":"Bloomington
+        - Archives of African American Music \u0026 Culture","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:53:00.000Z"},{"id":5,"code":"B-ALF","label":"Bloomington
+        - Auxiliary Library Facility","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:53:31.000Z"},{"id":3,"code":"B-ARCHIVES","label":"Bloomington
+        - University Archives","address":"Wells Library E460","address2":"1320 E 10th
+        St.","city":"Bloomington","state":"IN","zip":"47405","phone":"8128551127","email":"archives@indiana.edu","url":"https://libraries.indiana.edu/archives","urlHours":"https://libraries.indiana.edu/archives/hours","latitude":"39.17098","longitude":"-86.516189","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:59:08.000Z"},{"id":14,"code":"B-ATM","label":"Bloomington-
+        Archives of Traditional Music","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:53:16.000Z"},{"id":2,"code":"B-BCC","label":"Bloomington
+        - Neal-Marshall Black Culture Center Library","address":"Neal-Marshall Center
+        A113","address2":"275 N Jordan Ave","city":"Bloomington","state":"IN","zip":"47405","phone":"(812)
+        855-9271","email":"bcclib@indiana.edu","url":"https://libraries.indiana.edu/NMBCC-Library","urlHours":"https://libraries.indiana.edu/NMBCC-Library/hours","latitude":"39.1682904","longitude":"-86.5168656","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:58:36.000Z"},{"id":6,"code":"B-BUSSPEA","label":"Bloomington
+        - Business/SPEA Information Commons","address":"1315 E. 10th Street","address2":"","city":"Bloomington","state":"IN","zip":"47405","phone":"812-855-1957","email":"libbus@indiana.edu","url":"https://libraries.indiana.edu/bsic","urlHours":"https://libraries.indiana.edu/bsic/hours","latitude":"39.17259","longitude":"-86.51771","notes":"\u003cp\u003eTesting
+        the cool \u003cb\u003enotes\u003c/b\u003e \u003cspan style=\"background-color:
+        rgb(255, 255, 0);\"\u003ethingy\u003c/span\u003e..\u003c/p\u003e","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:56:25.000Z"},{"id":50,"code":"B-CEDIR","label":"Bloomington
+        - Indiana Institute on Disability","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:57:13.000Z"},{"id":7,"code":"B-CHEM","label":"Bloomington
+        - Sciences Library","address":"","address2":"800 E. Kirkwood Avenue","city":"Bloomington","state":"IN","zip":"47405-7005","phone":"812-855-9452","email":"libsci@indiana.edu","url":"https://libraries.indiana.edu/sciences-library","urlHours":"https://libraries.indiana.edu/sciences-library/hours","latitude":"39.165949","longitude":"-86.522658","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:58:56.000Z"},{"id":9,"code":"B-EDUC","label":"Bloomington
+        - Education Library","address":"201 N. Rose Street","address2":"","city":"Bloomington","state":"IN","zip":"47405","phone":"812-856-8590","email":"libeduc@indiana.edu","url":"https://libraries.indiana.edu/education-library","urlHours":"https://libraries.indiana.edu/libeduc/hours","latitude":"39.167360","longitude":"-86.512497","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:56:40.000Z"},{"id":16,"code":"B-KINSEY","label":"Bloomington
+        - Kinsey Institute Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"\u003cp\u003eBy
+        Appointment Only\u003c/p\u003e","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:57:38.000Z"},{"id":17,"code":"B-LAW","label":"Bloomington
+        - Law Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:57:54.000Z"},{"id":18,"code":"B-LIFESCI","label":"Bloomington
+        - Life Sciences Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:58:05.000Z"},{"id":19,"code":"B-LILLY","label":"Bloomington
+        - Lilly Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:58:15.000Z"},{"id":20,"code":"B-MUSIC","label":"Bloomington
+        - Music Library","address":"200 S Jordan Ave","address2":"","city":"Bloomington","state":"IN","zip":"47401","phone":"(812)
+        855-2970","email":"libmus@ indiana.edu","url":"https://libraries.indiana.edu/music","urlHours":"","latitude":"39.1488401","longitude":"-86.5308672","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:58:26.000Z"},{"id":21,"code":"B-OPTOMTRY","label":"Bloomington
+        - Optometry Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:58:46.000Z"},{"id":1,"code":"B-WELLS","label":"Bloomington
+        - Herman B Wells Library","address":"1320 E 10th St.","address2":"","city":"Bloomington","state":"IN","zip":"47405","phone":"(812)
+        855-0100","email":"libref@indiana.edu","url":"https://libraries.indiana.edu/wells","urlHours":"https://libraries.indiana.edu/wells/hours","latitude":"39.17098","longitude":"-86.51689","notes":"\u003ch2\u003eMy
+        \u003cspan style=\"background-color: rgb(255, 255, 0);\"\u003elibrary\u003c/span\u003e
+        \u003cb\u003enotes\u003c/b\u003e...\u0026nbsp; \u003c/h2\u003e\u003col\u003e\u003cli\u003e\u003ca
+        href=\"https://libraries.indiana.edu/\" target=\"_blank\"\u003eIU Libraries\u003c/a\u003e\u0026nbsp;website\u003c/li\u003e\u003cli\u003e\u003cbr\u003e\u003c/li\u003e\u003c/ol\u003e","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:56:58.000Z"},{"id":24,"code":"BH-APTLIB","label":"Bloomington
+        Res Halls - Campus View Apartments Lib \u0026 Res Ctr","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:01:08.000Z"},{"id":25,"code":"BH-BRISCOE","label":"Bloomington
+        Res Halls - Briscoe Movies Music \u0026 More","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:59:58.000Z"},{"id":26,"code":"BH-COLLINS","label":"Bloomington
+        Res Halls - Collins Comm Lib \u0026 Res Ctr","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:01:17.000Z"},{"id":28,"code":"BH-EIGENMN","label":"Bloomington
+        Res Halls - Eigenmann Comm Lib \u0026 Res Ctr","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:01:28.000Z"},{"id":29,"code":"BH-FOREST","label":"Bloomington
+        Res Halls - Forest Movies Music \u0026 More","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:01:40.000Z"},{"id":30,"code":"BH-FOSTER","label":"Bloomington
+        Res Halls - Foster Comm Lib \u0026 Res Ctr","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:01:53.000Z"},{"id":31,"code":"BH-MCNUTT","label":"Bloomington
+        Res Halls - McNutt Comm Lib \u0026 Res Ctr","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:02:03.000Z"},{"id":32,"code":"BH-READ","label":"Bloomington
+        Res Halls - Read Movies Music \u0026 More","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:02:12.000Z"},{"id":27,"code":"BH-ROSE","label":"Bloomington
+        Res Halls - Spruce Movies Music \u0026 More","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:02:22.000Z"},{"id":33,"code":"BH-TETER","label":"Bloomington
+        Res Halls - Teter Comm Lib \u0026 Res Ctr","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:02:32.000Z"},{"id":15,"code":"BH-UNIONST","label":"Bloomington
+        Res Halls - Union Street Movies Music \u0026 More","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:02:43.000Z"},{"id":34,"code":"BH-WILLKIE","label":"Bloomington
+        Res Halls - Willkie Comm Lib \u0026 Res Ctr","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:03:01.000Z"},{"id":22,"code":"BH-WQUAD","label":"Bloomington
+        Res Halls - Wells Quad Movies Music \u0026 More","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:02:52.000Z"},{"id":35,"code":"BH-WRIGHT","label":"Bloomington
+        Res Halls - Wright Movies Music \u0026 More","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:03:09.000Z"},{"id":36,"code":"COLUMBUS","label":"Columbus
+        - University Library of Columbus","address":"","address2":null,"city":null,"state":null,"zip":null,"phone":"","email":"","url":null,"urlHours":null,"latitude":"","longitude":null,"notes":null,"created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-11T21:47:17.000Z"},{"id":45,"code":"EAST","label":"East
+        Library - Richmond","address":"","address2":null,"city":null,"state":null,"zip":null,"phone":"","email":"","url":null,"urlHours":null,"latitude":"","longitude":null,"notes":null,"created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-11T21:47:17.000Z"},{"id":37,"code":"FORTWAYNE","label":"Fort
+        Wayne Helmke Library","address":"","address2":null,"city":null,"state":null,"zip":null,"phone":"","email":"","url":null,"urlHours":null,"latitude":"","longitude":null,"notes":null,"created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-11T21:47:17.000Z"},{"id":39,"code":"I-ART","label":"Indianapolis
+        - Herron Art Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:04:01.000Z"},{"id":38,"code":"I-DENTSTRY","label":"Indianapolis
+        - Dentistry Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:03:49.000Z"},{"id":40,"code":"I-LAW","label":"Indianapolis
+        - Ruth Lilly Law Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:04:21.000Z"},{"id":49,"code":"I-MEDICINE","label":"Indianapolis
+        - Ruth Lilly Medical Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:04:30.000Z"},{"id":42,"code":"I-UNIVLIB","label":"Indianapolis
+        - IUPUI University Library","address":"","address2":"","city":"","state":"","zip":"","phone":"","email":"","url":"","urlHours":"","latitude":"","longitude":"","notes":"","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T16:04:12.000Z"},{"id":43,"code":"KOKOMO","label":"Kokomo
+        Library","address":"2500 S. Washington Street","address2":"","city":"Kokomo","state":"IN","zip":"46902","phone":"(765)
+        455-9513","email":"iuklib@iuk.edu","url":"","urlHours":"","latitude":"39.1335604","longitude":"-86.5090041","notes":null,"created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-11T21:47:17.000Z"},{"id":44,"code":"NORTHWEST","label":"Northwest
+        Library (Gary)","address":"","address2":null,"city":null,"state":null,"zip":null,"phone":"","email":"","url":null,"urlHours":null,"latitude":"","longitude":null,"notes":null,"created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-11T21:47:17.000Z"},{"id":46,"code":"SBEND","label":"South
+        Bend - Schurz Library","address":"","address2":null,"city":null,"state":null,"zip":null,"phone":"","email":"","url":null,"urlHours":null,"latitude":"","longitude":null,"notes":null,"created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-11T21:47:17.000Z"},{"id":47,"code":"SBENDLRC","label":"South
+        Bend - Educational Resource Commons","address":"","address2":null,"city":null,"state":null,"zip":null,"phone":"","email":"","url":null,"urlHours":null,"latitude":"","longitude":null,"notes":null,"created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-11T21:47:17.000Z"},{"id":48,"code":"SOUTHEAST","label":"Southeast
+        Library - New Albany","address":"","address2":null,"city":null,"state":null,"zip":null,"phone":"","email":"","url":null,"urlHours":null,"latitude":"","longitude":null,"notes":null,"created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-11T21:47:17.000Z"}]}}'
+    http_version: 
+  recorded_at: Mon, 31 Dec 2018 23:22:08 GMT
+- request:
+    method: get
+    uri: http://iucat-feature-tadas.uits.iu.edu/api/library/B-WELLS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Dec 2018 23:22:09 GMT
+      Server:
+      - Apache/2.2.15 (Red Hat)
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - W/"229d8c3993bba26533aaeb5df99e947a"
+      X-Frame-Options:
+      - ALLOWALL
+      X-Runtime:
+      - '0.070816'
+      X-Request-Id:
+      - 6e315a96-2ba6-41bf-97ca-3af125ca682d
+      X-Powered-By:
+      - Phusion Passenger 5.1.3
+      Set-Cookie:
+      - _Blacklight5_session=8467068c484d04877f4e965b863352b8; path=/; HttpOnly
+      Status:
+      - 200 OK
+      Access-Control-Allow-Origin:
+      - "*"
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"data":{"library":{"id":1,"code":"B-WELLS","label":"Bloomington
+        - Herman B Wells Library","address":"1320 E 10th St.","address2":"","city":"Bloomington","state":"IN","zip":"47405","phone":"(812)
+        855-0100","email":"libref@indiana.edu","url":"https://libraries.indiana.edu/wells","urlHours":"https://libraries.indiana.edu/wells/hours","latitude":"39.17098","longitude":"-86.51689","notes":"\u003ch2\u003eMy
+        \u003cspan style=\"background-color: rgb(255, 255, 0);\"\u003elibrary\u003c/span\u003e
+        \u003cb\u003enotes\u003c/b\u003e...\u0026nbsp; \u003c/h2\u003e\u003col\u003e\u003cli\u003e\u003ca
+        href=\"https://libraries.indiana.edu/\" target=\"_blank\"\u003eIU Libraries\u003c/a\u003e\u0026nbsp;website\u003c/li\u003e\u003cli\u003e\u003cbr\u003e\u003c/li\u003e\u003c/ol\u003e","created_at":"2018-12-11T21:47:17.000Z","updated_at":"2018-12-21T15:56:58.000Z"},"hours":null,"today":{"dow":"monday","month":"12","day":"31","year":"2018"},"exceptions":[],"floors":[]}}'
+    http_version: 
+  recorded_at: Mon, 31 Dec 2018 23:22:09 GMT
+- request:
+    method: get
+    uri: http://iucat-feature-tadas.uits.iu.edu/api/library/foobar
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Dec 2018 23:22:09 GMT
+      Server:
+      - Apache/2.2.15 (Red Hat)
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - W/"2e1c72a6f2dcecaaf4cfacd0a8d8a863"
+      X-Frame-Options:
+      - ALLOWALL
+      X-Runtime:
+      - '0.079935'
+      X-Request-Id:
+      - 9491b68b-e1d8-4a71-a625-12c0e512539a
+      X-Powered-By:
+      - Phusion Passenger 5.1.3
+      Set-Cookie:
+      - _Blacklight5_session=adb8f43c1fd2f3107c59750d00e606e4; path=/; HttpOnly
+      Status:
+      - 200 OK
+      Access-Control-Allow-Origin:
+      - "*"
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":false,"data":"invalid id"}'
+    http_version: 
+  recorded_at: Mon, 31 Dec 2018 23:22:09 GMT
+recorded_with: VCR 4.0.0

--- a/spec/renderers/holding_location_renderer_spec.rb
+++ b/spec/renderers/holding_location_renderer_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe HoldingLocationAttributeRenderer do
   let(:uri) { 'http://rightsstatements.org/vocab/InC/1.0/' }
   let(:obj) {
     {
-      term: "Sample",
-      phone_number: "123-456-7890",
-      contact_email: "ex@example.org",
+      label: "Sample",
+      phone: "123-456-7890",
+      email: "ex@example.org",
       url: "https://bibdata.example.org/locations/delivery_locations/1.json",
       id: "https://bibdata.example.org/locations/delivery_locations/1",
       address: "Example Campus Delivery"
@@ -18,7 +18,7 @@ RSpec.describe HoldingLocationAttributeRenderer do
     # HoldingLocationService holds a reference to an authority as a
     # module-level attribute.  Must stub it in case the module is already
     # initialized by a previous test.
-    allow(HoldingLocationService).to receive(:find).and_return(obj.stringify_keys)
+    allow(HoldingLocationService).to receive(:find).and_return(obj)
   end
 
   context "with a rendered holding location" do

--- a/spec/services/holding_location_service_spec.rb
+++ b/spec/services/holding_location_service_spec.rb
@@ -3,22 +3,22 @@ require 'rails_helper'
 RSpec.describe HoldingLocationService do
   let(:service) { described_class }
 
-  let(:uri) { 'https://libraries.indiana.edu/music' }
-  let(:contact_email) { 'libmus@indiana.edu' }
-  let(:term) { 'William & Gayle Cook Music Library' }
-  let(:phone_number) { '(812) 855-2970' }
+  let(:id) { 'B-WELLS' }
+  let(:email) { 'libref@indiana.edu' }
+  let(:label) { 'Bloomington - Herman B Wells Library' }
+  let(:phone) { '(812) 855-0100' }
 
-  context "with rights statements" do
+  context "with rights statements", vcr: { cassette_name: 'iucat_libraries_up', record: :new_episodes } do
     it "gets the email of a holding location" do
-      expect(service.find(uri).fetch('contact_email')).to eq(contact_email)
+      expect(service.find(id).fetch('email')).to eq(email)
     end
 
     it "gets the label of a holding location" do
-      expect(service.find(uri).fetch('term')).to eq(term)
+      expect(service.find(id).fetch('label')).to eq(label)
     end
 
     it "gets the phone number of a holding location" do
-      expect(service.find(uri).fetch('phone_number')).to eq(phone_number)
+      expect(service.find(id).fetch('phone')).to eq(phone)
     end
   end
 end


### PR DESCRIPTION
Should be good for a first iteration, but known things to revisit include:
- Adding new options for display elements, like url
- Modifying label display in editing select field vs display (specifically, keeping/dropping "Bloomington - " prefix)
- Confirming final form of the API once released