### PR TITLE
ESSI-385 Allows Sidekiq to be configurable via environment settings in secrets file

### DIFF
--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -12,6 +12,11 @@ default: &default
   redis:
     host: 127.0.0.1
     port: 6379
+  sidekiq:
+    queue_names:
+      - default
+      - ingest
+    max_retries: 3
   rails:
     mailer:
       host: localhost:3000

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,1 @@
+Sidekiq.options[:max_retries] = ESSI.config.fetch(:sidekiq,{}).fetch(:max_retries,nil) || 3

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,2 @@
 ---
-:queues:
-  - default
-  - ingest
+:queues: <%= ESSI.config.fetch(:sidekiq,{}).fetch(:queue_namess,nil) || "['default','ingest']" %>


### PR DESCRIPTION
Allows Sidekiq queue names and failed job retry count to be configurable via main ESSI config file.