### PR TITLE
don't freeze bundler when using the Docker dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # system dependency image
 FROM ruby:2.5-stretch AS essi-sys-deps
 
-# throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
-
 RUN apt-get update -qq && \
     apt-get install -y build-essential default-jre-headless libpq-dev nodejs \
       libreoffice-writer libreoffice-impress imagemagick unzip ghostscript \
@@ -35,6 +32,9 @@ FROM essi-sys-deps AS essi-deps
 
 RUN mkdir /app
 WORKDIR /app
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
 
 COPY Gemfile Gemfile.lock ./
 RUN gem update bundler


### PR DESCRIPTION
Move the frozen Gemfile config from the base `essi-sys-deps` image that all other images are built off of (including `essi-dev`) to the `essi-deps` image. This allows new gems to be added in the dev environment without throwing errors 