### PR TITLE
[ESSI-648] For Consideration: Disable thumbnail creation

### DIFF
--- a/app/services/essi/file_set_ocr_derivatives_service.rb
+++ b/app/services/essi/file_set_ocr_derivatives_service.rb
@@ -1,9 +1,21 @@
 module ESSI
   class FileSetOCRDerivativesService < Hyrax::FileSetDerivativesService
+
+    # We have to do this if we never call super on other methods. See create_derivatives notes below with FIXME
+    def initialize(file_set)
+      @file_set = file_set
+    end
+
     def create_derivatives(filename)
       return if ESSI.config.dig(:essi, :skip_derivatives)
 
-      super
+      # FIXME: Fix MiniMagick problems so we can still call super here to create thumbnails?
+      # When we call create_derivatives upstream via super, we initiate thumbnail creation via MiniMagick.
+      # This is randomly failing, which causes OCR jobs to get missed on affected FileSets.
+      # We don't really need thumbnails as we derive them from the IIIF server, but what are the impacts?
+      # See https://github.com/IU-Libraries-Joint-Development/essi/issues/118
+      #
+      # super
       create_ocr_derivatives(filename)
       create_word_boundaries
     end

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -321,7 +321,6 @@
     <dynamicField name="*_llsi" type="location" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_llsim" type="location" stored="true" indexed="true" multiValued="true"/>
 
-    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
     <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
@@ -345,9 +344,6 @@
     copyField also supports a maxChars to copy setting.  -->
 
    <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
-   <!-- for suggestions -->
-   <copyField source="*_tesim" dest="suggest"/>
-   <copyField source="*_ssim" dest="suggest"/>
 
  <!-- Similarity is the scoring routine for each document vs. a query.
       A custom similarity may be specified here, but the default is fine


### PR DESCRIPTION
This PR is technically correct with tests passing but needs group discussion to merge. It disables the `super` call back up to `Hyrax::FileSetDerivativesService.create_derivatives`, and consequently skips the MiniMagick workflows of creating thumbnails.

**Background:**
In both local and deployed environments, OCR will randomly come up missing on pages with the likelihood increasing with page count.  When ingesting one unique paged work repetitively, the affected pages and number of pages are always different, eliminating the possibility of problems with source files.

For full discussion of the multiple issues, see #118