### PR TITLE
[ESSI-234] WIP: get faster result from work.lock?

### DIFF
--- a/app/models/concerns/extra_lockable.rb
+++ b/app/models/concerns/extra_lockable.rb
@@ -24,7 +24,7 @@ module ExtraLockable
     end
 
     def lock?(key = lock_id)
-      acquire_lock_for(key) { nil }
+      Hyrax::LockManager.new(10,0,0).lock(key) { nil }
       Rails.logger.info "ExtraLockable: No lock found for key: #{key}"
       return false
     rescue Hyrax::LockManager::UnableToAcquireLockError


### PR DESCRIPTION
WIP example of one way to get faster results from calling `lock?` on a work, to facilitate discussion -- not intended for actual merging.

The performance issue I ran into using the existing line 27 is that this uses the default `Hyrax::LockManager` initialized with the default settings for:
```
lock_time_to_live: 60 000 (ms -- 1 minute)
lock_retry_count: 600 # this was configured to 1 in pumpkin
lock_retry_delay: 200 (ms -- 0.2 seconds)
```
For each retry attempt, a delay (in ms) is randomly chosen between 0 and the `lock_retry_delay` value -- so with a default value of 0.2 seconds, we get an average of 0.1 seconds per retry.  Multiply that by the `default_retry_count` of 600, and we get an average of 1 minute of retry attempts before it gives up.

So, if there _is_ a lock on, `lock?` will try for one minute before returning true.  And it's quite possible that the existing lock will expire/complete, and the this will then succeed in returning false, in the meantime.

In pumpkin, `lock_retry_count` was set to 1, so we got a result within 0.2 seconds.  (`lock_time_to_live` was also upped from 1 minute to 10, with note that it was to support long-running jobs.)

So we could resolve this by making the same configuration change, and be done with it.  But the notion that's nagging me is: is it better, and worthwhile, to distinguish between the `LockManager` settings applied in cases where we _actually_ want a lock, with `acquire_lock_for`, vs potentially distinct settings when we just want to _check_ for a lock, with `.lock?` ?

To that end:
This WIP PR changes line 27 to build a different `LockManager`, specific to the `lock?` call, with different settings:
```
lock_time_to_live: 10
lock_retry_count: 0
lock_retry_delay: 0
```
We don't actually want the lock to live at _all_, but it rejects a setting of 0, and behaves oddly with a 1 or 2, so I bumped it up to 10ms.  Retry settings are intentionally at 0.  This _works_ at getting us a near-instantaneous check of whether there's a current lock on, but is a bit kludgey as it reaches deeper into the stack to do so.  Some alternative approaches might include:
* encapsulating this within `Hyrax::Lockable` as a distinct method, say `test_lock_for`, distinct from `acquire_lock_for`, that uses the minimally-lived and minimally-retried version of the `LockManager`.
* (not mutually exclusive with the above) `Hyrax::Lockable` could provide some way to return a `LockManager` with customizable intialization values -- there's no presently way to set or get a `LockManager` manually besides the default one.  I could see value in this if we want a more accessible way to tweak these settings depending on the task for which we're acquiring a lock?
* a fundamental refactoring would be to use some approach to test for an existing lock besides the current one of trying to fetch a lock and catching `Hyrax::LockManager::UnableToAcquireLockError`, but I'm not sure what that approach would be...



