### PR TITLE
ESSI-74 Fixes inability to add a PagedResource in the staging instance

### DIFF
--- a/app/authorities/qa/authorities/iucat_libraries.rb
+++ b/app/authorities/qa/authorities/iucat_libraries.rb
@@ -20,7 +20,8 @@ module Qa::Authorities
       end
 
       def data_for(id)
-        begin 
+        return {} unless ESSI.config[:iucat_libraries]
+        begin
           result = json(api_url(id)).with_indifferent_access
           result[:success] ? result[:data] : {}
         rescue TypeError, JSON::ParserError, Faraday::ConnectionFailed

--- a/spec/authorities/qa/authorities/iucat_libraries_spec.rb
+++ b/spec/authorities/qa/authorities/iucat_libraries_spec.rb
@@ -5,6 +5,17 @@ RSpec.describe Qa::Authorities::IucatLibraries do
   let(:matching_id) { 'B-WELLS' }
   let(:nonmatching_id) { 'foobar' }
 
+  context 'when configuration does not exist' do
+    describe '#all' do
+      let(:result) { authority.all }
+      it 'returns an empty Array' do
+        allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(nil)
+        expect(result).to be_a Array
+        expect(result).to be_empty
+      end
+    end
+  end
+
   context 'with server response', vcr: { cassette_name: 'iucat_libraries_up', record: :new_episodes } do
     describe '#all' do
       let(:result) { authority.all }


### PR DESCRIPTION
In the Docker staging environment, when you go to add a PagedResource you immediately get a generic error as soon as the edit form starts to render.  This is due the secrets configuration file not having a value for the url of the holding location authority service, resulting in a method being called on a nil result.

The configuration obviously needs to have that value added, but this PR adds a guard clause in the authority class to just return an empty object if the service url doesn't exist.  The resulting holding locations dropdown will be empty but at least the edit form can render.

