### PR TITLE
Resolve possible null value for default_url_options to empty hash

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,4 +5,5 @@ require_relative 'application'
 Rails.application.initialize!
 
 
-ESSI::Application.default_url_options = ESSI::Application.config.action_mailer.default_url_options
+
+ESSI::Application.default_url_options = ESSI::Application.config.action_mailer.default_url_options || {}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: "localhost:3000" }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
If this assignment returns nil, things get broken, so this adds a nil guard to resume the normal default value of an empty hash.