### PR TITLE
[ESSI-168] Restrict "Institution" access by LDAP groups

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,7 +462,7 @@ GEM
       rdf-xsd (>= 2.2, < 4.0)
       sparql (>= 2.2, < 4.0)
       sxp (~> 1.0)
-    ldap_groups_lookup (0.6.0)
+    ldap_groups_lookup (0.6.1)
       net-ldap
     ldp (0.7.2)
       deprecation
@@ -911,4 +911,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,11 +29,7 @@ class Ability
 
     @user_groups = default_user_groups
     @user_groups |= current_user.groups if current_user.respond_to? :groups
-    if ESSI.config[:authorized_ldap_groups].blank?
-      @user_groups |= ['registered'] unless current_user.new_record?
-    elsif current_user.music_patron?
-      @user_groups |= ['registered']
-    end
+    @user_groups |= ['registered'] if current_user.authorized_patron?
     @user_groups
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,4 +21,14 @@ class Ability
         can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
     end
   end
+
+  # Copied method from blacklight-access_controls Blacklight::AccessControls::Ability
+  def user_groups
+    return @user_groups if @user_groups
+
+    @user_groups = default_user_groups
+    @user_groups |= current_user.groups if current_user.respond_to? :groups
+    @user_groups |= ['registered'] unless current_user.new_record?
+    @user_groups
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,13 +22,18 @@ class Ability
     end
   end
 
-  # Copied method from blacklight-access_controls Blacklight::AccessControls::Ability
+  # Modified method from blacklight-access_controls Blacklight::AccessControls::Ability
+  # Grants registered status for authenticated visibility ("Institution") by ldap group membership, if so configured
   def user_groups
     return @user_groups if @user_groups
 
     @user_groups = default_user_groups
     @user_groups |= current_user.groups if current_user.respond_to? :groups
-    @user_groups |= ['registered'] unless current_user.new_record?
+    if ESSI.config[:authorized_ldap_groups].blank?
+      @user_groups |= ['registered'] unless current_user.new_record?
+    elsif current_user.music_patron?
+      @user_groups |= ['registered']
+    end
     @user_groups
   end
 end

--- a/app/models/concerns/iu_user_roles.rb
+++ b/app/models/concerns/iu_user_roles.rb
@@ -17,12 +17,12 @@ module IuUserRoles
     roles.where(name: 'curator').exists?
   end
 
-  def campus_patron?
-    persisted? && provider == "cas"
+  def institution_patron?
+    persisted? && !guest? && provider == "cas"
   end
 
-  def music_patron?
-    campus_patron? && (ESSI.config[:authorized_ldap_groups].blank? ||
+  def authorized_patron?
+    institution_patron? && (ESSI.config[:authorized_ldap_groups].blank? ||
                        authorized_ldap_member?)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,11 +38,7 @@ class User < ApplicationRecord
   # Grants registered status for authenticated visibility ("Institution") by ldap group membership, if so configured
   def groups
     g = roles.map(&:name)
-    if ESSI.config[:authorized_ldap_groups].blank?
-      g += ['registered'] unless new_record? || guest?
-    elsif music_patron?
-      g += ['registered']
-    end
+    g += ['registered'] if authorized_patron?
     g
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,8 @@ class User < ApplicationRecord
     email
   end
 
+  # Modified method from hydra-role-management Hydra::RoleManagement::UserRoles
+  # Grants registered status for authenticated visibility ("Institution") by ldap group membership, if so configured
   def groups
     g = roles.map(&:name)
     if ESSI.config[:authorized_ldap_groups].blank?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,8 +9,8 @@ FactoryBot.modify do
       roles { [Role.where(name: 'admin').first_or_create] }
     end
 
-    factory :campus_patron do
-      # All CAS users are campus patrons.
+    factory :authorized_patron do
+      # All CAS users are authorized patrons.
     end
 
     factory :image_editor do

--- a/spec/features/create_paged_resource_spec.rb
+++ b/spec/features/create_paged_resource_spec.rb
@@ -25,6 +25,8 @@ RSpec.feature 'Create a PagedResource', js: true do
         agent_id: user.user_key,
         access: 'deposit'
       )
+      # Ensure empty requirement for ldap group authorization
+      allow(ESSI.config[:authorized_ldap_groups]).to receive(:blank?).and_return(true)
       login_as user
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Ability do
+  let(:user) { FactoryBot.create :user }
+  let(:options) { {} }
+  let(:ability) { described_class.new(user, options) }
+  let(:authorized_groups) { ['Test group'] }
+
+  describe '#user_groups' do
+    context 'when no authorized ldap groups are configured' do
+      before(:each) do
+        allow(ESSI.config[:authorized_ldap_groups]).to receive(:blank?).and_return(true)
+      end
+      context 'when a user is persisted' do
+        it 'considers the user registered' do
+          expect(ability.user_groups).to include('registered')
+        end
+      end
+      context 'when a user is not persisted' do
+        let(:user) { FactoryBot.build :user }
+        it 'considers the user unregistered' do
+          expect(ability.user_groups).not_to include('registered')
+        end
+      end
+    end
+    context 'when authorized ldap groups are configured' do
+      before(:each) do
+        ESSI.config[:authorized_ldap_groups] = authorized_groups
+      end
+      context 'when the user has authorized group membership' do
+        before(:each) do
+          allow(user).to receive(:music_patron?).and_return(true)
+        end
+        it 'considers the user registered' do
+          expect(ability.user_groups).to include('registered')
+        end
+      end
+      context 'when the user lacks authorized group membership' do
+        before(:each) do
+          allow(user).to receive(:music_patron?).and_return(false)
+        end
+        it 'considers the user unregistered' do
+          expect(ability.user_groups).not_to include('registered')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Ability do
       end
       context 'when the user has authorized group membership' do
         before(:each) do
-          allow(user).to receive(:music_patron?).and_return(true)
+          allow(user).to receive(:authorized_patron?).and_return(true)
         end
         it 'considers the user registered' do
           expect(ability.user_groups).to include('registered')
@@ -37,7 +37,7 @@ RSpec.describe Ability do
       end
       context 'when the user lacks authorized group membership' do
         before(:each) do
-          allow(user).to receive(:music_patron?).and_return(false)
+          allow(user).to receive(:authorized_patron?).and_return(false)
         end
         it 'considers the user unregistered' do
           expect(ability.user_groups).not_to include('registered')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
   it 'has IuUserRoles functionality' do
     expect(included_modules).to include(::IuUserRoles)
     expect(included_modules).to include(LDAPGroupsLookup::Behavior)
-    expect(user).to respond_to(:campus_patron?)
+    expect(user).to respond_to(:institution_patron?)
     expect(user).to respond_to(:image_editor?)
     expect(user).to respond_to(:ldap_lookup_key)
   end
@@ -16,7 +16,7 @@ RSpec.describe User, type: :model do
     expect(user).to respond_to(:admin?)
   end
 
-  describe "#campus_patron?" do
+  describe "#institution_patron?" do
     context "when logged in from CAS" do
       let(:user) do
         described_class.find_for_iu_cas(OpenStruct.new(provider: "cas",
@@ -24,7 +24,7 @@ RSpec.describe User, type: :model do
       end
 
       it "is true" do
-        expect(user).to be_campus_patron
+        expect(user).to be_institution_patron
       end
     end
     context "when not logged in from CAS" do
@@ -32,43 +32,43 @@ RSpec.describe User, type: :model do
         allow(user).to receive(:provider).and_return(:not_cas)
       end
       it "is false" do
-        expect(user).not_to be_campus_patron
+        expect(user).not_to be_institution_patron
       end
     end
   end
 
-  describe "#music_patron?" do
-    context "when not a campus_patron" do
+  describe "#authorized_patron?" do
+    context "when not a institution_patron" do
       before(:each) do
-        allow(user).to receive(:campus_patron?).and_return(false)
+        allow(user).to receive(:institution_patron?).and_return(false)
       end
       it "is false" do
-        expect(user).not_to be_campus_patron
+        expect(user).not_to be_institution_patron
       end
     end
     context "when a campus patron" do
       before(:each) do
-        allow(user).to receive(:campus_patron?).and_return(true)
+        allow(user).to receive(:institution_patron?).and_return(true)
       end
       context "without authorized groups configured" do
         before(:each) do
           allow(ESSI.config[:authorized_ldap_groups]).to receive(:blank?).and_return(true)
         end
         it "is true" do
-          expect(user).to be_music_patron
+          expect(user).to be_authorized_patron
         end
       end
       context "with authorized ldap groups configured" do
         context "when the user has group membership" do
           before(:each) { allow(user).to receive(:authorized_ldap_member?).and_return(true) }
           it "is true" do
-            expect(user).to be_music_patron
+            expect(user).to be_authorized_patron
           end
         end
         context "when the user lacks group membership" do
           before(:each) { allow(user).to receive(:authorized_ldap_member?).and_return(false) }
           it "is false" do
-            expect(user).not_to be_music_patron
+            expect(user).not_to be_authorized_patron
           end
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,5 +27,51 @@ RSpec.describe User, type: :model do
         expect(user).to be_campus_patron
       end
     end
+    context "when not logged in from CAS" do
+      before(:each) do
+        allow(user).to receive(:provider).and_return(:not_cas)
+      end
+      it "is false" do
+        expect(user).not_to be_campus_patron
+      end
+    end
+  end
+
+  describe "#music_patron?" do
+    context "when not a campus_patron" do
+      before(:each) do
+        allow(user).to receive(:campus_patron?).and_return(false)
+      end
+      it "is false" do
+        expect(user).not_to be_campus_patron
+      end
+    end
+    context "when a campus patron" do
+      before(:each) do
+        allow(user).to receive(:campus_patron?).and_return(true)
+      end
+      context "without authorized groups configured" do
+        before(:each) do
+          allow(ESSI.config[:authorized_ldap_groups]).to receive(:blank?).and_return(true)
+        end
+        it "is true" do
+          expect(user).to be_music_patron
+        end
+      end
+      context "with authorized ldap groups configured" do
+        context "when the user has group membership" do
+          before(:each) { allow(user).to receive(:authorized_ldap_member?).and_return(true) }
+          it "is true" do
+            expect(user).to be_music_patron
+          end
+        end
+        context "when the user lacks group membership" do
+          before(:each) { allow(user).to receive(:authorized_ldap_member?).and_return(false) }
+          it "is false" do
+            expect(user).not_to be_music_patron
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Should serve to satisfy ESSI-168, and/or as a basis for further changes.