### PR TITLE
[ESSI-92] Fix remote metadata creation error with "raw" attributes

### DIFF
--- a/app/controllers/concerns/essi/remote_metadata_lookup_behavior.rb
+++ b/app/controllers/concerns/essi/remote_metadata_lookup_behavior.rb
@@ -17,7 +17,7 @@ module ESSI
 
     def remote_attributes
       @remote_attributes ||= begin
-         remote_attributes = remote_data.attributes
+         remote_attributes = remote_data.raw_attributes
          remote_attributes['source_metadata'] = remote_data.source.dup.try(:force_encoding, 'utf-8') if remote_data.source
          remote_attributes
       end

--- a/app/models/vocab/pul_terms.rb
+++ b/app/models/vocab/pul_terms.rb
@@ -1,0 +1,18 @@
+require 'rdf'
+# FIXME: change to IU equivalent link?
+class PULTerms < RDF::StrictVocabulary('http://library.princeton.edu/terms/')
+  term :exhibit_id, label: 'Exhibit ID'.freeze, type: 'rdf:Property'.freeze
+  term :metadata_id, label: 'Metadata ID'.freeze, type: 'rdf:Property'.freeze
+  term :source_metadata,
+       label: 'Source Metadata'.freeze,
+       type: 'rdf:Property'.freeze
+  term :ocr_language,
+       label: "OCR Language".freeze,
+       type: 'rdf:Property'.freeze
+  term :pdf_type, label: "PDF Type".freeze, type: 'rdf:Property'.freeze
+  term :call_number, label: "Call Number".freeze, type: 'rdf:Property'.freeze
+  term :published, label: "Published".freeze, type: 'rdf:Property'.freeze
+  # visibility is specified for preingest attribute mapping
+  term :visibility, label: "Visibility".freeze, type: 'rdf:Property'.freeze
+  term :full_text_searchable, label: "Search within".freeze, type: 'rdf:Property'.freeze
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ module ESSI
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+    config.autoload_paths += ['app/models/vocab']
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Using "raw" attributes -- Arrays of Strings, rather than ActiveTriple::Relation values -- gets Work creation to successfully receive and process remote metadata without erroring out.