### PR TITLE
ESSI-287: Collapsible work items

### DIFF
--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,0 +1,30 @@
+
+<%  array_of_ids = presenter.list_of_item_ids_to_display %>
+<%  members = presenter.member_presenters_for(array_of_ids) %>
+<% if members.present? %>
+  <table class="table table-striped related-files">
+    <thead>
+      <tr>
+        <th><%= t('.thumbnail') %></th>
+        <th><%= t('.title') %></th>
+        <th><%= t('.date_uploaded') %></th>
+        <th><%= t('.visibility') %></th>
+        <th><%= t('.actions') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'member', collection: members %>
+    </tbody>
+  </table>
+  <div class="row">
+    <% if presenter.total_pages > 1 %>
+        <div class="row record-padding col-md-9">
+          <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+        </div><!-- /pager -->
+    <% end %>
+  </div>
+<% elsif can? :edit, presenter.id %>
+    <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>
+<% else %>
+  <div class="alert alert-warning" role="alert"><%= t('.unauthorized', type: presenter.human_readable_type) %></div>
+<% end %>

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -2,26 +2,35 @@
 <%  array_of_ids = presenter.list_of_item_ids_to_display %>
 <%  members = presenter.member_presenters_for(array_of_ids) %>
 <% if members.present? %>
-  <table class="table table-striped related-files">
-    <thead>
-      <tr>
-        <th><%= t('.thumbnail') %></th>
-        <th><%= t('.title') %></th>
-        <th><%= t('.date_uploaded') %></th>
-        <th><%= t('.visibility') %></th>
-        <th><%= t('.actions') %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <%= render partial: 'member', collection: members %>
-    </tbody>
-  </table>
-  <div class="row">
-    <% if presenter.total_pages > 1 %>
-        <div class="row record-padding col-md-9">
-          <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
-        </div><!-- /pager -->
-    <% end %>
+  <%= link_to t('hyrax.works.form.show_child_items'),
+              '#work-items',
+              class: 'btn btn-default additional-fields',
+              data: { toggle: 'collapse' },
+              role: "button",
+              'aria-expanded'=> "false",
+              'aria-controls'=> "work-items" %>
+  <div id="work-items" class='collapse'>
+    <table class="table table-striped related-files">
+      <thead>
+        <tr>
+          <th><%= t('.thumbnail') %></th>
+          <th><%= t('.title') %></th>
+          <th><%= t('.date_uploaded') %></th>
+          <th><%= t('.visibility') %></th>
+          <th><%= t('.actions') %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: 'member', collection: members %>
+      </tbody>
+    </table>
+    <div class="row">
+      <% if presenter.total_pages > 1 %>
+          <div class="row record-padding col-md-9">
+            <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+          </div><!-- /pager -->
+      <% end %>
+    </div>
   </div>
 <% elsif can? :edit, presenter.id %>
     <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,47 +1,49 @@
-<div class="show-actions">
-  <div class="col-sm-4 text-left">
-    <% if Hyrax.config.analytics? %>
-      <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
-    <% end %>
-    <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
-        class: 'btn btn-default submits-batches submits-batches-add',
-        data: { toggle: "modal", target: "#collection-list-container" } %>
-    <% if presenter.work_featurable? %>
-        <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),
-            data: { behavior: 'feature' },
-            class: presenter.display_unfeature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+<div class="row">
+  <div class="show-actions">
+    <div class="col-sm-4 text-left">
+      <% if Hyrax.config.analytics? %>
+        <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
+      <% end %>
+      <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+          class: 'btn btn-default submits-batches submits-batches-add',
+          data: { toggle: "modal", target: "#collection-list-container" } %>
+      <% if presenter.work_featurable? %>
+          <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),
+              data: { behavior: 'feature' },
+              class: presenter.display_unfeature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+    
+          <%= link_to "Unfeature", hyrax.featured_work_path(presenter, format: :json),
+              data: { behavior: 'unfeature' },
+              class: presenter.display_feature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+      <% end %>
+    </div>
+    <div class="col-sm-8 text-right">
+    <% if presenter.editor? %>
+        <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
+        <% if presenter.member_presenters.size > 1 %>
+            <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
+            <%= link_to t("hyrax.structure_manager.link_text"), polymorphic_path([main_app, :structure, presenter]), class: 'btn btn-default' %>
+        <% end %>
+        <% if presenter.valid_child_concerns.length > 0 %>
+          <div class="btn-group">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Attach Child <span class="caret"></span>
+            </button>
   
-        <%= link_to "Unfeature", hyrax.featured_work_path(presenter, format: :json),
-            data: { behavior: 'unfeature' },
-            class: presenter.display_feature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+            <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+  
+            <ul class="dropdown-menu">
+              <% presenter.valid_child_concerns.each do |concern| %>
+                <li>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
     <% end %>
-  </div>
-  <div class="col-sm-8 text-right">
-  <% if presenter.editor? %>
-      <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
-      <% if presenter.member_presenters.size > 1 %>
-          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
-          <%= link_to t("hyrax.structure_manager.link_text"), polymorphic_path([main_app, :structure, presenter]), class: 'btn btn-default' %>
-      <% end %>
-      <% if presenter.valid_child_concerns.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Attach Child <span class="caret"></span>
-          </button>
-
-          <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
-
-          <ul class="dropdown-menu">
-            <% presenter.valid_child_concerns.each do |concern| %>
-              <li>
-                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-      <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
-  <% end %>
+    </div>
   </div>
 </div>
 

--- a/app/views/hyrax/base/_work_title.erb
+++ b/app/views/hyrax/base/_work_title.erb
@@ -10,9 +10,4 @@
       <% end %>
     </div>
   </div>
-  <div class="row">
-    <% if index == 0 %>
-      <%= render "show_actions", presenter: presenter %>
-    <% end %>
-  </div>
 <% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -32,6 +32,7 @@
       </div>
     </div><!-- /panel -->
 
+    <% if @presenter.grouped_presenters.any? %>
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title"><%= t('hyrax.base.show.relationships') %></h3>
@@ -40,6 +41,7 @@
         <%= render 'relationships', presenter: @presenter %>
       </div>
     </div>
+    <% end %>
 
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -3,14 +3,14 @@
 <%= render 'shared/citations' %>
 
 <div class="row work-type">
-  <div class="col-xs-12">
+  <div class="col-sm-12">
     <%= render 'work_type', presenter: @presenter %>
   </div>
-  <div class="col-xs-12">&nbsp;</div>
   <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
     <div class="panel panel-default">
       <div class="panel-heading">
         <%= render 'work_title', presenter: @presenter %>
+        <%= render 'show_actions', presenter: @presenter %>
       </div>
       <div class="panel-body">
         <div class="row">
@@ -28,16 +28,34 @@
             <%= render 'work_description', presenter: @presenter %>
             <%= render 'metadata', presenter: @presenter %>
           </div>
-          <div class="col-sm-12">
-            <%= render 'relationships', presenter: @presenter %>
-            <%= render 'items', presenter: @presenter %>
-            <%# TODO: we may consider adding these partials in the future %>
-            <%# = render 'sharing_with', presenter: @presenter %>
-            <%# = render 'user_activity', presenter: @presenter %>
-          </div>
-          <%= render 'workflow_actions_widget', presenter: @presenter %>
         </div>
       </div>
+    </div><!-- /panel -->
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title"><%= t('hyrax.base.show.relationships') %></h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'relationships', presenter: @presenter %>
+      </div>
     </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title"><%= t('.items') %></h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'items', presenter: @presenter %>
+      </div>
+    </div>
+
+    <%= render 'workflow_actions_widget', presenter: @presenter %>     
+
+    <%# TODO: we may consider adding these partials in the future %>
+    <%# = render 'sharing_with', presenter: @presenter %>
+    <%# = render 'user_activity', presenter: @presenter %>
+
   </div>
 </div>
+

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -65,6 +65,8 @@ en:
       browse_everything:
         browse_files_button: Upload from server
     works:
+      form:
+        show_child_items: Show Child Items
       structure:
         breadcrumb: Edit Structure
       file_manager:

--- a/spec/features/create_paged_resource_spec.rb
+++ b/spec/features/create_paged_resource_spec.rb
@@ -76,6 +76,7 @@ RSpec.feature 'Create a PagedResource', js: true do
       expect(page).to have_content('My Test Work')
       expect(page).to have_content "Your files are being processed by Hyrax in the background."
       expect(find('li.attribute-creator')).to have_content('Doe, Jane')
+      click_on('Show Child Items')
       expect(find('table.related-files')).to have_content('rgb.png')
 
       click_on('Go')


### PR DESCRIPTION
Makes the Items table collapsible, and collapsed by default, as the "Additional Fields" set of metadata in Edit.

Should get Nick to confirm/deny last commit, hiding an empty Relationships section.

Note that this is based on ESSI-288 and should be rebased on updated master after #55 is merged. 