### PR TITLE
Redefining how and where Sidekiq configuration values get set

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,1 +1,20 @@
-Sidekiq.options[:max_retries] = ESSI.config.fetch(:sidekiq,{}).fetch(:max_retries,nil) || 3
+# Sidekiq normally sets options from (Rails.root)/config/sidekiq.yml. This initializer allows us to set
+# configuration options that may have been overridden using the ESSI configuration YAML file.
+
+# Retrieve Sidekiq options set in the default configuration file
+sidekiq_config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'sidekiq.yml'))).result,[Symbol], [], true)
+
+# The following calls to Sidekiq.options establishes the following order of precedence:
+# 1. The named option is set from the ESSI configuration file if exists
+# 2. Or the named option is set from the default Sidekiq YAML configuration file if exists
+# 3. Or no options are set and Sidekiq defaults to internal defaults
+
+# If no queue names are set in either the ESSI or Sidekiq config files, the queue
+# will be set to the Sidekiq internal of default.
+Sidekiq.options[:queues] = ESSI.config.fetch(:sidekiq,{}).fetch(:queue_names,nil) ||
+    sidekiq_config.fetch(:queues,['default']) if sidekiq_config
+
+# If max_retries is not set in either the ESSI or Sidekiq config files, the value
+# will be set to the Sidekiq internal default (10?)
+Sidekiq.options[:max_retries] = ESSI.config.fetch(:sidekiq,{}).fetch(:max_retries,nil) ||
+    sidekiq_config.fetch(:max_retries,3) if sidekiq_config

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,5 @@
 ---
-:queues: <%= ESSI.config.fetch(:sidekiq,{}).fetch(:queue_namess,nil) || "['default','ingest']" %>
+:queues:
+  - default
+  - ingest
+:max_retries: 3


### PR DESCRIPTION
PR #63 introduced the ability to configure Sidekiq settings from the main ESSI configuration YAML file.  However, it wasn't until trying to run Sidekiq standalone that it was apparent that the ESSI config stash was not loaded and available when Sidekiq's default config file is parsed (`config/sidekiq.yml`)  which resulted in a runtime error (i.e. uninitialized constant ESSI)

Rather than try to figure out how to provide the ESSI config stash to that file, the Sidekiq initializer was refactored to have complete control of the assignment process and set an order of precedence.  See comments in `config/initializers/sidekiq.rb`.