### PR TITLE
ESSI-279: Fixing problem suddenly breaking all commits and PRs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.13'
+  gem 'capybara'
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,11 +58,11 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
-    archive-zip (0.11.0)
+    archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
@@ -147,20 +147,21 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancancan (1.17.0)
-    capybara (2.18.0)
+    capybara (3.24.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     carrierwave (1.3.1)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
+    childprocess (1.0.1)
+      rake (< 13.0)
+    chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     clipboard-rails (1.7.1)
@@ -262,7 +263,7 @@ GEM
       faraday
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.9.25)
+    ffi (1.11.1)
     flipflop (2.4.0)
       activesupport (>= 4.0)
     flot-rails (0.0.7)
@@ -568,7 +569,7 @@ GEM
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.2)
-    public_suffix (3.0.3)
+    public_suffix (3.1.0)
     pul_uv_rails (2.0.1)
     puma (3.12.0)
     qa (2.2.0)
@@ -677,6 +678,7 @@ GEM
       redis (>= 3.0.4)
     redlock (1.0.0)
       redis (>= 3.0.0, < 5.0)
+    regexp_parser (1.5.1)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -727,7 +729,7 @@ GEM
       oauth2
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (1.2.3)
     safe_yaml (1.0.4)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
@@ -748,9 +750,9 @@ GEM
     scrub_rb (1.0.1)
     select2-rails (3.5.10)
       thor (~> 0.14)
-    selenium-webdriver (3.14.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.2)
+    selenium-webdriver (3.142.3)
+      childprocess (>= 0.5, < 2.0)
+      rubyzip (~> 1.2, >= 1.2.2)
     shex (0.5.2)
       ebnf (~> 1.1)
       json-ld (>= 2.2, < 4.0)
@@ -851,7 +853,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
     xml-simple (1.1.5)
-    xpath (3.1.0)
+    xpath (3.2.0)
       nokogiri (~> 1.8)
 
 PLATFORMS
@@ -863,7 +865,7 @@ DEPENDENCIES
   bixby
   blacklight_iiif_search
   byebug
-  capybara (~> 2.13)
+  capybara
   chromedriver-helper
   coffee-rails (~> 4.2)
   database_cleaner

--- a/spec/features/create_paged_resource_spec.rb
+++ b/spec/features/create_paged_resource_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'Create a PagedResource', js: true do
       click_on('Go')
       within '#facets' do
         click_on('Pages')
-        expect(page).to have_content('Pages 2')
+        expect(page).to have_content('2')
         click_on('Publisher')
         expect(page).to have_content('Rspec')
         click_on('Publication Place')


### PR DESCRIPTION
Updates selenium-webdriver and capybara on the client side to fix incompatibility with headless chrome on CircleCI.  

At some point recently, commits in the repo started failing, even for previously passing PRs when master was merged back in.  This was ultimately determined to be caused by a sudden incompatibility between the server-side headless chrome and the client-side version of the Selenium driver. This was causing failures in the Paged Resource feature test when Javascript interactions were initiated.  

The underlying root cause was incompatible response formats between the client and server when checking for w3c standards compliance.  Updating the Selenium webdriver fixes this, but this then produces many Selenium deprecation errors which are fixed by updating Capybara.