### PR TITLE
ESSI-457 Remove IUCAT Holding Locations from ESSI config

### DIFF
--- a/app/authorities/qa/authorities/iucat_libraries.rb
+++ b/app/authorities/qa/authorities/iucat_libraries.rb
@@ -16,17 +16,23 @@ module Qa::Authorities
 
     private
       def api_url(id)
+        return nil unless ESSI.config[:iucat_libraries]
         [ESSI.config[:iucat_libraries][:url], id].join('/')
       end
 
       def data_for(id)
-        return {} unless ESSI.config[:iucat_libraries]
+        return {} unless api_enabled? && api_url(id)
         begin
           result = json(api_url(id)).with_indifferent_access
           result[:success] ? result[:data] : {}
         rescue TypeError, JSON::ParserError, Faraday::ConnectionFailed
           {}
         end
+      end
+
+      def api_enabled?
+        return nil unless ESSI.config[:iucat_libraries]
+        ESSI.config[:iucat_libraries][:api_enabled]
       end
   end
 end

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -31,6 +31,7 @@ default: &default
     path: <%= Rails.root.join("tmp/derivatives") %>
   iucat_libraries:
     url: http://iucat-feature-tadas.uits.iu.edu/api/library
+    api_enabled: false
   ldap:
     enabled: false
     host: ads.iu.edu

--- a/spec/authorities/qa/authorities/iucat_libraries_spec.rb
+++ b/spec/authorities/qa/authorities/iucat_libraries_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Qa::Authorities::IucatLibraries do
   let(:authority) { described_class.new }
   let(:matching_id) { 'B-WELLS' }
   let(:nonmatching_id) { 'foobar' }
+  let(:api_config) { { url: 'http://iucat-feature-tadas.uits.iu.edu/api/library',
+                       api_enabled: true } }
 
   context 'when configuration does not exist' do
     describe '#all' do
@@ -16,10 +18,26 @@ RSpec.describe Qa::Authorities::IucatLibraries do
     end
   end
 
+  context 'when api is disabled' do
+    describe '#all' do
+      let(:result) { authority.all }
+      let(:api_config) { { url: 'http://some_unreachable_server',
+                           api_enabled: false } }
+      #let(:api_config) { { api_enabled: false } }
+      it 'returns an empty Array' do
+        allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
+        expect(ESSI.config[:iucat_libraries][:api_enabled]).to_not be_truthy
+        expect(result).to be_a Array
+        expect(result).to be_empty
+      end
+    end
+  end
+
   context 'with server response', vcr: { cassette_name: 'iucat_libraries_up', record: :new_episodes } do
     describe '#all' do
       let(:result) { authority.all }
       it 'returns a populated Array' do
+        allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
         expect(result).to be_a Array
         expect(result).not_to be_empty
       end
@@ -29,6 +47,7 @@ RSpec.describe Qa::Authorities::IucatLibraries do
       context 'with a matching id' do
         let(:result) { authority.find(matching_id) }
         it 'returns a Hash' do
+          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
           expect(result).to be_a Hash
           expect(result).not_to be_empty
         end
@@ -36,6 +55,7 @@ RSpec.describe Qa::Authorities::IucatLibraries do
       context 'with a non-matching id' do
         let(:result) { authority.find(nonmatching_id) }
         it 'returns an empty Hash' do
+          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
           expect(result).to be_a Hash
           expect(result).to be_empty
         end
@@ -46,6 +66,7 @@ RSpec.describe Qa::Authorities::IucatLibraries do
       context 'with a matching id' do
         let(:result) { authority.search(matching_id) }
         it 'returns a populated Array' do
+          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
           expect(result).to be_a Array
           expect(result).not_to be_empty
         end
@@ -53,6 +74,7 @@ RSpec.describe Qa::Authorities::IucatLibraries do
       context 'with a non-matching id' do
         let(:result) { authority.search(nonmatching_id) }
         it 'returns an empty Array' do
+          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
           expect(result).to be_a Array
           expect(result).to be_empty
         end

--- a/spec/services/holding_location_service_spec.rb
+++ b/spec/services/holding_location_service_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe HoldingLocationService do
   let(:service) { described_class }
+  let(:api_config) { { url: 'http://iucat-feature-tadas.uits.iu.edu/api/library',
+                       api_enabled: true } }
 
   let(:id) { 'B-WELLS' }
   let(:email) { 'libref@indiana.edu' }
@@ -10,14 +12,17 @@ RSpec.describe HoldingLocationService do
 
   context "with rights statements", vcr: { cassette_name: 'iucat_libraries_up', record: :new_episodes } do
     it "gets the email of a holding location" do
+      allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
       expect(service.find(id).fetch('email')).to eq(email)
     end
 
     it "gets the label of a holding location" do
+      allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
       expect(service.find(id).fetch('label')).to eq(label)
     end
 
     it "gets the phone number of a holding location" do
+      allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
       expect(service.find(id).fetch('phone')).to eq(phone)
     end
   end


### PR DESCRIPTION
The ESSI config contained the full configuration value for the IUCAT holding location, which usually works even in the developer environment even though that should probably be a deployment concern.  However, when outside developers began working with the app (i.e. Notch8) the service could not be contacted and created timeout errors.  This PR disables the api configuration by default and makes the QA vocab (and specs) behave correctly when not configured.