### PR TITLE
[ESSI-35] Add Series property to ExtendedMetadata, UI elements

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -68,6 +68,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
     config.add_index_field solr_name("keyword", :stored_searchable), itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
     config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable)
+    config.add_index_field solr_name("series", :stored_searchable), label: 'Series', link_to_search: solr_name("series", :facetable)
     config.add_index_field solr_name("creator", :stored_searchable), itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile

--- a/app/forms/hyrax/bib_record_form.rb
+++ b/app/forms/hyrax/bib_record_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   # Generated form for BibRecord
   class BibRecordForm < Hyrax::Forms::WorkForm
     self.model_class = ::BibRecord
-    self.terms += [:resource_type, :source_metadata_identifier]
+    self.terms += [:resource_type, :source_metadata_identifier, :series]
     self.required_fields -= [:keyword]
     self.required_fields += [:source_metadata_identifier]
     include ESSI::BibRecordFormBehavior

--- a/app/forms/hyrax/paged_resource_form.rb
+++ b/app/forms/hyrax/paged_resource_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   # Generated form for PagedResource
   class PagedResourceForm < Hyrax::Forms::WorkForm
     self.model_class = ::PagedResource
-    self.terms += [:resource_type, :source_metadata_identifier]
+    self.terms += [:resource_type, :source_metadata_identifier, :series]
     self.required_fields -= [:keyword]
     self.required_fields += [:source_metadata_identifier]
     include ESSI::PagedResourceFormBehavior

--- a/app/models/concerns/essi/extended_metadata.rb
+++ b/app/models/concerns/essi/extended_metadata.rb
@@ -5,14 +5,19 @@ module ESSI
 
     included do
       property :holding_location,
-               predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/heldBy"),
+               predicate: RDF::Vocab::BF2.heldBy,
                multiple: false do |index|
+                 index.as :stored_searchable, :facetable
+               end
+      property :series,
+               predicate: RDF::Vocab::BF2.seriesStatement do |index|
                  index.as :stored_searchable, :facetable
                end
 
       property :physical_description,
                predicate: RDF::Vocab::MODS.physicalExtent,
                multiple: false
+
       property :abridger, predicate: RDF::Vocab::MARCRelators.abr
       property :actor, predicate: RDF::Vocab::MARCRelators.act
       property :adapter, predicate: RDF::Vocab::MARCRelators.adp

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -29,4 +29,9 @@ class SolrDocument
   def holding_location
     self[Solrizer.solr_name('holding_location')]
   end
+
+  def series
+    self[Solrizer.solr_name('series')]
+  end
+
 end

--- a/app/presenters/hyrax/bib_record_presenter.rb
+++ b/app/presenters/hyrax/bib_record_presenter.rb
@@ -2,5 +2,6 @@
 #  `rails generate hyrax:work BibRecord`
 module Hyrax
   class BibRecordPresenter < Hyrax::WorkShowPresenter
+    delegate :series, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -2,6 +2,8 @@
 #  `rails generate hyrax:work PagedResource`
 module Hyrax
   class PagedResourcePresenter < Hyrax::WorkShowPresenter
+    delegate :series, to: :solr_document
+
     def holding_location
       HoldingLocationAttributeRenderer.new(solr_document.holding_location).render_dl_row
     end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -2,9 +2,10 @@
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:series, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:identifier, render_as: :external_link, html_dl: true) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim', html_dl: true) %>
 <%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>
@@ -15,5 +16,3 @@
 <% if @presenter.respond_to? :holding_location %>
   <%= @presenter.holding_location %>
 <% end %>
-
-


### PR DESCRIPTION
Adds Series, in the following capacities:
- to `ExtendedMetadata` module
- to results of remote metadata lookup when supplying a `source_metadata_identifier`
- to `PagedResource`, `BibRecord` edit forms
- to single-record view
- to catalog search results view, as links

Threw in a couple of other minor tweaks:
- Changed `identifier` display from internal link to external link (since that's the value we're supplying)
- Changed `holding_location` RDF value to come from class call instead of manual specification