### PR TITLE
[ESSI-759] Standardize thumbnail indexing across work types

### DIFF
--- a/app/indexers/bib_record_indexer.rb
+++ b/app/indexers/bib_record_indexer.rb
@@ -5,6 +5,7 @@ class BibRecordIndexer < Hyrax::WorkIndexer
   # provide your own metadata and indexing.
   include Hyrax::IndexesBasicMetadata
   include ESSI::BibRecordIndexerBehavior
+  include ESSI::IIIFThumbnailBehavior
 
   # Fetch remote labels for based_near. You can remove this if you don't want
   # this behavior

--- a/app/indexers/image_indexer.rb
+++ b/app/indexers/image_indexer.rb
@@ -5,6 +5,7 @@ class ImageIndexer < Hyrax::WorkIndexer
   # provide your own metadata and indexing.
   include Hyrax::IndexesBasicMetadata
   include ESSI::ImageIndexerBehavior
+  include ESSI::IIIFThumbnailBehavior
 
   # Fetch remote labels for based_near. You can remove this if you don't want
   # this behavior

--- a/app/indexers/scientific_indexer.rb
+++ b/app/indexers/scientific_indexer.rb
@@ -5,6 +5,7 @@ class ScientificIndexer < Hyrax::WorkIndexer
   # provide your own metadata and indexing.
   include Hyrax::IndexesBasicMetadata
   include ESSI::ScientificIndexerBehavior
+  include ESSI::IIIFThumbnailBehavior
 
   # Fetch remote labels for based_near. You can remove this if you don't want
   # this behavior


### PR DESCRIPTION
Revised solr indexing of the thumbnail had only been applied to the Paged Resource work type.
This applies it to the other work types.