### PR TITLE
ESSI-84 When navigating from search results to show page, invoke UV search with term

### DIFF
--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -15,6 +15,22 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::PagedResourcePresenter
 
+    def show
+      super
+      set_catalog_search_term_for_uv_search
+    end
+
+    def set_catalog_search_term_for_uv_search
+      return unless request&.referer&.present? && request&.referer&.include?('catalog')
+      url_args = request&.referer&.split('&')
+      search_term = []
+      url_args&.each do |arg|
+        next unless arg.match?('query=')
+        search_term << CGI::parse(arg)['query']
+      end
+      params[:query] = search_term&.flatten&.first
+    end
+
     def structure
       parent_presenter
       @members = presenter.member_presenters

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,0 +1,5 @@
+<div class="search-results-title-row">
+  <h4 class="search-result-title">
+    <%= link_to document.title_or_label, params['q'].present? ? [document, query: CGI.escape(params['q'])] : document %>
+  </h4>
+</div>

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -6,3 +6,34 @@
     frameborder="0" 
   ></iframe>
 </div>
+
+<%# Currently, only PagedResource work type supports searching catalog term within the UV on page load. %>
+<%# Use query param set by Hyrax::PagedResourcesController#set_catalog_search_term_for_uv_search %>
+<% if params[:query].present? %>
+  <script>
+
+    $(document).ready(function(){
+      waitForUV();
+    });
+
+    <%# Wait until the UV search box elements are in place before trying to act upon its selectors. %>
+    function waitForUV() {
+        <%#
+          Using requestAnimationFrame keeps us from having to write complicated polling or deferred logic.
+          It is well-supported by all browsers as a way to smooth visual changes, like animations. It
+          provides a way to automatically retry logic at the browser's display refresh rate.
+        %>
+        if (!$("iframe").contents().find(".searchTextContainer input").length) {
+            window.requestAnimationFrame(waitForUV);
+        }else {
+              UVloaded();
+        }
+    }
+
+    function UVloaded()
+    {
+      $("iframe").contents().find(".searchTextContainer input").val("<%= CGI.unescape(params[:query]) %>");
+      $("iframe").contents().find(".searchTextContainer a")[0].click();
+    }
+  </script>
+<% end %>

--- a/config/initializers/blacklight_helpers.rb
+++ b/config/initializers/blacklight_helpers.rb
@@ -1,0 +1,29 @@
+Blacklight::UrlHelperBehavior.module_eval do
+  # link_to_document(doc, 'VIEW', :counter => 3)
+  # Use the catalog_path RESTful route to create a link to the show page for a specific item.
+  # catalog_path accepts a hash. The solr query params are stored in the session,
+  # so we only need the +counter+ param here. We also need to know if we are viewing to document as part of search results.
+  # TODO: move this to the IndexPresenter
+  def link_to_document(doc, field_or_opts = nil, opts = { counter: nil })
+    if field_or_opts.is_a? Hash
+      opts = field_or_opts
+    else
+      field = field_or_opts
+    end
+
+    field ||= document_show_link_field(doc)
+    label = index_presenter(doc).label field, opts
+    # Pass search on to item view.
+    url = add_highlight_url(doc)
+    link_to label, url, document_link_params(doc, opts)
+  end
+
+  # Adds search term to be highlighed on item
+  # to catalog search URL
+  #
+  # @param [Object] SOLR document
+  # @return [String] url string
+  def add_highlight_url(doc)
+    params['q'].present? ? [doc, query: CGI.escape(params['q'])] : url_for_document(doc)
+  end
+end


### PR DESCRIPTION
Replicates functionality in Pumpkin that automatically passes search term from a results link into the UV and invokes search.  

There is new JavaScript in the Universal Viewer partial that looks for the `query` parameter and uses its value, if it exists, to invoke the UV search within.  It has logic to determine when the UV search box elements are in place before trying to act upon its selectors, which can take a variable amount of time depending on manifest building and/or caching.