### PR TITLE
Ensures that Docker image will deploy and run in local developer environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ docker.secrets
 .dockerignore
 tmp/*
 log/*
-db/development.sqlite3
 db/test.sqlite3
 coverage
 spec/tmp


### PR DESCRIPTION
We want developers to be able to deploy the Docker image to a local environment without a lot of fiddling or troubleshooting.  One thing preventing that was the lack of a properly migrated development database once the container was running.  This was because the .dockerignore file had a filespec to ignore copying the development SQLite file on build, but the migration state was being copied in so that the Rails app didn't know to flag that migrations were outstanding.

One benefit of including the developer's database file in the build is that the running Rails app in the container will be identical to running it in as a local Rails app because the database will be the same and presumably be pointed to the same Fedora/Solr.

HOW-TO:
So to build correctly and deploy, the local environment should be complete with a migrated database and the necessary AdminSet task completed:

(git clone...; cd to cloned directory)
bundle exec rake db:migrate

In separate windows, provide Fedora/Solr for the container:
solr_wrapper
fcrepo_wrapper

Once Fedora/Solr are running, create the AdminSet in the local app directory:
bundle exec rails hyrax:default_admin_set:create

Now build and run:
docker build --tag=essi .
docker run --net="host" -p 3000:3000 essi

