### PR TITLE
ESSI-416 Adding ability to disable search within for a PagedResource

### DIFF
--- a/app/actors/hyrax/actors/paged_resource_actor.rb
+++ b/app/actors/hyrax/actors/paged_resource_actor.rb
@@ -6,6 +6,7 @@ module Hyrax
       def create(env)
         apply_creation_data_to_curation_concern(env)
         apply_save_data_to_curation_concern(env)
+        apply_ocr_option_data_to_curation_concern(env)
         save(env) && next_actor.create(env) && run_callbacks(:after_create_concern, env)
       end
 

--- a/app/actors/hyrax/actors/paged_resource_actor.rb
+++ b/app/actors/hyrax/actors/paged_resource_actor.rb
@@ -3,6 +3,18 @@
 module Hyrax
   module Actors
     class PagedResourceActor < Hyrax::Actors::BaseActor
+      def create(env)
+        apply_creation_data_to_curation_concern(env)
+        apply_save_data_to_curation_concern(env)
+        save(env) && next_actor.create(env) && run_callbacks(:after_create_concern, env)
+      end
+
+      private
+
+        def apply_ocr_option_data_to_curation_concern(env)
+          return unless ESSI.config.dig(:essi, :index_hocr_files)
+          env.curation_concern.ocr_state = "searchable"
+        end
     end
   end
 end

--- a/app/assets/javascripts/hyrax/file_manager.es6
+++ b/app/assets/javascripts/hyrax/file_manager.es6
@@ -75,6 +75,12 @@ export default class FileManager {
       $("*[data-member-link=viewing_hint_option]").val(val)
       $("*[data-member-link=viewing_hint_option]").change()
     })
+    new InputTracker($("*[data-member-link=ocr_state_option]"), manager)
+    $("*[name=ocr_state_option]").change(function() {
+        let val = $("*[name=ocr_state_option]:checked").val()
+        $("*[data-member-link=ocr_state_option]").val(val)
+        $("*[data-member-link=ocr_state_option]").change()
+    })
   }
 
   // Keep the ui/sortable placeholder the right size.

--- a/app/forms/concerns/essi/paged_resource_form_behavior.rb
+++ b/app/forms/concerns/essi/paged_resource_form_behavior.rb
@@ -4,7 +4,7 @@ module ESSI
     # Add behaviors that make this work type unique
 
     included do
-      self.terms += [:holding_location, :publication_place, :viewing_direction, :viewing_hint]
+      self.terms += [:holding_location, :publication_place, :viewing_direction, :viewing_hint, :ocr_state]
     end
   end
 end

--- a/app/models/concerns/essi/paged_resource_behavior.rb
+++ b/app/models/concerns/essi/paged_resource_behavior.rb
@@ -4,6 +4,18 @@ module ESSI
     # Add behaviors that make this work type unique
     included do
       before_save :set_num_pages
+
+      def ocr_searchable?
+        return true if self.ocr_state == 'searchable'
+        return false
+      end
+    end
+
+    def to_solr(solr_doc = {})
+      super.tap do |doc|
+        doc[Solrizer.solr_name('ocr_searchable',
+                               Solrizer::Descriptor.new(:boolean, :stored, :indexed))] = self.ocr_searchable?
+      end
     end
 
   private

--- a/app/models/concerns/essi/paged_resource_metadata.rb
+++ b/app/models/concerns/essi/paged_resource_metadata.rb
@@ -7,6 +7,9 @@ module ESSI
       property :viewing_hint, predicate: ::RDF::Vocab::IIIF.viewingHint, multiple: false
       property :viewing_direction, predicate: ::RDF::Vocab::IIIF.viewingDirection, multiple: false
       property :num_pages, predicate: ::RDF::Vocab::BIBO.numPages, multiple: false
+      property :ocr_state, predicate: ::RDF::URI.new('http://dlib.indiana.edu/vocabulary/OCRState'), multiple: false do |index|
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,15 +30,9 @@ class SolrDocument
   attribute :holding_location, Solr::String, solr_name('holding_location')
   attribute :viewing_hint, Solr::String, solr_name('viewing_hint')
   attribute :viewing_direction, Solr::String, solr_name('viewing_direction')
-
-
-  # def holding_location
-  #   self[Solrizer.solr_name('holding_location')]
-  # end
-
+  attribute :ocr_searchable, Solr::String, solr_name('ocr_searchable', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
 
   def series
     self[Solrizer.solr_name('series')]
   end
-
 end

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -10,6 +10,7 @@ module Hyrax
     end
 
     def search_service
+      return nil unless solr_document.ocr_searchable
       Rails.application.routes.url_helpers.solr_document_iiif_search_url(solr_document.id)
     end
 

--- a/app/views/hyrax/base/_file_manager_resource_form.html.erb
+++ b/app/views/hyrax/base/_file_manager_resource_form.html.erb
@@ -41,5 +41,20 @@
           <% end %>
         </div>
       <% end %>
+
+      <% searchable_opts = ['searchable', 'disabled'] %>
+      <% selected_opt = @form.model.ocr_searchable? ? searchable_opts[0] : searchable_opts[1]%>
+      <%= f.input :ocr_state, as: :hidden, input_html: { data: {member_link: 'ocr_state_option'}, value: selected_opt } %>
+      <div class="form-group <%= f.object.model_name.singular %>_search_opts list-group-item">
+        <legend class="legend-save-work">Search within:</legend>
+        <% searchable_opts.each do |val| %>
+          <div class="radio">
+            <%= content_tag :label do %>
+              <%= tag :input, name: "ocr_state_option", id: "#{f.object.model_name.singular}_ocr_state_#{val}", type: :radio, value: val, checked: (val == selected_opt), class: 'resource-radio-button' %>
+              <%= val %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     <% end %>
   </div>

--- a/spec/actors/hyrax/actors/paged_resource_actor_spec.rb
+++ b/spec/actors/hyrax/actors/paged_resource_actor_spec.rb
@@ -1,7 +1,44 @@
 # Generated via
 #  `rails generate hyrax:work PagedResource`
+require 'spec_helper'
 require 'rails_helper'
 
 RSpec.describe Hyrax::Actors::PagedResourceActor do
-  # "Add your tests here"
+  let(:work) { FactoryBot.create(:paged_resource_with_one_image) }
+  let(:ability) { ::Ability.new(user) }
+  let(:env) { Hyrax::Actors::Environment.new(work, ability, attributes) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:user)     { FactoryBot.create(:user) }
+  let(:attributes) { {} }
+
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  describe "#create" do
+    context 'when index_hocr_files is true', :clean do
+      it 'OCR should be searchable' do
+        allow(ESSI.config).to receive(:dig) \
+        .with(any_args).and_call_original
+        allow(ESSI.config).to receive(:dig) \
+        .with(:essi, :index_hocr_files) \
+        .and_return(true)
+        expect { middleware.create(env) }.to change { work.ocr_state }.from(nil).to("searchable")
+      end
+    end
+
+    context 'when index_hocr_files is false', :clean do
+      it 'OCR should not be searchable' do
+        allow(ESSI.config).to receive(:dig) \
+        .with(any_args).and_call_original
+        allow(ESSI.config).to receive(:dig) \
+        .with(:essi, :index_hocr_files) \
+        .and_return(false)
+        expect { middleware.create(env) }.not_to change { work.ocr_state }
+      end
+    end
+  end
 end

--- a/spec/models/paged_resource_spec.rb
+++ b/spec/models/paged_resource_spec.rb
@@ -9,4 +9,28 @@ RSpec.describe PagedResource do
   include_examples "ExtraLockable Behaviors" do
     let(:curation_concern) { FactoryBot.create(:paged_resource) }
   end
+
+  describe '#ocr_searchable?' do
+    let(:work) { described_class.new(ocr_state: nil) }
+
+    context "when ocr_state is searchable" do
+      it 'is searchable' do
+        work.ocr_state = 'searchable'
+        expect(work).to be_ocr_searchable
+      end
+    end
+
+    context "when ocr_state is suppressed" do
+      it 'is not searchable' do
+        work.ocr_state = 'suppressed'
+        expect(work).not_to be_ocr_searchable
+      end
+    end
+
+    context "when ocr_state is nil" do
+      it 'is not searchable' do
+        expect(work).not_to be_ocr_searchable
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/metadata_helper.rb
+++ b/spec/support/shared_examples/metadata_helper.rb
@@ -31,6 +31,7 @@ RSpec.shared_examples "PagedResource Properties" do
     # Test a small subset of the properties available.
     expect(subject).to respond_to(:viewing_hint)
     expect(subject).to respond_to(:viewing_direction)
+    expect(subject).to respond_to(:ocr_state)
   end
 end
 


### PR DESCRIPTION
A PagedResource will typically have searchable text extracted during OCR derivative creation, but there will be a chance that the fidelity of the text is not high enough to make searching useful.  In these cases we will want to hide the search bar in the Universal Viewer.  

This PR adds all of the pieces needed to disable searching via a control in the File Manager toolbar.  It also adds a step in the actor to ensure that searching is enabled by default so that the option only needs to be changed in the case of wanting to disable it.  All of this is specific to the PagedResource work type.