### PR TITLE
[ESSI-751] Move extensions initializers to after_initialize

### DIFF
--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -1,29 +1,29 @@
-# active fedora node cache initialization
-ActiveFedora::Orders::OrderedList.prepend Extensions::ActiveFedora::Orders::OrderedList::InitializeNodeCache
-
-# extracted text support
 Rails.application.config.after_initialize do
+  # active fedora node cache initialization
+  ActiveFedora::Orders::OrderedList.prepend Extensions::ActiveFedora::Orders::OrderedList::InitializeNodeCache
+
+  # extracted text support
   Hyrax::DownloadsController.prepend Extensions::Hyrax::DownloadsController::ExtractedText
+  Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ExtractedText
+
+  # viewing hint support
+  IIIFManifest::ManifestBuilder::ImageBuilder.include Extensions::IIIFManifest::ManifestBuilder::ImageBuilder::ViewingHint
+  Hyrax::Forms::FileManagerForm.include Extensions::Hyrax::Forms::FileManagerForm::ViewingMetadata
+  Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ViewingHint
+
+  # primary fields support
+  Hyrax::Forms::WorkForm.class_eval { include Extensions::Hyrax::Forms::WorkForm::PrimaryFields }
+
+  # TODO: determine if needed?
+  # iiif manifest support
+  Hyrax::WorkShowPresenter.prepend Extensions::Hyrax::WorkShowPresenter::ManifestMetadata
+
+  # add campus logo information when available.
+  Hyrax::CollectionPresenter.prepend Extensions::Hyrax::CollectionPresenter::CampusLogo
+  Hyrax::WorkShowPresenter.prepend Extensions::Hyrax::WorkShowPresenter::CampusLogo
+  Hyrax::FileSetPresenter.prepend Extensions::Hyrax::FileSetPresenter::CampusLogo
+
+  # add collection banner to works and file sets.
+  Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::CollectionBanner
+  Hyrax::WorkShowPresenter.include Extensions::Hyrax::WorkShowPresenter::CollectionBanner
 end
-Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ExtractedText
-
-# viewing hint support
-IIIFManifest::ManifestBuilder::ImageBuilder.include Extensions::IIIFManifest::ManifestBuilder::ImageBuilder::ViewingHint
-Hyrax::Forms::FileManagerForm.include Extensions::Hyrax::Forms::FileManagerForm::ViewingMetadata
-Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ViewingHint
-
-# primary fields support
-Hyrax::Forms::WorkForm.class_eval { include Extensions::Hyrax::Forms::WorkForm::PrimaryFields }
-
-# TODO: determine if needed?
-# iiif manifest support
-Hyrax::WorkShowPresenter.prepend Extensions::Hyrax::WorkShowPresenter::ManifestMetadata
-
-# add campus logo information when available.
-Hyrax::CollectionPresenter.prepend Extensions::Hyrax::CollectionPresenter::CampusLogo
-Hyrax::WorkShowPresenter.prepend Extensions::Hyrax::WorkShowPresenter::CampusLogo
-Hyrax::FileSetPresenter.prepend Extensions::Hyrax::FileSetPresenter::CampusLogo
-
-# add collection banner to works and file sets.
-Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::CollectionBanner
-Hyrax::WorkShowPresenter.include Extensions::Hyrax::WorkShowPresenter::CollectionBanner


### PR DESCRIPTION
The extensions of `CollectionPresenter` and `WorkShowPresenter` were loading [Hyrax constants set to I18n lookup values](https://github.com/samvera/hyrax/blob/320512447cb48b2bfe6fb9a05b99d0fce193d810/app/models/hyrax/collection_type.rb#L12-L16), before the entire `I18n.load_path` was populated, resulting in "translation not found" results.

This PR resolves this by moving _all_ of the extension monkeypatches into an `after_initialize` callback, relocating these I18n lookups to later in the initialization sequence, after `locale` files for all the gems have been populated into `I18n.load_path`.