### PR TITLE
[ESSI-513] Structure editor fix for deleted FileSet, as for ESSI-440

### DIFF
--- a/app/models/with_proxy_for_object.rb
+++ b/app/models/with_proxy_for_object.rb
@@ -43,6 +43,11 @@ class WithProxyForObject < SimpleDelegator
     @file_set_presenters ||= nodes.map(&:proxy_for_object).select(&:present?)
   end
 
+  # Filters out any deleted nodes from UI presentation
+  def nodes
+    super.reject { |node| node.proxy_for_id.present? && node.proxy_for_object.nil? }
+  end
+
   private
 
     def all_nodes


### PR DESCRIPTION
This applies the same bugfix as ESSI-440, minimally.

Not included:
* Broader test coverage for logical order / structure functionality, including this change
* Any refactoring of the `LogicalOrder` stack, with regards to either/both:
  * Cleaner separation of logic vs UI 
  * Abandoning `ActiveFedora` persistence, and just using `JSON` persisted in `solr`