### PR TITLE
[ESSI-36] Apply some #save_structure bugfixes to ESSI (as was to pumpkin)

### DIFF
--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -21,8 +21,12 @@ module Hyrax
 
     def save_structure
       structure = { "label": params["label"], "nodes": params["nodes"] }
-      SaveStructureJob.perform_later(curation_concern, structure.to_json)
-      head 200
+      if curation_concern.lock?
+        head 423
+      else
+        SaveStructureJob.perform_later(curation_concern, structure.to_json)
+        head 200
+      end
     end
   end
 end

--- a/app/models/with_proxy_for_object.rb
+++ b/app/models/with_proxy_for_object.rb
@@ -55,9 +55,9 @@ class WithProxyForObject < SimpleDelegator
         @members = members
       end
 
-      def new(order_hash = {}, rdf_subject = nil, node_class = nil, top = true)
+      def new(order_hash = {}, rdf_subject = nil, node_class = nil, top = true, node_cache = ActiveFedora::Orders::OrderedList::NodeCache.new)
         ::WithProxyForObject.new(
-          LogicalOrder.new(order_hash, rdf_subject, node_class || self, top),
+          LogicalOrder.new(order_hash, rdf_subject, node_class || self, top, node_cache),
           members
         )
       end

--- a/config/initializers/modify_active_fedora_node_cache.rb
+++ b/config/initializers/modify_active_fedora_node_cache.rb
@@ -1,0 +1,27 @@
+# Modify initialization to allow passing in an existing node_cache
+# Needed for generating structure as nested OrderedList without id collision
+module OrderedListInitializationModification
+  # @param [::RDF::Enumerable] graph Enumerable where ORE statements are
+  #   stored.
+  # @param [::RDF::URI] head_subject URI of head node in list.
+  # @param [::RDF::URI] tail_subject URI of tail node in list.
+  def initialize(graph,
+                 head_subject,
+                 tail_subject,
+                 node_cache = ActiveFedora::Orders::OrderedList::NodeCache.new)
+    @graph = if graph.respond_to?(:graph)
+               graph.graph.data
+             else
+               graph
+             end
+    @head_subject = head_subject
+    @tail_subject = tail_subject
+    @node_cache = node_cache
+    @changed = false
+    tail
+  end
+end
+
+ActiveFedora::Orders::OrderedList.class_eval do
+  prepend OrderedListInitializationModification
+end

--- a/spec/support/shared_examples/paged_structured_controller.rb
+++ b/spec/support/shared_examples/paged_structured_controller.rb
@@ -80,10 +80,9 @@ do |resource_symbol, presenter_factory|
       end
 
       it 'returns Locked status for a locked resource' do
-        lock_info = resource.lock
+        allow_any_instance_of(resource.class).to receive(:lock?).and_return(true)
         post :save_structure, params: {nodes: nodes, id: resource.id, label: 'TOP!'}
         expect(response.status).to eq 423
-        resource.unlock(lock_info)
       end
     end
 

--- a/spec/support/shared_examples/paged_structured_controller.rb
+++ b/spec/support/shared_examples/paged_structured_controller.rb
@@ -78,6 +78,13 @@ do |resource_symbol, presenter_factory|
         expect(resource.reload.logical_order.order) \
         .to eq({ 'label': 'TOP!', 'nodes': nodes }.with_indifferent_access)
       end
+
+      it 'returns Locked status for a locked resource' do
+        lock_info = resource.lock
+        post :save_structure, params: {nodes: nodes, id: resource.id, label: 'TOP!'}
+        expect(response.status).to eq 423
+        resource.unlock(lock_info)
+      end
     end
 
     describe '#manifest', :clean do


### PR DESCRIPTION
Note that completion of ESSI-24 is also required for full resolution of `#save_structure` bugs, pertaining to job queuing.

This covers:
* aborting a `#save_structure` request if the resource is locked, returning 423 status.
* sharing a `NodeCache` across nested `OrderedList` members, to avoid id collision