### PR TITLE
Fixing ESSI-602, failure of search term to be passed to UV

### DIFF
--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -25,10 +25,10 @@ module Hyrax
       url_args = request&.referer&.split('&')
       search_term = []
       url_args&.each do |arg|
-        next unless arg.match?('query=')
-        search_term << CGI::parse(arg)['query']
+        next unless arg.match?('q=')
+        search_term << CGI::parse(arg)['q']
       end
-      params[:query] = search_term&.flatten&.first
+      params[:highlight] = search_term&.flatten&.first
     end
 
     def structure

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,5 +1,0 @@
-<div class="search-results-title-row">
-  <h4 class="search-result-title">
-    <%= link_to document.title_or_label, params['q'].present? ? [document, query: CGI.escape(params['q'])] : document %>
-  </h4>
-</div>

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -8,8 +8,8 @@
 </div>
 
 <%# Currently, only PagedResource work type supports searching catalog term within the UV on page load. %>
-<%# Use query param set by Hyrax::PagedResourcesController#set_catalog_search_term_for_uv_search %>
-<% if params[:query].present? %>
+<%# Use highlight param set by Hyrax::PagedResourcesController#set_catalog_search_term_for_uv_search %>
+<% if params[:highlight].present? %>
   <script>
 
     $(document).ready(function(){
@@ -32,7 +32,7 @@
 
     function UVloaded()
     {
-      $("iframe").contents().find(".searchTextContainer input").val("<%= CGI.unescape(params[:query]) %>");
+      $("iframe").contents().find(".searchTextContainer input").val("<%= CGI.unescape(params[:highlight]) %>");
       $("iframe").contents().find(".searchTextContainer a")[0].click();
     }
   </script>


### PR DESCRIPTION
The previously merged PR #90 worked if accessing a PagedResource with direct URL containing a search term, but not if linking through from search results. This fixes that by refactoring parameter handling to distinguish between a catalog search term and a request for a highlighted term.