### PR TITLE
[ESSI-688] Bugfix for linking structure path when absent

### DIFF
--- a/app/controllers/concerns/essi/structure_behavior.rb
+++ b/app/controllers/concerns/essi/structure_behavior.rb
@@ -1,0 +1,20 @@
+module ESSI
+  module StructureBehavior
+    def structure
+      parent_presenter
+      @members = presenter.member_presenters
+      @logical_order = presenter.logical_order_object
+    end
+
+    def save_structure
+      structure = { "label": params["label"], "nodes": params["nodes"] }
+      if curation_concern.lock?
+        head 423
+      else
+        SaveStructureJob.perform_later(curation_concern, structure.to_json)
+        head 200
+      end
+    end
+  end
+end
+

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -8,6 +8,7 @@ module Hyrax
     include ESSI::WorksControllerBehavior
     include ESSI::PagedResourcesControllerBehavior
     include ESSI::RemoteMetadataLookupBehavior
+    include ESSI::StructureBehavior
     include Hyrax::BreadcrumbsForWorks
     include ESSI::BreadcrumbsForWorks
     self.curation_concern_type = ::PagedResource
@@ -31,26 +32,10 @@ module Hyrax
       params[:highlight] = search_term&.flatten&.first
     end
 
-    def structure
-      parent_presenter
-      @members = presenter.member_presenters
-      @logical_order = presenter.logical_order_object
-    end
-
     def additional_response_formats(wants)
       wants.uv do
         presenter && parent_presenter
         render 'viewer_only.html.erb', layout: 'boilerplate', content_type: 'text/html'
-      end
-    end
-
-    def save_structure
-      structure = { "label": params["label"], "nodes": params["nodes"] }
-      if curation_concern.lock?
-        head 423
-      else
-        SaveStructureJob.perform_later(curation_concern, structure.to_json)
-        head 200
       end
     end
   end

--- a/app/presenters/concerns/essi/presents_structure.rb
+++ b/app/presenters/concerns/essi/presents_structure.rb
@@ -1,0 +1,30 @@
+module ESSI
+  module PresentsStructure
+
+    # FIXME: delegate to solr_document?
+    def logical_order
+      @logical_order ||=
+        begin
+          JSON.parse(solr_document[Solrizer.solr_name("logical_order",
+                                             :stored_searchable)].first)
+        rescue StandardError
+          {}
+        end
+    end
+
+    def logical_order_object
+      @logical_order_object ||=
+          logical_order_factory.new(logical_order, nil, logical_order_factory)
+    end
+
+    def ranges
+      Array.wrap(logical_order_object.to_manifest_range)
+    end
+
+    private
+      def logical_order_factory
+        @logical_order_factory ||=
+          WithProxyForObject::Factory.new(member_presenters)
+      end
+  end
+end

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work PagedResource`
 module Hyrax
   class PagedResourcePresenter < Hyrax::WorkShowPresenter
+    include ESSI::PresentsStructure
     delegate :num_pages, :series, :viewing_direction, :viewing_hint,
              to: :solr_document
 
@@ -13,31 +14,5 @@ module Hyrax
       return nil unless solr_document.ocr_searchable
       Rails.application.routes.url_helpers.solr_document_iiif_search_url(solr_document.id)
     end
-
-    # FIXME: delegate to solr_document?
-    def logical_order
-      @logical_order ||=
-        begin
-          JSON.parse(solr_document[Solrizer.solr_name("logical_order",
-                                             :stored_searchable)].first)
-        rescue StandardError
-          {}
-        end
-    end
-
-    def logical_order_object
-      @logical_order_object ||=
-          logical_order_factory.new(logical_order, nil, logical_order_factory)
-    end
-
-    def ranges
-      Array.wrap(logical_order_object.to_manifest_range)
-    end
-
-    private
-      def logical_order_factory
-        @logical_order_factory ||=
-          WithProxyForObject::Factory.new(member_presenters)
-      end
-   end
- end
+  end
+end

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -22,7 +22,10 @@
         <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
         <% if presenter.member_presenters.size > 1 %>
             <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
-            <%= link_to t("hyrax.structure_manager.link_text"), polymorphic_path([main_app, :structure, presenter]), class: 'btn btn-default' %>
+            <% begin %>
+              <%= link_to t("hyrax.structure_manager.link_text"), polymorphic_path([main_app, :structure, presenter]), class: 'btn btn-default' %>
+            <% rescue NoMethodError %>
+            <% end %>
         <% end %>
         <% if presenter.valid_child_concerns.length > 0 %>
           <div class="btn-group">


### PR DESCRIPTION
The first commit resolves the bug by wrapping a `begin`/`rescue` block around the `link_to` for the Structure page, as an inelegant means of making it appropriately conditional.

The second commit is an optional refactor that matches the pattern for the model of having structure-related elements in an included model, in the controller and presenter.