### PR TITLE
[ESSI-139] In the File Manager, add Viewing Direction and Viewing Hint

### DIFF
--- a/app/assets/javascripts/hyrax/file_manager.es6
+++ b/app/assets/javascripts/hyrax/file_manager.es6
@@ -1,0 +1,79 @@
+import SaveManager from 'hyrax/file_manager/save_manager'
+import SortManager from 'hyrax/file_manager/sorting'
+import {InputTracker, FileManagerMember} from 'hyrax/file_manager/member'
+export default class FileManager {
+  constructor() {
+    this.save_manager = this.initialize_save_manager()
+    this.sorting()
+    this.save_affix()
+    this.member_tracking()
+    this.sortable_placeholder()
+    this.resource_form()
+  }
+
+  initialize_save_manager() {
+    return(new SaveManager)
+  }
+
+  sorting() {
+    window.new_sort_manager = new SortManager(this.save_manager)
+  }
+
+  save_affix() {
+    let tools = $("#file-manager-tools")
+    if(tools.length > 0) {
+      tools.affix({
+        offset: {
+          top: $("#file-manager-tools .actions").offset().top,
+          bottom: function() {
+            return $("#file-manager-extra-tools").outerHeight(true) + $("footer").outerHeight(true)
+          }
+        }
+      })
+    }
+  }
+
+  member_tracking() {
+    let sm = this.save_manager
+    $("li[data-reorder-id]").each(function(index, element) {
+      var manager_member = new FileManagerMember($(element), sm)
+      $(element).data("file_manager_member", manager_member)
+    })
+  }
+
+  // Initialize a form that represents the parent resource as a whole.
+  // For the purpose of CC, this comes with hidden fields for
+  // thumbnail_id and representative_id
+  // which are synchronized with the radio buttons on each member and then
+  // submitted with the SaveManager.
+  resource_form() {
+    let manager = new FileManagerMember($("#resource-form").parent(), this.save_manager)
+    $("#resource-form").parent().data("file_manager_member", manager)
+    // Track thumbnail ID hidden field
+    new InputTracker($("*[data-member-link=thumbnail_id]"), manager)
+    $("#sortable *[name=thumbnail_id]").change(function() {
+      let val = $("#sortable *[name=thumbnail_id]:checked").val()
+      $("*[data-member-link=thumbnail_id]").val(val)
+      $("*[data-member-link=thumbnail_id]").change()
+    })
+    new InputTracker($("*[data-member-link=representative_id]"), manager)
+    $("#sortable *[name=representative_id]").change(function() {
+      let val = $("#sortable *[name=representative_id]:checked").val()
+      $("*[data-member-link=representative_id]").val(val)
+      $("*[data-member-link=representative_id]").change()
+    })
+  }
+
+  // Keep the ui/sortable placeholder the right size.
+  // This keeps the grid a consistent height so when the
+  // last row contains 1 object,
+  // - an element can be moved into the last spot, and
+  // - the footer doesn't jump up.
+  sortable_placeholder() {
+    $( "#sortable" ).on( "sortstart", function( event, ui ) {
+      let found_element = $("#sortable").children("li[data-reorder-id]").first()
+      ui.placeholder.width(found_element.width())
+      ui.placeholder.height(found_element.height())
+    })
+  }
+}

--- a/app/assets/javascripts/hyrax/file_manager.es6
+++ b/app/assets/javascripts/hyrax/file_manager.es6
@@ -62,6 +62,19 @@ export default class FileManager {
       $("*[data-member-link=representative_id]").val(val)
       $("*[data-member-link=representative_id]").change()
     })
+    // essi additions for viewing direction, hint
+    new InputTracker($("*[data-member-link=viewing_direction_option]"), manager)
+    $("*[name=viewing_direction_option]").change(function() {
+      let val = $("*[name=viewing_direction_option]:checked").val()
+      $("*[data-member-link=viewing_direction_option]").val(val)
+      $("*[data-member-link=viewing_direction_option]").change()
+    })
+    new InputTracker($("*[data-member-link=viewing_hint_option]"), manager)
+    $("*[name=viewing_hint_option]").change(function() {
+      let val = $("*[name=viewing_hint_option]:checked").val()
+      $("*[data-member-link=viewing_hint_option]").val(val)
+      $("*[data-member-link=viewing_hint_option]").change()
+    })
   }
 
   // Keep the ui/sortable placeholder the right size.

--- a/app/forms/concerns/essi/paged_resource_form_behavior.rb
+++ b/app/forms/concerns/essi/paged_resource_form_behavior.rb
@@ -4,7 +4,7 @@ module ESSI
     # Add behaviors that make this work type unique
 
     included do
-      self.terms += [:holding_location, :publication_place]
+      self.terms += [:holding_location, :publication_place, :viewing_direction, :viewing_hint]
     end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -28,7 +28,7 @@ class SolrDocument
 
   attribute :num_pages, Solr::String, solr_name('num_pages')
   attribute :holding_location, Solr::String, solr_name('holding_location')
-  attribute :viewing_hint, Solr::String, solr_name('viewing_direction')
+  attribute :viewing_hint, Solr::String, solr_name('viewing_hint')
   attribute :viewing_direction, Solr::String, solr_name('viewing_direction')
 
 

--- a/app/views/hyrax/base/_file_manager_resource_form.html.erb
+++ b/app/views/hyrax/base/_file_manager_resource_form.html.erb
@@ -1,0 +1,6 @@
+<div class="resource-form-container">
+  <%= simple_form_for [main_app, @form], remote: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
+    <%= f.input :thumbnail_id, as: :hidden, input_html: { data: {member_link: 'thumbnail_id'}} %>
+    <%= f.input :representative_id, as: :hidden, input_html: { data: {member_link: 'representative_id'}} %>
+  <% end %>
+</div>

--- a/app/views/hyrax/base/_file_manager_resource_form.html.erb
+++ b/app/views/hyrax/base/_file_manager_resource_form.html.erb
@@ -5,35 +5,39 @@
       <%= f.input :representative_id, as: :hidden, input_html: { data: {member_link: 'representative_id'}} %>
   
       <%# essi customization for viewing direction, hint %>
-      <% directions = ['left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top'] %>
-      <% selected_direction = @form.model.viewing_direction || directions.first %>
-      <%= f.input :viewing_direction, as: :hidden, input_html: { data: {member_link: 'viewing_direction_option'}, value: selected_direction } %>
-      <div class="form-group <%= f.object.model_name.singular %>_viewing_direction">
-        <label>Viewing Direction:</label>
-        <% directions.each_with_index do |val, index| %>
-          <div class="radio">
-            <%= content_tag :label do %>
-              <%= tag :input, name: "viewing_direction_option", id: "#{f.object.model_name.singular}_viewing_direction_#{val}", type: :radio, value: val, checked: (val == selected_direction), class: 'resource-radio-button' %>
-              <%= val %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
-  
-      <% hints = ['individuals', 'paged', 'continuous'] %>
-      <% selected_hint = @form.model.viewing_hint || hints.first %>
-      <%= f.input :viewing_hint, as: :hidden, input_html: { data: {member_link: 'viewing_hint_option'}, value: selected_hint } %>
-      <div class="form-group <%= f.object.model_name.singular %>_viewing_hint">
-        <label>Viewing Hint:</label>
-        <% hints.each_with_index do |val, index| %>
-          <div class="radio">
-            <%= content_tag :label do %>
-              <%= tag :input, name: "viewing_hint_option", id: "#{f.object.model_name.singular}_viewing_hint_#{val}", type: :radio, value: val, checked: (val == selected_hint), class: 'resource-radio-button' %>
-              <%= val %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+      <% if @form.model.respond_to?(:viewing_direction) %>
+        <% directions = ['left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top'] %>
+        <% selected_direction = @form.model.viewing_direction || directions.first %>
+        <%= f.input :viewing_direction, as: :hidden, input_html: { data: {member_link: 'viewing_direction_option'}, value: selected_direction } %>
+        <div class="form-group <%= f.object.model_name.singular %>_viewing_direction">
+          <label>Viewing Direction:</label>
+          <% directions.each_with_index do |val, index| %>
+            <div class="radio">
+              <%= content_tag :label do %>
+                <%= tag :input, name: "viewing_direction_option", id: "#{f.object.model_name.singular}_viewing_direction_#{val}", type: :radio, value: val, checked: (val == selected_direction), class: 'resource-radio-button' %>
+                <%= val %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% if @form.model.respond_to?(:viewing_hint) %>
+        <% hints = ['individuals', 'paged', 'continuous'] %>
+        <% selected_hint = @form.model.viewing_hint || hints.first %>
+        <%= f.input :viewing_hint, as: :hidden, input_html: { data: {member_link: 'viewing_hint_option'}, value: selected_hint } %>
+        <div class="form-group <%= f.object.model_name.singular %>_viewing_hint">
+          <label>Viewing Hint:</label>
+          <% hints.each_with_index do |val, index| %>
+            <div class="radio">
+              <%= content_tag :label do %>
+                <%= tag :input, name: "viewing_hint_option", id: "#{f.object.model_name.singular}_viewing_hint_#{val}", type: :radio, value: val, checked: (val == selected_hint), class: 'resource-radio-button' %>
+                <%= val %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/hyrax/base/_file_manager_resource_form.html.erb
+++ b/app/views/hyrax/base/_file_manager_resource_form.html.erb
@@ -2,5 +2,36 @@
   <%= simple_form_for [main_app, @form], remote: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
     <%= f.input :thumbnail_id, as: :hidden, input_html: { data: {member_link: 'thumbnail_id'}} %>
     <%= f.input :representative_id, as: :hidden, input_html: { data: {member_link: 'representative_id'}} %>
+
+    <%# essi customization for viewing direction, hint %>
+    <% directions = ['left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top'] %>
+    <% selected_direction = @form.model.viewing_direction || directions.first %>
+    <%= f.input :viewing_direction, as: :hidden, input_html: { data: {member_link: 'viewing_direction_option'}, value: selected_direction } %>
+    <div class="form-group <%= f.object.model_name.singular %>_viewing_direction">
+      <label>Viewing Direction:</label>
+      <% directions.each_with_index do |val, index| %>
+        <div class="radio">
+          <%= content_tag :label do %>
+            <%= tag :input, name: "viewing_direction_option", id: "#{f.object.model_name.singular}_viewing_direction_#{val}", type: :radio, value: val, checked: (val == selected_direction), class: 'resource-radio-button' %>
+            <%= val %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <% hints = ['individuals', 'paged', 'continuous'] %>
+    <% selected_hint = @form.model.viewing_hint || hints.first %>
+    <%= f.input :viewing_hint, as: :hidden, input_html: { data: {member_link: 'viewing_hint_option'}, value: selected_hint } %>
+    <div class="form-group <%= f.object.model_name.singular %>_viewing_hint">
+      <label>Viewing Hint:</label>
+      <% hints.each_with_index do |val, index| %>
+        <div class="radio">
+          <%= content_tag :label do %>
+            <%= tag :input, name: "viewing_hint_option", id: "#{f.object.model_name.singular}_viewing_hint_#{val}", type: :radio, value: val, checked: (val == selected_hint), class: 'resource-radio-button' %>
+            <%= val %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/app/views/hyrax/base/_file_manager_resource_form.html.erb
+++ b/app/views/hyrax/base/_file_manager_resource_form.html.erb
@@ -1,37 +1,39 @@
-<div class="resource-form-container">
-  <%= simple_form_for [main_app, @form], remote: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
-    <%= f.input :thumbnail_id, as: :hidden, input_html: { data: {member_link: 'thumbnail_id'}} %>
-    <%= f.input :representative_id, as: :hidden, input_html: { data: {member_link: 'representative_id'}} %>
-
-    <%# essi customization for viewing direction, hint %>
-    <% directions = ['left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top'] %>
-    <% selected_direction = @form.model.viewing_direction || directions.first %>
-    <%= f.input :viewing_direction, as: :hidden, input_html: { data: {member_link: 'viewing_direction_option'}, value: selected_direction } %>
-    <div class="form-group <%= f.object.model_name.singular %>_viewing_direction">
-      <label>Viewing Direction:</label>
-      <% directions.each_with_index do |val, index| %>
-        <div class="radio">
-          <%= content_tag :label do %>
-            <%= tag :input, name: "viewing_direction_option", id: "#{f.object.model_name.singular}_viewing_direction_#{val}", type: :radio, value: val, checked: (val == selected_direction), class: 'resource-radio-button' %>
-            <%= val %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-
-    <% hints = ['individuals', 'paged', 'continuous'] %>
-    <% selected_hint = @form.model.viewing_hint || hints.first %>
-    <%= f.input :viewing_hint, as: :hidden, input_html: { data: {member_link: 'viewing_hint_option'}, value: selected_hint } %>
-    <div class="form-group <%= f.object.model_name.singular %>_viewing_hint">
-      <label>Viewing Hint:</label>
-      <% hints.each_with_index do |val, index| %>
-        <div class="radio">
-          <%= content_tag :label do %>
-            <%= tag :input, name: "viewing_hint_option", id: "#{f.object.model_name.singular}_viewing_hint_#{val}", type: :radio, value: val, checked: (val == selected_hint), class: 'resource-radio-button' %>
-            <%= val %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
+<div class="well">
+  <div class="resource-form-container">
+    <%= simple_form_for [main_app, @form], remote: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
+      <%= f.input :thumbnail_id, as: :hidden, input_html: { data: {member_link: 'thumbnail_id'}} %>
+      <%= f.input :representative_id, as: :hidden, input_html: { data: {member_link: 'representative_id'}} %>
+  
+      <%# essi customization for viewing direction, hint %>
+      <% directions = ['left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top'] %>
+      <% selected_direction = @form.model.viewing_direction || directions.first %>
+      <%= f.input :viewing_direction, as: :hidden, input_html: { data: {member_link: 'viewing_direction_option'}, value: selected_direction } %>
+      <div class="form-group <%= f.object.model_name.singular %>_viewing_direction">
+        <label>Viewing Direction:</label>
+        <% directions.each_with_index do |val, index| %>
+          <div class="radio">
+            <%= content_tag :label do %>
+              <%= tag :input, name: "viewing_direction_option", id: "#{f.object.model_name.singular}_viewing_direction_#{val}", type: :radio, value: val, checked: (val == selected_direction), class: 'resource-radio-button' %>
+              <%= val %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+  
+      <% hints = ['individuals', 'paged', 'continuous'] %>
+      <% selected_hint = @form.model.viewing_hint || hints.first %>
+      <%= f.input :viewing_hint, as: :hidden, input_html: { data: {member_link: 'viewing_hint_option'}, value: selected_hint } %>
+      <div class="form-group <%= f.object.model_name.singular %>_viewing_hint">
+        <label>Viewing Hint:</label>
+        <% hints.each_with_index do |val, index| %>
+          <div class="radio">
+            <%= content_tag :label do %>
+              <%= tag :input, name: "viewing_hint_option", id: "#{f.object.model_name.singular}_viewing_hint_#{val}", type: :radio, value: val, checked: (val == selected_hint), class: 'resource-radio-button' %>
+              <%= val %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/records/edit_fields/_viewing_direction.html.erb
+++ b/app/views/records/edit_fields/_viewing_direction.html.erb
@@ -1,0 +1,5 @@
+<%= f.input :viewing_direction, as: :select,
+    collection: ['left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top'],
+    include_blank: true,
+    input_html: { class: 'form-control' }
+%>

--- a/app/views/records/edit_fields/_viewing_hint.html.erb
+++ b/app/views/records/edit_fields/_viewing_hint.html.erb
@@ -1,0 +1,5 @@
+<%= f.input :viewing_hint, as: :select,
+    collection: ['individuals', 'paged', 'continuous'],
+    include_blank: true,
+    input_html: { class: 'form-control' }
+%>

--- a/config/initializers/add_file_manager_form_fields.rb
+++ b/config/initializers/add_file_manager_form_fields.rb
@@ -1,0 +1,7 @@
+module FileManagerFormExtensions
+  delegate :viewing_direction, :viewing_hint, to: :model
+end
+
+Hyrax::Forms::FileManagerForm.class_eval do
+  prepend FileManagerFormExtensions
+end


### PR DESCRIPTION
Required adding and modifying a couple of stock hyrax assets: one javascript, one view partial.

Since a model's form `terms` are used for _both_ deciding what passes `params` sanitizing _and_ what shows up in the general editing form, this does add `viewing_direction` and `viewing_hint` to the Edit form, as a side effect.  In the longer term, we probably want to either hide/remove it, or change the interface from free text to a select box.

One thing this revealed is that any additions you want to make to File Manager sidebar content will necessarily require modifying the stock Hyrax javascript, if you want to the "Save" button-enabling logic to be aware of your new content -- otherwise, users will have to change something _else_ to get the Save button enabled!