### PR TITLE
Admins are always in registered user group, in user#groups method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,9 @@ jobs:
     # Download and cache dependencies
     - restore_cache:
         keys:
-        - dependencies-v1-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        - dependencies-v1-{{ .Branch }}
-        - dependencies-v1-
+        - dependencies-v2-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - dependencies-v2-{{ .Branch }}
+        - dependencies-v2-
 
     - run:
         name: Install dependencies
@@ -89,7 +89,7 @@ jobs:
     - save_cache:
         paths:
         - ./vendor/bundle
-        key: dependencies-v1-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        key: dependencies-v2-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
 
 #    - run:
 #        name: Call Rubocop

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,7 +23,7 @@ class Ability
   end
 
   # Modified method from blacklight-access_controls Blacklight::AccessControls::Ability
-  # Grants registered status for authenticated visibility ("Institution") by ldap group membership, if so configured
+  # Grants registered status for authenticated visibility ("Institution") by ldap group membership, if so configured, and admins
   def user_groups
     return @user_groups if @user_groups
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,10 +35,10 @@ class User < ApplicationRecord
   end
 
   # Modified method from hydra-role-management Hydra::RoleManagement::UserRoles
-  # Grants registered status for authenticated visibility ("Institution") by ldap group membership, if so configured
+  # Grants registered status for authenticated visibility ("Institution") by ldap group membership, if so configured, and admins
   def groups
     g = roles.map(&:name)
-    g += ['registered'] if authorized_patron?
+    g += ['registered'] if authorized_patron? || admin?
     g
   end
 


### PR DESCRIPTION
For ESSI-344, adds the corresponding change to the Ability model into the User model.