### PR TITLE
[ESSI-719] Bugfix for opening large viewer for Image format

### DIFF
--- a/app/controllers/concerns/essi/works_controller_behavior.rb
+++ b/app/controllers/concerns/essi/works_controller_behavior.rb
@@ -1,5 +1,13 @@
 module ESSI
   module WorksControllerBehavior
+
+    def additional_response_formats(wants)
+      wants.uv do
+        presenter && parent_presenter
+        render 'viewer_only.html.erb', layout: 'boilerplate', content_type: 'text/html'
+      end
+    end
+
     # Overrides stock Hyrax method to accept retrieving a cached JSON manifest_builder
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -13,12 +13,5 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ImagePresenter
-
-    def additional_response_formats(wants)
-      wants.uv do
-        presenter && parent_presenter
-        render 'viewer_only.html.erb', layout: 'boilerplate', content_type: 'text/html'
-      end
-    end
   end
 end

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -13,13 +13,12 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ImagePresenter
-  end
 
-  def additional_response_formats(wants)
-    wants.uv do
-      presenter && parent_presenter
-      render 'viewer_only.html.erb', layout: 'boilerplate', content_type: 'text/html'
+    def additional_response_formats(wants)
+      wants.uv do
+        presenter && parent_presenter
+        render 'viewer_only.html.erb', layout: 'boilerplate', content_type: 'text/html'
+      end
     end
   end
-
 end

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -37,13 +37,6 @@ module Hyrax
       @logical_order = presenter.logical_order_object
     end
 
-    def additional_response_formats(wants)
-      wants.uv do
-        presenter && parent_presenter
-        render 'viewer_only.html.erb', layout: 'boilerplate', content_type: 'text/html'
-      end
-    end
-
     def save_structure
       structure = { "label": params["label"], "nodes": params["nodes"] }
       if curation_concern.lock?


### PR DESCRIPTION
The first commit fixes the bug for Image format by moving the method definition inside the class.

The second commit makes the pertinent method available for all Work types, since the "Open large viewer" work is displayed for all Work types.