### PR TITLE
Adds example file for ldap groups lookup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+fits.log
 
 /node_modules
 /yarn-error.log
@@ -30,3 +31,6 @@
 # Ignore local secrets
 .secrets.sh
 /secrets
+
+# Ignore LDAP connection config
+/config/ldap_groups_lookup.yml

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -33,6 +33,8 @@ default: &default
       admin:
         - ESSI-USERS
     default_email_domain: iu.edu
+  authorized_ldap_groups:
+    - ESSI-USERS
   essi:
     notifier_email: example@test.test
     store_original_files: true

--- a/config/ldap_groups_lookup.exmple.yml
+++ b/config/ldap_groups_lookup.exmple.yml
@@ -1,0 +1,10 @@
+:enabled: true
+:host: ads.example.edu
+:tree: dc=ads,dc=example,dc=edu
+:account_ou: Accounts
+:group_ou: Groups
+:auth:
+  :method: :simple
+  :username: cn=user,ou=Groups,ou=Accounts,dc=ads,dc=example,dc=edu
+  :password: "password"
+


### PR DESCRIPTION
Also adds actual file to ignore list and adds `authorized_ldap_groups:` to example config file.