### PR TITLE
[ESSI-32] Source_metadata_identifier obviates conditionally required metadata

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/required_fields.es6
+++ b/app/assets/javascripts/hyrax/save_work/required_fields.es6
@@ -1,0 +1,31 @@
+// Override stock Hyrax version to support mutex (mutually exclusive) fieldsets
+// If at least one of mutex_a/mutex_b class fieldsets are present, at least one set must be complete
+export class RequiredFields {
+  // Monitors the form and runs the callback if any of the required fields change
+  constructor(form, callback) {
+    this.form = form
+    this.callback = callback
+    this.reload()
+  }
+
+  get areComplete() {
+    return this.alwaysRequired.filter((n, elem) => { return this.isValuePresent(elem) } ).length === 0 &&
+           ((this.mutexFieldsA.length === 0 && this.mutexFieldsB.length === 0) ||
+            (this.mutexFieldsA.length > 0 && this.mutexFieldsA.filter((n, elem) => { return this.isValuePresent(elem) } ).length === 0) ||
+            (this.mutexFieldsB.length > 0 && this.mutexFieldsB.filter((n, elem) => { return this.isValuePresent(elem) } ).length === 0))
+  }
+
+  isValuePresent(elem) {
+    return ($(elem).val() === null) || ($(elem).val().length < 1)
+  }
+
+  // Reassign requiredFields because fields may have been added or removed.
+  reload() {
+    // ":input" matches all input, select or textarea fields.
+    this.requiredFields = this.form.find(':input[required]')
+    this.mutexFieldsA = this.form.find(':input[required].mutex_a')
+    this.mutexFieldsB = this.form.find(':input[required].mutex_b')
+    this.alwaysRequired = this.form.find(':input[required]').not('.mutex_a, .mutex_b')
+    this.requiredFields.change(this.callback)
+  }
+}

--- a/app/forms/hyrax/bib_record_form.rb
+++ b/app/forms/hyrax/bib_record_form.rb
@@ -5,6 +5,8 @@ module Hyrax
   class BibRecordForm < Hyrax::Forms::WorkForm
     self.model_class = ::BibRecord
     self.terms += [:resource_type, :source_metadata_identifier]
+    self.required_fields -= [:keyword]
+    self.required_fields += [:source_metadata_identifier]
     include ESSI::BibRecordFormBehavior
   end
 end

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -5,6 +5,7 @@ module Hyrax
   class ImageForm < Hyrax::Forms::WorkForm
     self.model_class = ::Image
     self.terms += [:resource_type]
+    self.required_fields -= [:keyword]
     include ESSI::ImageFormBehavior
   end
 end

--- a/app/forms/hyrax/paged_resource_form.rb
+++ b/app/forms/hyrax/paged_resource_form.rb
@@ -5,6 +5,8 @@ module Hyrax
   class PagedResourceForm < Hyrax::Forms::WorkForm
     self.model_class = ::PagedResource
     self.terms += [:resource_type, :source_metadata_identifier]
+    self.required_fields -= [:keyword]
+    self.required_fields += [:source_metadata_identifier]
     include ESSI::PagedResourceFormBehavior
   end
 end

--- a/app/forms/hyrax/scientific_form.rb
+++ b/app/forms/hyrax/scientific_form.rb
@@ -5,6 +5,7 @@ module Hyrax
   class ScientificForm < Hyrax::Forms::WorkForm
     self.model_class = ::Scientific
     self.terms += [:resource_type]
+    self.required_fields -= [:keyword]
     include ESSI::ScientificFormBehavior
   end
 end

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { class: ['form-control', 'mutex_a'] }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key), input_html: { class: 'mutex_a' } %>
+<% end %>

--- a/app/views/records/edit_fields/_source_metadata_identifier.html.erb
+++ b/app/views/records/edit_fields/_source_metadata_identifier.html.erb
@@ -1,7 +1,7 @@
 <% if f.object.multiple? key %>
-  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+  <%= f.input key, as: :multi_value, input_html: { class: ['form-control', 'mutex_b'] }, required: f.object.required?(key) %>
 <% else %>
-  <%= f.input key, required: f.object.required?(key) %>
+  <%= f.input key, required: f.object.required?(key), input_html: { class: 'mutex_b' } %>
 <% end %>
 <%= check_box_tag :refresh_remote_metadata, 1, false %>
 <label for="refresh_metadata">Refresh metadata from <%= t('services.metadata') %></label>

--- a/app/views/records/edit_fields/_title.html.erb
+++ b/app/views/records/edit_fields/_title.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { class: ['form-control', 'mutex_a'] }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key), input_html: { class: 'mutex_a' } %>
+<% end %>


### PR DESCRIPTION
What this includes:
* removing `keyword` as a required field (from all 4 work types)
* adds `source_metadata_identifier` as required field (for the 2 work types carrying that property)
* changes the javascript logic to check completion of all required fields to require only one of the two "mutex" (mutually exclusive) fieldsets, currently comprised of:
  * Set A: `title`, `creator`
  * Set B: `source_metadata_identifier`

Some notes on implementation:
The view partials that set a field as belonging to `mutex_a` or `mutex_b` are currently at:
`app/views/records/edit_fields/`
and apply across all work types, but they could be moved to worktype-specific folders.  The javascript required fields check is such that if neither or only one of mutex_a/mutex_b are present, they function as normal "required" fields -- so under the current configuration, all 4 worktypes have functioning required-metadata checks (even the 2 that have no `source_metadata_identifier`)

Things _not_ included, that may merit becoming separate stories:
- allow setting _optional_ "primary" properties -- the stock Hyrax logic is to set "primary" == "required" equivalence, with everything optional moved into the "additional fields" section
- have entry of any field in a mutex set disable the opposing mutex fieldset's inputs -- pumpkin has this behavior for title vs source_metadata_identifier
- add some UI indication about fields belonging to a mutex set
- refactor mutex set specification to be within model, rather than implicitly specified through view partials?