### PR TITLE
WIP ESSI-187, UI display of locked works

### DIFF
--- a/app/helpers/lock_warning_helper.rb
+++ b/app/helpers/lock_warning_helper.rb
@@ -1,5 +1,5 @@
 module LockWarningHelper
-  def lock_warning
+  def lock_warning(curation_concern)
     return nil unless curation_concern.try(:lock?)
     content_tag(:h1,
                 'This object is currently queued for processing.',

--- a/app/helpers/lock_warning_helper.rb
+++ b/app/helpers/lock_warning_helper.rb
@@ -1,0 +1,9 @@
+module LockWarningHelper
+  def lock_warning
+    return nil unless curation_concern.try(:lock?)
+    content_tag(:h1,
+                'This object is currently queued for processing.',
+                class: 'alert alert-warning')
+  end
+end
+

--- a/app/models/concerns/extra_lockable.rb
+++ b/app/models/concerns/extra_lockable.rb
@@ -6,7 +6,13 @@ module ExtraLockable
     class_attribute :lock_id_attribute
     self.lock_id_attribute = :id
 
-    # TODO: Handle when id is nil or not defined.
+    delegate :lock_manager, to: :LockManagerService
+    delegate :lock_checker, to: :LockManagerService
+
+    def check_lock_for(lock_key, &block)
+      lock_checker.lock(lock_key, &block)
+    end
+
     def lock_id
       ident = try(lock_id_attribute)
       raise ArgumentError, "lock id attribute cannot be blank" if ident.blank?
@@ -24,7 +30,7 @@ module ExtraLockable
     end
 
     def lock?(key = lock_id)
-      acquire_lock_for(key) { nil }
+      check_lock_for(key) { nil }
       Rails.logger.info "ExtraLockable: No lock found for key: #{key}"
       return false
     rescue Hyrax::LockManager::UnableToAcquireLockError

--- a/app/models/membership_builder.rb
+++ b/app/models/membership_builder.rb
@@ -1,5 +1,5 @@
 class MembershipBuilder
-  include ::Hyrax::Lockable
+  include ExtraLockable
   attr_reader :work, :members
 
   def initialize(work, members)

--- a/app/services/lock_manager_service.rb
+++ b/app/services/lock_manager_service.rb
@@ -1,0 +1,14 @@
+class LockManagerService
+  def self.lock_manager
+    @@lock_manager ||= ::Hyrax::LockManager.new(
+      Hyrax.config.lock_time_to_live,
+      Hyrax.config.lock_retry_count,
+      Hyrax.config.lock_retry_delay
+    )
+  end
+
+  # Returns a LockManager with minimal settings sufficient for testing locks
+  def self.lock_checker
+    @@lock_checker ||= ::Hyrax::LockManager.new(10, 0, 0)
+  end
+end

--- a/app/views/hyrax/base/edit.html.erb
+++ b/app/views/hyrax/base/edit.html.erb
@@ -1,0 +1,6 @@
+<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_header do %>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t("hyrax.works.update.header") %></h1>
+<% end %>
+
+<%= render 'form' %>

--- a/app/views/hyrax/base/edit.html.erb
+++ b/app/views/hyrax/base/edit.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
-  <%= lock_warning %>
+  <%= lock_warning(curation_concern) %>
   <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t("hyrax.works.update.header") %></h1>
 <% end %>
 

--- a/app/views/hyrax/base/edit.html.erb
+++ b/app/views/hyrax/base/edit.html.erb
@@ -1,5 +1,6 @@
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
+  <%= lock_warning %>
   <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t("hyrax.works.update.header") %></h1>
 <% end %>
 

--- a/app/views/hyrax/base/file_manager.html.erb
+++ b/app/views/hyrax/base/file_manager.html.erb
@@ -1,5 +1,5 @@
 <div class="col-xs-12 main-header">
-  <%= lock_warning %>
+  <%= lock_warning(curation_concern) %>
   <h1><span class="fa fa-folder-open" aria-hidden="true"></span><%= t("hyrax.file_manager.link_text") %></h1>
 </div>
 

--- a/app/views/hyrax/base/file_manager.html.erb
+++ b/app/views/hyrax/base/file_manager.html.erb
@@ -1,4 +1,5 @@
 <div class="col-xs-12 main-header">
+  <%= lock_warning %>
   <h1><span class="fa fa-folder-open" aria-hidden="true"></span><%= t("hyrax.file_manager.link_text") %></h1>
 </div>
 

--- a/app/views/hyrax/paged_resources/structure.html.erb
+++ b/app/views/hyrax/paged_resources/structure.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
-  <%= lock_warning %>
+  <%= lock_warning(curation_concern) %>
   <h1><span class="fa fa-sitemap" aria-hidden="true"></span>Edit Structure</h1>
 <% end %>
 

--- a/app/views/hyrax/paged_resources/structure.html.erb
+++ b/app/views/hyrax/paged_resources/structure.html.erb
@@ -1,5 +1,6 @@
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
+  <%= lock_warning %>
   <h1><span class="fa fa-sitemap" aria-hidden="true"></span>Edit Structure</h1>
 <% end %>
 

--- a/spec/helpers/lock_warning_helper.rb
+++ b/spec/helpers/lock_warning_helper.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe LockWarningHelper do
+
+  describe '#lock_arning(curation_concern)' do
+    context 'when the concern is not locked' do
+      it 'returns nil' do
+        mock_concern = double('PagedResource')
+        allow(mock_concern).to receive(:lock?).and_return(false)
+        expect(helper.lock_warning(mock_concern)).to be_nil
+      end
+    end
+    context 'when fileset does have extracted text' do
+      it 'returns an alert String' do
+        mock_concern = double('PagedResource')
+        allow(mock_concern).to receive(:lock?).and_return(true)
+        expect(helper.lock_warning(mock_concern)).to be_a String
+      end
+    end
+  end
+end

--- a/spec/models/paged_resource_spec.rb
+++ b/spec/models/paged_resource_spec.rb
@@ -6,4 +6,7 @@ RSpec.describe PagedResource do
 
   include_examples "MARC Relators"
   include_examples "PagedResource Properties"
+  include_examples "ExtraLockable Behaviors" do
+    let(:curation_concern) { FactoryBot.create(:paged_resource) }
+  end
 end

--- a/spec/services/lock_manager_service_spec.rb
+++ b/spec/services/lock_manager_service_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe LockManagerService do
+  describe '.lock_manager' do
+    it 'returns a LockManager instance' do
+      expect(described_class.lock_manager).to be_a Hyrax::LockManager
+    end
+  end
+  describe '.lock_checker' do
+    it 'returns a LockManager instance' do
+      expect(described_class.lock_checker).to be_a Hyrax::LockManager
+    end
+  end
+end

--- a/spec/support/shared_examples/extra_lockable.rb
+++ b/spec/support/shared_examples/extra_lockable.rb
@@ -1,0 +1,70 @@
+RSpec.shared_examples "ExtraLockable Behaviors" do
+  describe "#lock_manager" do
+    it "delegates to LockManagerService" do
+      expect(LockManagerService).to receive(:lock_manager)
+      curation_concern.lock_manager
+    end
+  end
+  describe "#lock_checker" do
+    it "delegates to LockManagerService" do
+      expect(LockManagerService).to receive(:lock_checker)
+      curation_concern.lock_checker
+    end
+  end
+  describe "#acquire_lock_for(lock_key, &block)" do
+    it "acquires lock through lock_manager" do
+      expect(LockManagerService.lock_manager).to receive(:lock)
+      curation_concern.acquire_lock_for(curation_concern.lock_id)
+    end
+  end
+  describe "#check_lock_for(lock_key, &block)" do
+    it "checks lock through lock_checker" do
+      expect(LockManagerService.lock_checker).to receive(:lock)
+      curation_concern.check_lock_for(curation_concern.lock_id)
+    end
+  end
+  describe "#lock?" do
+    it "calls lock_checker's #lock" do
+      expect(LockManagerService.lock_checker).to receive(:lock)
+      curation_concern.lock?
+    end
+  end
+  describe "#lock_id" do
+    context "with a blank lock id attribute" do
+      before(:each) { allow(curation_concern).to receive(:id).and_return(nil) }
+      it "raises an ArgumentError" do
+        expect { curation_concern.lock_id }.to raise_error ArgumentError
+      end
+    end
+    context "with a non-blank lock id attribute" do
+      it "returns a String" do
+        expect(curation_concern.lock_id).to match /^lock_/
+      end
+    end
+  end
+  describe "#lock(key, options)" do
+    it "passes call to underlying Redlock client" do
+      expect(LockManagerService.lock_manager.client).to receive(:lock)
+      curation_concern.lock
+    end
+  end
+  describe "#lock?" do
+    context "on a locked resource" do
+      it "returns true" do
+        curation_concern.lock
+        expect(curation_concern.lock?).to eq true
+      end
+    end
+    context "on an unlocked resource" do
+      it "returns false" do
+        expect(curation_concern.lock?).to eq false
+      end
+    end
+  end
+  describe "#unlock(lock_info)" do
+    it "calls lock_manager's client's unlock" do
+      expect(LockManagerService.lock_manager.client).to receive(:unlock)
+      curation_concern.unlock({})
+    end
+  end
+end


### PR DESCRIPTION
Marked WIP pending PR review.
* Adds display of lock warning into edit, structure, file manager views
* changes generation of `LockManager` to a single instance for standard use, and a single instance for `lock?` checks
   * gets speedier results of `lock?` checks

Doesn't:
* doesn't add a `lock?` check into the `save_structure` action as it was already there
* doesn't modify `LockableJob`