### PR TITLE
[ESSI-790] Add missing host parameter to search url

### DIFF
--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -12,7 +12,7 @@ module Hyrax
 
     def search_service
       return nil unless solr_document.ocr_searchable
-      Rails.application.routes.url_helpers.solr_document_iiif_search_url(solr_document.id)
+      Rails.application.routes.url_helpers.solr_document_iiif_search_url(solr_document.id, host: request.host)
     end
   end
 end


### PR DESCRIPTION
It seems [url helpers in a work presenter context need to be explicitly passed the request host](https://github.com/samvera/hyrax/blob/2.x-stable/app/presenters/hyrax/work_show_presenter.rb#L52-L56).
Resolves ESSI-790.