### PR TITLE
Admins are always in the registered user group.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,7 +29,7 @@ class Ability
 
     @user_groups = default_user_groups
     @user_groups |= current_user.groups if current_user.respond_to? :groups
-    @user_groups |= ['registered'] if current_user.authorized_patron?
+    @user_groups |= ['registered'] if current_user.authorized_patron? || current_user.admin?
     @user_groups
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Ability do
         it 'considers the user unregistered' do
           expect(ability.user_groups).not_to include('registered')
         end
+        context 'when the user is an admin' do
+          before(:each) do
+            allow(user).to receive(:admin?).and_return(true)
+          end
+          it 'considers the user registered' do
+            expect(ability.user_groups).to include('registered')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Some parts of the stack assume admins are in the registered group, but
that now depends on the user being in a valid ldap group.