### PR TITLE
Set any S3 region to satisfy BrowseEverything 1.0

### DIFF
--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -41,6 +41,7 @@ default: &default
   browse_everything:
     s3:
       :bucket: essi-dropbox
+      :region: iu-local
       :response_type: :signed_url
     file_system:
       :home: <%= Rails.root.join("staged_files") %>


### PR DESCRIPTION
This region does not have any effect in our minio s3 service, but is necessary for Browse Everything to function due to its configuration checks.