### PR TITLE
[ESSI-747] Optional Cantaloupe Configuration

### DIFF
--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -27,6 +27,8 @@ default: &default
       options:
     active_job:
       queue_adapter: async
+  # cantaloupe:
+  #   iiif_server_url: http://localhost:8182/iiif/2/
   derivatives:
     path: <%= Rails.root.join("tmp/derivatives") %>
   iucat_libraries:

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -146,7 +146,13 @@ Hyrax.config do |config|
 
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, _base_url, size|
-    Riiif::Engine.routes.url_helpers.image_url(file_id, host: ESSI.config.dig(:essi, :iiif_host), size: size)
+    if ESSI.config[:cantaloupe][:iiif_server_url].present?
+      iiif_url = ESSI.config[:cantaloupe][:iiif_server_url] + file_id.gsub('/', '%2F') + '/full/' + size + '/0/default.jpg'
+      Rails.logger.debug "event: iiif_image_request: #{iiif_url}"
+      iiif_url
+    else
+      Riiif::Engine.routes.url_helpers.image_url(file_id, host: ESSI.config.dig(:essi, :iiif_host), size: size)
+    end
   end
   # config.iiif_image_url_builder = lambda do |file_id, base_url, size|
   #   "#{base_url}/downloads/#{file_id.split('/').first}"
@@ -154,8 +160,12 @@ Hyrax.config do |config|
 
   # Returns a URL that resolves to an info.json file provided by a IIIF image server
   config.iiif_info_url_builder = lambda do |file_id, base_url|
-    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
-    uri.sub(%r{/info\.json\Z}, '')
+    if ESSI.config[:cantaloupe][:iiif_server_url].present?
+      ESSI.config[:cantaloupe][:iiif_server_url] + file_id.gsub('/', '%2F')
+    else
+      uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
+      uri.sub(%r{/info\.json\Z}, '')
+    end
   end
   # config.iiif_info_url_builder = lambda do |_, _|
   #   ""

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -146,7 +146,7 @@ Hyrax.config do |config|
 
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, _base_url, size|
-    if ESSI.config[:cantaloupe][:iiif_server_url].present?
+    if ESSI.config[:cantaloupe].present? && ESSI.config[:cantaloupe][:iiif_server_url]
       iiif_url = ESSI.config[:cantaloupe][:iiif_server_url] + file_id.gsub('/', '%2F') + '/full/' + size + '/0/default.jpg'
       Rails.logger.debug "event: iiif_image_request: #{iiif_url}"
       iiif_url
@@ -160,7 +160,7 @@ Hyrax.config do |config|
 
   # Returns a URL that resolves to an info.json file provided by a IIIF image server
   config.iiif_info_url_builder = lambda do |file_id, base_url|
-    if ESSI.config[:cantaloupe][:iiif_server_url].present?
+    if ESSI.config[:cantaloupe].present? && ESSI.config[:cantaloupe][:iiif_server_url]
       ESSI.config[:cantaloupe][:iiif_server_url] + file_id.gsub('/', '%2F')
     else
       uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)


### PR DESCRIPTION
This branch along with setting up Cantaloupe as described on the wiki (https://github.com/IU-Libraries-Joint-Development/essi/wiki/1.6-Cantaloupe-Configuration) worked for me in using cantaloupe in development.