### PR TITLE
[ESSI-704] Move branding files to FileSet backing

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,4 +4,18 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
+
+  def collection_branding_infos(role: nil)
+    cbis = ::CollectionBrandingInfo.where(collection_id: id)
+    cbis = cbis.where(role: role) if role.present?
+    cbis
+  end
+
+  def banner_branding
+    collection_branding_infos(role: 'banner')
+  end
+
+  def logo_branding
+    collection_branding_infos(role: 'logo')
+  end
 end

--- a/app/models/collection_branding_info.rb
+++ b/app/models/collection_branding_info.rb
@@ -1,19 +1,26 @@
-# Imported from Hyrax to modify for FileSet-backed branding images
+# Imported from Hyrax and modified for FileSet-backed branding images
 class CollectionBrandingInfo < ApplicationRecord
 
   def initialize(collection_id:,
                  filename:,
                  role:,
                  alt_txt: "",
-                 target_url: "")
+                 target_url: "",
+                 local_path: nil,
+                 file_set_id: nil,
+                 image_path: nil)
 
     super()
     self.collection_id = collection_id
     self.role = role
     self.alt_text = alt_txt
     self.target_url = target_url
+    self.file_set_id = file_set_id
+    self.image_path = image_path
 
-    self.local_path = find_local_filename(collection_id, role, filename)
+    # the file is no longer stored at this location, but this is retained
+    # for infrastructure for form field identifiers via local_path value
+    self.local_path = local_path || find_local_filename(collection_id, role, filename)
   end
 
   def collection
@@ -24,41 +31,86 @@ class CollectionBrandingInfo < ApplicationRecord
     @file_set ||= FileSet.find(file_set_id) if file_set_id.present?
   end
 
-  def save(file_location, copy_file = true)
-    local_dir = find_local_dir_name(collection_id, role)
-    FileUtils.mkdir_p local_dir
-    FileUtils.cp file_location, local_path unless file_location == local_path || !copy_file
-    FileUtils.remove_file(file_location) if File.exist?(file_location) && copy_file
+  def save(uploaded_file_id: nil, user_key: nil)
+    if uploaded_file_id && user_key
+      uploaded_file = uploaded_files(uploaded_file_id)
+      user = User.find_by_user_key(user_key)
+      attach_file_set(uploaded_file, user)
+    end
     super()
   end
 
-  def delete(location_path)
-    FileUtils.remove_file(location_path) if File.exist?(location_path)
-  end
-
-  def find_local_filename(collection_id, role, filename)
-    local_dir = find_local_dir_name(collection_id, role)
-    File.join(local_dir, filename)
-  end
-
-  def find_local_dir_name(collection_id, role)
-    File.join(Hyrax.config.branding_path, collection_id.to_s, role.to_s)
-  end
-
-  def file
-    File.split(local_path).last
-  end
-
-  def relative_path
-    relative_path = "/" + local_path.split("/")[-4..-1].join("/")
+  def file_set_image_path
+    @file_set_image_path ||= begin
+      generate_image_path!
+      image_path if image_path.present?
+    end
   end
 
   def display_hash
     { file: file,
       full_path: local_path,
-      relative_path: relative_path,
-      file_location: relative_path,
+      relative_path: file_set_image_path,
+      file_location: file_set_image_path,
       alttext: alt_text,
       linkurl: target_url }
   end
+
+  private
+
+    def attach_file_set(uploaded_file, user)
+      actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+      uploaded_file.update(file_set_uri: actor.file_set.uri)
+      self.file_set_id = actor.file_set.id
+      # FIXME: change visibility permissions?
+      # actor.file_set.permissions_attributes = work_permissions
+      actor.create_metadata()
+      actor.create_content(uploaded_file)
+    end
+
+    # privatize image_path to require going through file_set_image_path
+    def image_path
+      self[:image_path]
+    end
+
+    def image_path=(val)
+      write_attribute(:image_path, val)
+    end
+
+    def file
+      File.split(local_path).last
+    end
+    
+    def find_local_filename(collection_id, role, filename)
+      local_dir = find_local_dir_name(collection_id, role)
+      File.join(local_dir, filename)
+    end
+  
+    def find_local_dir_name(collection_id, role)
+      File.join(Hyrax.config.branding_path, collection_id.to_s, role.to_s)
+    end  
+    
+    # FIXME: use different image dimensions than default?
+    # this passes a nil value for request base_url, as our custom url builder
+    # does not use that argument, and the model also doesn't have a request
+    def generate_image_path!
+      if image_path.blank? && file_set_versions.any?
+        original_uri = file_set_versions.all.last.uri
+        uri_to_id = ActiveFedora::File.uri_to_id(original_uri.sub(/\/fcr.versions.*/,''))
+        self.image_path = \
+          Hyrax.config.iiif_image_url_builder.call(uri_to_id,
+                                                   nil,
+                                                   Hyrax.config.iiif_image_size_default)
+        save
+      end
+    end  
+
+    def file_set_versions
+      file_set&.reload&.original_file&.versions
+    end
+
+    def uploaded_files(uploaded_file_ids)
+      return [] if uploaded_file_ids.empty?
+      Hyrax::UploadedFile.find(uploaded_file_ids)
+    end
 end

--- a/app/models/collection_branding_info.rb
+++ b/app/models/collection_branding_info.rb
@@ -16,6 +16,10 @@ class CollectionBrandingInfo < ApplicationRecord
     self.local_path = find_local_filename(collection_id, role, filename)
   end
 
+  def collection
+    @collection ||= Collection.where(id: collection_id).first
+  end
+
   def save(file_location, copy_file = true)
     local_dir = find_local_dir_name(collection_id, role)
     FileUtils.mkdir_p local_dir
@@ -35,5 +39,22 @@ class CollectionBrandingInfo < ApplicationRecord
 
   def find_local_dir_name(collection_id, role)
     File.join(Hyrax.config.branding_path, collection_id.to_s, role.to_s)
+  end
+
+  def file
+    File.split(local_path).last
+  end
+
+  def relative_path
+    relative_path = "/" + local_path.split("/")[-4..-1].join("/")
+  end
+
+  def display_hash
+    { file: file,
+      full_path: local_path,
+      relative_path: relative_path,
+      file_location: relative_path,
+      alttext: alt_text,
+      linkurl: target_url }
   end
 end

--- a/app/models/collection_branding_info.rb
+++ b/app/models/collection_branding_info.rb
@@ -31,6 +31,11 @@ class CollectionBrandingInfo < ApplicationRecord
     @file_set ||= FileSet.find(file_set_id) if file_set_id.present?
   end
 
+  def destroy
+    file_set&.destroy
+    super
+  end
+
   def save(uploaded_file_id: nil, user_key: nil)
     if uploaded_file_id && user_key
       uploaded_file = uploaded_files(uploaded_file_id)
@@ -62,8 +67,6 @@ class CollectionBrandingInfo < ApplicationRecord
       actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
       uploaded_file.update(file_set_uri: actor.file_set.uri)
       self.file_set_id = actor.file_set.id
-      # FIXME: change visibility permissions?
-      # actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata()
       actor.create_content(uploaded_file)
     end
@@ -90,7 +93,6 @@ class CollectionBrandingInfo < ApplicationRecord
       File.join(Hyrax.config.branding_path, collection_id.to_s, role.to_s)
     end  
     
-    # FIXME: use different image dimensions than default?
     # this passes a nil value for request base_url, as our custom url builder
     # does not use that argument, and the model also doesn't have a request
     def generate_image_path!
@@ -106,7 +108,7 @@ class CollectionBrandingInfo < ApplicationRecord
     end  
 
     def file_set_versions
-      file_set&.reload&.original_file&.versions
+      file_set&.reload&.original_file&.versions || []
     end
 
     def uploaded_files(uploaded_file_ids)

--- a/app/models/collection_branding_info.rb
+++ b/app/models/collection_branding_info.rb
@@ -1,0 +1,39 @@
+# Imported from Hyrax to modify for FileSet-backed branding images
+class CollectionBrandingInfo < ApplicationRecord
+
+  def initialize(collection_id:,
+                 filename:,
+                 role:,
+                 alt_txt: "",
+                 target_url: "")
+
+    super()
+    self.collection_id = collection_id
+    self.role = role
+    self.alt_text = alt_txt
+    self.target_url = target_url
+
+    self.local_path = find_local_filename(collection_id, role, filename)
+  end
+
+  def save(file_location, copy_file = true)
+    local_dir = find_local_dir_name(collection_id, role)
+    FileUtils.mkdir_p local_dir
+    FileUtils.cp file_location, local_path unless file_location == local_path || !copy_file
+    FileUtils.remove_file(file_location) if File.exist?(file_location) && copy_file
+    super()
+  end
+
+  def delete(location_path)
+    FileUtils.remove_file(location_path) if File.exist?(location_path)
+  end
+
+  def find_local_filename(collection_id, role, filename)
+    local_dir = find_local_dir_name(collection_id, role)
+    File.join(local_dir, filename)
+  end
+
+  def find_local_dir_name(collection_id, role)
+    File.join(Hyrax.config.branding_path, collection_id.to_s, role.to_s)
+  end
+end

--- a/app/models/collection_branding_info.rb
+++ b/app/models/collection_branding_info.rb
@@ -20,6 +20,10 @@ class CollectionBrandingInfo < ApplicationRecord
     @collection ||= Collection.where(id: collection_id).first
   end
 
+  def file_set
+    @file_set ||= FileSet.find(file_set_id) if file_set_id.present?
+  end
+
   def save(file_location, copy_file = true)
     local_dir = find_local_dir_name(collection_id, role)
     FileUtils.mkdir_p local_dir

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -8,6 +8,14 @@ class FileSet < ActiveFedora::Base
 
   self.indexer = ESSI::FileSetIndexer
 
+  def collection_branding_info
+    @collection_branding_info ||= CollectionBrandingInfo.where(file_set_id: self.id).first
+  end
+
+  def collection_branding?
+    collection_branding_info.present?
+  end
+
   def ocr_language
     [language.entries,
      parent&.language&.entries,

--- a/db/migrate/20200428144941_add_file_set_backing_to_collection_branding_info.rb
+++ b/db/migrate/20200428144941_add_file_set_backing_to_collection_branding_info.rb
@@ -1,0 +1,6 @@
+class AddFileSetBackingToCollectionBrandingInfo < ActiveRecord::Migration[5.1]
+  def change
+    add_column :collection_branding_infos, :file_set_id, :string
+    add_column :collection_branding_infos, :image_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200326235838) do
+ActiveRecord::Schema.define(version: 20200428144941) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -126,6 +126,8 @@ ActiveRecord::Schema.define(version: 20200326235838) do
     t.integer "width"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "file_set_id"
+    t.string "image_path"
   end
 
   create_table "collection_type_participants", force: :cascade do |t|

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -26,5 +26,10 @@ Hyrax::WorkShowPresenter.include Extensions::Hyrax::WorkShowPresenter::Collectio
 # primary fields support
 Hyrax::Forms::WorkForm.include Extensions::Hyrax::Forms::WorkForm::PrimaryFields
 
+# Use FileSet to store and display collection banner/logo image
+Hyrax::Forms::CollectionForm.prepend Extensions::Hyrax::Forms::CollectionForm::FileSetBackedBranding
+Hyrax::CollectionPresenter.prepend Extensions::Hyrax::CollectionPresenter::FileSetBackedBranding
+Hyrax::Dashboard::CollectionsController.prepend Extensions::Hyrax::Dashboard::CollectionsController::FileSetBackedBranding
+
 Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest, ESSI::Actors::PerformLaterActor
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesActor, ESSI::Actors::CreateWithRemoteFilesActor

--- a/lib/extensions/hyrax/collection_presenter/file_set_backed_branding.rb
+++ b/lib/extensions/hyrax/collection_presenter/file_set_backed_branding.rb
@@ -4,23 +4,12 @@ module Extensions
       module FileSetBackedBranding
         def banner_file
           # Find Banner filename
-          ci = ::CollectionBrandingInfo.where(collection_id: id, role: "banner")
-          "/" + ci[0].local_path.split("/")[-4..-1].join("/") unless ci.empty?
+          ::CollectionBrandingInfo.where(collection_id: id, role: "banner").map(&:relative_path).first
         end
     
         def logo_record
-          logo_info = []
           # Find Logo filename, alttext, linktext
-          cis = ::CollectionBrandingInfo.where(collection_id: id, role: "logo")
-          return if cis.empty?
-          cis.each do |coll_info|
-            logo_file = ::File.split(coll_info.local_path).last
-            file_location = "/" + coll_info.local_path.split("/")[-4..-1].join("/") unless logo_file.empty?
-            alttext = coll_info.alt_text
-            linkurl = coll_info.target_url
-            logo_info << { file: logo_file, file_location: file_location, alttext: alttext, linkurl: linkurl }
-          end
-          logo_info
+          ::CollectionBrandingInfo.where(collection_id: id, role: "logo").map(&:display_hash)
         end
       end
     end

--- a/lib/extensions/hyrax/collection_presenter/file_set_backed_branding.rb
+++ b/lib/extensions/hyrax/collection_presenter/file_set_backed_branding.rb
@@ -4,7 +4,7 @@ module Extensions
       module FileSetBackedBranding
         def banner_file
           # Find Banner filename
-          ::CollectionBrandingInfo.where(collection_id: id, role: "banner").map(&:relative_path).first
+          ::CollectionBrandingInfo.where(collection_id: id, role: "banner").map(&:file_set_image_path).first
         end
     
         def logo_record

--- a/lib/extensions/hyrax/collection_presenter/file_set_backed_branding.rb
+++ b/lib/extensions/hyrax/collection_presenter/file_set_backed_branding.rb
@@ -1,0 +1,28 @@
+module Extensions
+  module Hyrax
+    module CollectionPresenter
+      module FileSetBackedBranding
+        def banner_file
+          # Find Banner filename
+          ci = ::CollectionBrandingInfo.where(collection_id: id, role: "banner")
+          "/" + ci[0].local_path.split("/")[-4..-1].join("/") unless ci.empty?
+        end
+    
+        def logo_record
+          logo_info = []
+          # Find Logo filename, alttext, linktext
+          cis = ::CollectionBrandingInfo.where(collection_id: id, role: "logo")
+          return if cis.empty?
+          cis.each do |coll_info|
+            logo_file = ::File.split(coll_info.local_path).last
+            file_location = "/" + coll_info.local_path.split("/")[-4..-1].join("/") unless logo_file.empty?
+            alttext = coll_info.alt_text
+            linkurl = coll_info.target_url
+            logo_info << { file: logo_file, file_location: file_location, alttext: alttext, linkurl: linkurl }
+          end
+          logo_info
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/dashboard/collections_controller/file_set_backed_branding.rb
+++ b/lib/extensions/hyrax/dashboard/collections_controller/file_set_backed_branding.rb
@@ -1,0 +1,73 @@
+module Extensions
+  module Hyrax
+    module Dashboard
+      module CollectionsController
+        module FileSetBackedBranding
+          def show
+            if @collection.collection_type.brandable?
+              banner_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "banner")
+              @banner_file = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
+            end
+    
+            presenter
+            query_collection_members
+          end
+
+          private
+    
+            def update_existing_banner
+              banner_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "banner")
+              banner_info.first.save(banner_info.first.local_path, false)
+            end
+    
+            def add_new_banner(uploaded_file_ids)
+              f = uploaded_files(uploaded_file_ids).first
+              banner_info = ::CollectionBrandingInfo.new(
+                collection_id: @collection.id,
+                filename: ::File.split(f.file_url).last,
+                role: "banner",
+                alt_txt: "",
+                target_url: ""
+              )
+              banner_info.save f.file_url
+            end
+    
+            def remove_banner
+              banner_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "banner")
+              banner_info&.delete_all
+            end
+    
+            def update_logo_info(uploaded_file_id, alttext, linkurl)
+              logo_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "logo").where(local_path: uploaded_file_id.to_s)
+              logo_info.first.alt_text = alttext
+              logo_info.first.target_url = linkurl
+              logo_info.first.local_path = uploaded_file_id
+              logo_info.first.save(uploaded_file_id, false)
+            end
+    
+            def create_logo_info(uploaded_file_id, alttext, linkurl)
+              file = uploaded_files(uploaded_file_id)
+              logo_info = ::CollectionBrandingInfo.new(
+                collection_id: @collection.id,
+                filename: ::File.split(file.file_url).last,
+                role: "logo",
+                alt_txt: alttext,
+                target_url: linkurl
+              )
+              logo_info.save file.file_url
+              logo_info
+            end
+    
+            def remove_redundant_files(public_files)
+              # remove any public ones that were not included in the selection.
+              logos_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "logo")
+              logos_info.each do |logo_info|
+                logo_info.delete(logo_info.local_path) unless public_files.include? logo_info.local_path
+                logo_info.destroy unless public_files.include? logo_info.local_path
+              end
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/dashboard/collections_controller/file_set_backed_branding.rb
+++ b/lib/extensions/hyrax/dashboard/collections_controller/file_set_backed_branding.rb
@@ -5,7 +5,7 @@ module Extensions
         module FileSetBackedBranding
           def show
             if @collection.collection_type.brandable?
-              @banner_file = @collection.banner_branding.first&.relative_path
+              @banner_file = @collection.banner_branding.first&.file_set_image_path
             end
     
             presenter
@@ -16,7 +16,7 @@ module Extensions
     
             def update_existing_banner
               banner_info = @collection.banner_branding.first
-              banner_info.save(banner_info.local_path, false)
+              banner_info.save
             end
     
             def add_new_banner(uploaded_file_ids)
@@ -28,7 +28,8 @@ module Extensions
                 alt_txt: "",
                 target_url: ""
               )
-              banner_info.save f.file_url
+              banner_info.save(uploaded_file_id: uploaded_file_ids.first,
+                               user_key: @current_user.user_key)
             end
     
             def remove_banner
@@ -40,7 +41,7 @@ module Extensions
               logo_info.first.alt_text = alttext
               logo_info.first.target_url = linkurl
               logo_info.first.local_path = uploaded_file_id
-              logo_info.first.save(uploaded_file_id, false)
+              logo_info.first.save
             end
     
             def create_logo_info(uploaded_file_id, alttext, linkurl)
@@ -52,14 +53,14 @@ module Extensions
                 alt_txt: alttext,
                 target_url: linkurl
               )
-              logo_info.save file.file_url
+              logo_info.save(uploaded_file_id: uploaded_file_id,
+                             user_key: @current_user.user_key)
               logo_info
             end
     
             def remove_redundant_files(public_files)
               # remove any public ones that were not included in the selection.
               @collection.logo_branding.each do |logo_info|
-                logo_info.delete(logo_info.local_path) unless public_files.include? logo_info.local_path
                 logo_info.destroy unless public_files.include? logo_info.local_path
               end
             end

--- a/lib/extensions/hyrax/dashboard/collections_controller/file_set_backed_branding.rb
+++ b/lib/extensions/hyrax/dashboard/collections_controller/file_set_backed_branding.rb
@@ -5,8 +5,7 @@ module Extensions
         module FileSetBackedBranding
           def show
             if @collection.collection_type.brandable?
-              banner_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "banner")
-              @banner_file = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
+              @banner_file = @collection.banner_branding.first&.relative_path
             end
     
             presenter
@@ -16,8 +15,8 @@ module Extensions
           private
     
             def update_existing_banner
-              banner_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "banner")
-              banner_info.first.save(banner_info.first.local_path, false)
+              banner_info = @collection.banner_branding.first
+              banner_info.save(banner_info.local_path, false)
             end
     
             def add_new_banner(uploaded_file_ids)
@@ -33,8 +32,7 @@ module Extensions
             end
     
             def remove_banner
-              banner_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "banner")
-              banner_info&.delete_all
+              @collection.banner_branding&.delete_all
             end
     
             def update_logo_info(uploaded_file_id, alttext, linkurl)
@@ -60,8 +58,7 @@ module Extensions
     
             def remove_redundant_files(public_files)
               # remove any public ones that were not included in the selection.
-              logos_info = ::CollectionBrandingInfo.where(collection_id: @collection.id.to_s).where(role: "logo")
-              logos_info.each do |logo_info|
+              @collection.logo_branding.each do |logo_info|
                 logo_info.delete(logo_info.local_path) unless public_files.include? logo_info.local_path
                 logo_info.destroy unless public_files.include? logo_info.local_path
               end

--- a/lib/extensions/hyrax/forms/collection_form/file_set_backed_branding.rb
+++ b/lib/extensions/hyrax/forms/collection_form/file_set_backed_branding.rb
@@ -3,29 +3,15 @@ module Extensions
     module Forms
       module CollectionForm
         module FileSetBackedBranding
+
+          delegate :banner_branding, :logo_branding, to: :model
+
           def banner_info
-            @banner_info ||= begin
-              # Find Banner filename
-              banner_info = ::CollectionBrandingInfo.where(collection_id: id).where(role: "banner")
-              banner_file = ::File.split(banner_info.first.local_path).last unless banner_info.empty?
-              file_location = banner_info.first.local_path unless banner_info.empty?
-              relative_path = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
-              { file: banner_file, full_path: file_location, relative_path: relative_path }
-            end
+            @banner_info ||= (banner_branding.first&.display_hash || {})
           end
     
           def logo_info
-            @logo_info ||= begin
-              # Find Logo filename, alttext, linktext
-              logos_info = ::CollectionBrandingInfo.where(collection_id: id).where(role: "logo")
-              logos_info.map do |logo_info|
-                logo_file = ::File.split(logo_info.local_path).last
-                relative_path = "/" + logo_info.local_path.split("/")[-4..-1].join("/")
-                alttext = logo_info.alt_text
-                linkurl = logo_info.target_url
-                { file: logo_file, full_path: logo_info.local_path, relative_path: relative_path, alttext: alttext, linkurl: linkurl }
-              end
-            end
+            @logo_info ||= logo_branding.map(&:display_hash)
           end
         end
       end

--- a/lib/extensions/hyrax/forms/collection_form/file_set_backed_branding.rb
+++ b/lib/extensions/hyrax/forms/collection_form/file_set_backed_branding.rb
@@ -1,0 +1,34 @@
+module Extensions
+  module Hyrax
+    module Forms
+      module CollectionForm
+        module FileSetBackedBranding
+          def banner_info
+            @banner_info ||= begin
+              # Find Banner filename
+              banner_info = ::CollectionBrandingInfo.where(collection_id: id).where(role: "banner")
+              banner_file = ::File.split(banner_info.first.local_path).last unless banner_info.empty?
+              file_location = banner_info.first.local_path unless banner_info.empty?
+              relative_path = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
+              { file: banner_file, full_path: file_location, relative_path: relative_path }
+            end
+          end
+    
+          def logo_info
+            @logo_info ||= begin
+              # Find Logo filename, alttext, linktext
+              logos_info = ::CollectionBrandingInfo.where(collection_id: id).where(role: "logo")
+              logos_info.map do |logo_info|
+                logo_file = ::File.split(logo_info.local_path).last
+                relative_path = "/" + logo_info.local_path.split("/")[-4..-1].join("/")
+                alttext = logo_info.alt_text
+                linkurl = logo_info.target_url
+                { file: logo_file, full_path: logo_info.local_path, relative_path: relative_path, alttext: alttext, linkurl: linkurl }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -9,46 +9,49 @@ describe Hyrax::Actors::FileActor do
   let(:file) { File.new(filename) }
   let(:io) { JobIoWrapper.create_with_varied_file_handling!(user: user, file: file, relation: :original_file, file_set: file_set) }
 
-  context 'when :store_original_files is false', :clean do
-    it 'sets the mime_type to an external body redirect' do
-      expect(CharacterizeJob).not_to receive(:perform_later)
-      allow(ESSI.config).to receive(:dig) \
-        .with(any_args).and_call_original
-      allow(ESSI.config).to receive(:dig) \
-        .with(:essi, :store_original_files) \
-        .and_return(false)
-      allow(ESSI.config).to receive(:dig) \
-        .with(:essi, :create_hocr_files) \
+  describe '#ingest_file' do
+    before do
+      allow(ESSI.config).to receive(:dig).with(any_args).and_call_original
+      allow(ESSI.config).to receive(:dig).with(:essi, :create_hocr_files) \
         .and_return(true)
-      allow(ESSI.config).to receive(:dig) \
-        .with(:essi, :index_hocr_files) \
+      allow(ESSI.config).to receive(:dig).with(:essi, :index_hocr_files) \
         .and_return(true)
-      allow(ESSI.config).to receive(:dig) \
-        .with(:essi, :master_file_service_url) \
-        .and_return('http://service')
-      file_actor.ingest_file(io)
-      expect(file_set.reload.original_file.mime_type).to include \
-        ESSI.config.dig :essi, :master_file_service_url
     end
-  end
-
-  context 'when :store_original_files is true', :clean do
-    it 'saves an image file to the member file_set' do
-      expect(CharacterizeJob).to receive(:perform_later) \
-        .with(file_set, String, String)
-      allow(ESSI.config).to receive(:dig) \
-        .with(any_args).and_call_original
-      allow(ESSI.config).to receive(:dig) \
-        .with(:essi, :store_original_files) \
-        .and_return(true)
-      allow(ESSI.config).to receive(:dig) \
-        .with(:essi, :create_hocr_files) \
-        .and_return(true)
-      allow(ESSI.config).to receive(:dig) \
-        .with(:essi, :index_hocr_files) \
-        .and_return(true)
-      file_actor.ingest_file(io)
-      expect(file_set.reload.original_file.mime_type).to include "image/png"
+    context 'when :store_original_files is false', :clean do
+      before do
+        allow(ESSI.config).to receive(:dig)
+          .with(:essi, :store_original_files) \
+          .and_return(false)
+        allow(ESSI.config).to receive(:dig) \
+          .with(:essi, :master_file_service_url) \
+          .and_return('http://service')
+      end
+      it 'sets the mime_type to an external body redirect' do
+        file_actor.ingest_file(io)
+        expect(file_set.reload.original_file.mime_type).to include \
+          ESSI.config.dig :essi, :master_file_service_url
+      end
+      it 'does not run characterization' do
+        expect(CharacterizeJob).not_to receive(:perform_later)
+        file_actor.ingest_file(io)
+      end
+    end
+  
+    context 'when :store_original_files is true', :clean do
+      before do
+        allow(ESSI.config).to receive(:dig) \
+          .with(:essi, :store_original_files) \
+          .and_return(true)
+      end
+      it 'saves an image file to the member file_set' do
+        file_actor.ingest_file(io)
+        expect(file_set.reload.original_file.mime_type).to include "image/png"
+      end
+      it 'runs characterization' do
+        expect(CharacterizeJob).to receive(:perform_later) \
+          .with(file_set, String, String)
+        file_actor.ingest_file(io)
+      end
     end
   end
 end

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -47,10 +47,25 @@ describe Hyrax::Actors::FileActor do
         file_actor.ingest_file(io)
         expect(file_set.reload.original_file.mime_type).to include "image/png"
       end
-      it 'runs characterization' do
-        expect(CharacterizeJob).to receive(:perform_later) \
-          .with(file_set, String, String)
-        file_actor.ingest_file(io)
+      context 'when the file_set is for collection branding' do
+        before do
+          allow(file_set).to receive(:collection_branding?).and_return(true)
+        end
+        it 'does not run characterization' do
+          expect(CharacterizeJob).not_to receive(:perform_later) \
+            .with(file_set, String, String)
+          file_actor.ingest_file(io)
+        end
+      end
+      context 'when the file_set is not for collection branding' do
+        before do
+          allow(file_set).to receive(:collection_branding?).and_return(false)
+        end
+        it 'runs characterization' do
+          expect(CharacterizeJob).to receive(:perform_later) \
+            .with(file_set, String, String)
+          file_actor.ingest_file(io)
+        end
       end
     end
   end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
+  # TODO: test controller changes for FileSet-backed branding
+end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -1,5 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
-  # TODO: test controller changes for FileSet-backed branding
+  routes { Hyrax::Engine.routes }
+  let(:user) { FactoryBot.create(:user) }
+  let(:collection_type) { double(:brandable, true) }
+  let(:collection_type_gid) { FactoryBot.create(:user_collection_type).gid }
+  let(:collection) { Collection.create(title: ['Test collection'],
+                                       collection_type_gid: collection_type_gid,
+                                       visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+  let(:banner) { FactoryBot.build(:collection_branding_banner) }
+
+  describe "#show" do
+    before do
+      sign_in user
+      allow(collection).to receive(:brandable?).and_return(true)
+    end
+
+    context 'with a collection branding banner present' do
+      before do
+        allow_any_instance_of(Collection).to receive(:banner_branding).and_return([banner])
+        allow(banner).to receive(:file_set_image_path).and_return('file_set_image_path')
+      end
+
+      it 'assigns a banner file' do
+        get :show, params: { id: collection.id }
+        expect(assigns(:banner_file)).not_to be_nil
+      end
+    end
+
+    context 'without a collection branding banner present' do
+      it 'assigns collection branding' do
+        get :show, params: { id: collection.id }
+        expect(assigns(:banner_file)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/factories/collection_branding_infos.rb
+++ b/spec/factories/collection_branding_infos.rb
@@ -1,0 +1,32 @@
+FactoryBot.define do
+  factory :collection_branding_banner, class: CollectionBrandingInfo do
+    transient do
+      collection_id { '1' }
+      filename { 'banner.png' }
+      role { 'banner' }
+      local_path { '/fake/path/to/banner.png' }
+      alt_text { '' }
+      target_url { '' }
+      height { 0 }
+      width { 0 }
+      file_set_id { '1' }
+      image_path { '/fake/path/to/image' }
+    end
+   initialize_with { CollectionBrandingInfo.new(collection_id: collection_id, filename: filename, role: role, alt_txt: alt_text, target_url: target_url, local_path: local_path, file_set_id: file_set_id, image_path: image_path) }
+  end
+  factory :collection_branding_logo, class: CollectionBrandingInfo do
+    transient do
+      collection_id { '1' }
+      filename { 'logo.png' }
+      role { 'logo' }
+      local_path { '/fake/path/to/logo.png' }
+      alt_text { 'This is the logo' }
+      target_url { 'http://example.com/' }
+      height { 0 }
+      width { 0 }
+      file_set_id { '1' }
+      image_path { '/fake/path/to/image' }
+    end
+   initialize_with { CollectionBrandingInfo.new(collection_id: collection_id, filename: filename, role: role, alt_txt: alt_text, target_url: target_url, local_path: local_path, file_set_id: file_set_id, image_path: image_path) }
+  end
+end

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Forms::CollectionForm do
+  let(:collection) { FactoryBot.build(:collection_lw) }
+  let(:ability) { Ability.new(FactoryBot.create(:user)) }
+  let(:repository) { double }
+  let(:form) { described_class.new(collection, ability, repository) }
+  let(:banner) do
+    CollectionBrandingInfo.new(
+      collection_id: '1',
+      filename: 'banner.png',
+      role: 'banner',
+      image_path: '/fake/path/to/banner'
+    )
+  end
+  let(:logo) do
+    CollectionBrandingInfo.new(
+      collection_id: '1',
+      filename: 'logo.png',
+      role: 'logo',
+      alt_txt: '',
+      target_url: '',
+      image_path: '/fake/path/to/banner'
+    )
+  end
+
+  describe "#banner_branding" do
+    it "delegates to the model" do
+      expect(form.model).to receive(:banner_branding)
+      form.banner_branding
+    end
+ end
+
+  describe "#logo_branding" do
+    it "delegates to the model" do
+      expect(form.model).to receive(:logo_branding)
+      form.logo_branding
+    end
+  end
+
+  describe "#banner_info" do
+    context "without banners present" do
+      it "returns an empty hash" do
+        expect(form.banner_info).to be_a Hash
+        expect(form.banner_info).to be_empty
+      end
+    end
+    context "with banners present" do
+      before do
+        allow(collection).to receive(:banner_branding).and_return([banner])
+      end
+      it "returns a hash" do
+        expect(form.banner_info).to be_a Hash
+        expect(form.banner_info).not_to be_empty
+      end
+    end
+  end
+
+  describe "#logo_info" do
+    context "without logos present" do
+      it "returns an empty array" do
+        expect(form.logo_info).to be_empty
+      end
+    end
+    context "with logos present" do
+      before do
+        allow(collection).to receive(:logo_branding).and_return([logo])
+      end
+      it "returns an array of display_hash values" do
+        expect(form.logo_info).to be_a Array
+        expect(form.logo_info).not_to be_empty
+        expect(form.logo_info.first).to be_a Hash
+      end
+    end
+  end
+end

--- a/spec/models/collection_branding_info_spec.rb
+++ b/spec/models/collection_branding_info_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe CollectionBrandingInfo, type: :model do
+  let(:banner) { FactoryBot.build(:collection_branding_banner) }
+  let(:file_set) { double(id: 'file_set_id', uri: 'file_set_uri') }
+  let(:version) { double(uri: 'version_uri') }
+  let(:versions) { double(any?: true, all: self, last: version) }
+
+
+  describe '#initialize' do
+    context 'with local_path value provided' do
+      it 'uses the provided value' do
+        with_value = FactoryBot.build(:collection_branding_banner, local_path: 'provided_path')
+        expect(with_value.local_path).to eq 'provided_path'
+      end
+    end
+    context 'without a local_path value provided' do
+      it 'infers a value' do
+        without_value = FactoryBot.build(:collection_branding_banner, local_path: nil)
+        expect(without_value.local_path).not_to be_empty
+      end
+    end
+  end
+
+  describe '#image_path' do
+    it 'is private' do
+      expect { banner.image_path }.to raise_error NoMethodError
+    end
+  end
+
+  describe '#image_path=' do
+    it 'is private' do
+      expect { banner.image_path = 'val' }.to raise_error NoMethodError
+    end
+  end
+
+  describe '#save' do
+    context  'without an uploaded_file_id or user_key' do
+      it 'does not call #attach_file_set' do
+        expect(banner).not_to receive(:attach_file_set)
+        banner.save
+      end
+    end
+    context  'with an uploaded_file_id and user_key' do
+      let(:actor) { double(file_set: file_set, create_metadata: nil, create_content: nil) }
+      let(:uploaded_file) { double(update: nil) }
+      before do
+        allow(FileSet).to receive(:create).and_return(file_set)
+        allow(Hyrax::Actors::FileSetActor).to receive(:new).and_return(actor)
+        allow(banner).to receive(:uploaded_files).and_return(uploaded_file)
+        allow(User).to receive(:find_by_user_key).and_return('user')
+      end
+      it 'updates the uploaded_file' do
+        expect(uploaded_file).to receive(:update)
+        banner.save(uploaded_file_id: 1, user_key: 'user')
+      end
+      it 'updates the file_set_id' do
+        expect(banner.file_set_id).not_to eq file_set.id
+        banner.save(uploaded_file_id: 1, user_key: 'user')
+        expect(banner.file_set_id).to eq file_set.id
+      end
+      it 'creates FileSet metadata' do
+        expect(actor).to receive(:create_metadata)
+        banner.save(uploaded_file_id: 1, user_key: 'user')
+      end
+      it 'creates FileSet content' do
+        expect(actor).to receive(:create_content)
+        banner.save(uploaded_file_id: 1, user_key: 'user')
+      end
+    end
+  end
+  describe '#file_set_image_path' do
+    context 'with an image_path available' do
+      it 'returns the image path' do
+        expect(banner.file_set_image_path).to eq banner.send(:image_path)
+      end
+    end
+    context 'without an image_path value' do
+      before do
+        banner.send(:image_path=, nil)
+      end
+      context 'and unable to generate one' do
+        before do
+          allow(banner).to receive(:file_set_versions).and_return([])
+        end
+        it 'returns nil' do
+          expect(banner.file_set_image_path).to be_nil
+        end
+      end
+      context 'but able to generate one' do
+        before do
+          allow(banner).to receive(:file_set_versions).and_return(versions)
+          allow(versions).to receive(:all).and_return(versions)
+        end
+        it 'sets the image_path value' do
+          expect(banner).to receive(:image_path=)
+          banner.file_set_image_path
+        end
+        it 'returns the image_path value' do
+          expect(banner.file_set_image_path).to match version.uri
+        end
+      end
+    end
+  end
+  describe '#display_hash' do
+    it 'returns a values hash' do
+      expect(banner.display_hash).to be_a Hash
+    end
+  end
+end

--- a/spec/models/collection_branding_info_spec.rb
+++ b/spec/models/collection_branding_info_spec.rb
@@ -34,6 +34,27 @@ RSpec.describe CollectionBrandingInfo, type: :model do
     end
   end
 
+  describe '#destroy' do
+    context 'without an associated FileSet' do
+      before do
+        allow(banner).to receive(:file_set).and_return(nil)
+      end
+      it 'does not raise an error' do
+        expect { banner.destroy }.not_to raise_error
+      end
+    end
+    context 'with an associated FileSet' do
+      before do
+        allow(banner).to receive(:file_set).and_return(file_set)
+        allow(file_set).to receive(:destroy)
+      end
+      it 'destroys the FileSet' do
+        expect(file_set).to receive(:destroy)
+        banner.destroy
+      end
+    end
+  end
+
   describe '#save' do
     context  'without an uploaded_file_id or user_key' do
       it 'does not call #attach_file_set' do

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,5 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe FileSet do
-  # "Add your tests here"
+  let(:file_set) { FactoryBot.build(:file_set) }
+  let(:collection_branding_info) { FactoryBot.build(:collection_branding_banner, file_set_id: nil) }
+
+  describe 'collection_branding_info' do
+    context 'with an associated CollectionBrandingInfo' do
+      before do
+        file_set.save!
+        collection_branding_info.update_attributes!(file_set_id: file_set.id)
+      end
+      it 'returns the object' do
+        expect(file_set.collection_branding_info).to eq collection_branding_info
+      end
+    end
+    context 'without an associated CollectionBrandingInfo' do
+      it 'returns nil' do
+        expect(file_set.collection_branding_info).to be_nil
+      end
+    end
+  end
+
+  describe '#collection_branding?' do
+    context 'without an associated branding object' do
+      it 'returns false' do
+        expect(file_set.collection_branding?).to be false
+      end
+    end
+    context 'with an associated branding object' do
+      before do
+        allow(file_set).to receive(:collection_branding_info).and_return(collection_branding_info)
+      end
+      it 'returns true' do
+        expect(file_set.collection_branding?).to be true
+      end
+    end
+  end
 end

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -2,40 +2,97 @@ require 'rails_helper'
 
 RSpec.describe Hyrax::CollectionPresenter do
   subject { described_class.new(double, double) }
-
-  before do
-    name = 'The Collection'
-    @snake = 'the_collection'
-    @title = 'The Title'
-    @url = 'http://university.edu'
-    collection = double('CollectionType', title: name)
-    allow(subject).to receive(:collection_type).and_return(collection)
-    @campus_logos = ESSI.config[:essi][:campus_logos]
+  let(:banner) do
+    CollectionBrandingInfo.new(
+      collection_id: '1',
+      filename: 'banner.png',
+      role: 'banner',
+      image_path: '/fake/path/to/banner'
+    )
+  end
+  let(:logo) do
+    CollectionBrandingInfo.new(
+      collection_id: '1',
+      filename: 'logo.png',
+      role: 'logo',
+      alt_txt: '',
+      target_url: '',
+      image_path: '/fake/path/to/banner'
+    )
   end
 
-  context 'When initialized' do
-    it '.campus_logo is available' do
-      expect(subject).to respond_to(:campus_logo)
+  describe '.campus_logo' do
+    before do
+      name = 'The Collection'
+      @snake = 'the_collection'
+      @title = 'The Title'
+      @url = 'http://university.edu'
+      collection = double('CollectionType', title: name)
+      allow(subject).to receive(:collection_type).and_return(collection)
+      @campus_logos = ESSI.config[:essi][:campus_logos]
+    end
+  
+    context 'When initialized' do
+      it 'is available' do
+        expect(subject).to respond_to(:campus_logo)
+      end
+    end
+  
+    context 'When campus_logos is not configured' do
+      it 'returns false' do
+        ESSI.config[:essi][:campus_logos] = nil
+        expect(subject.campus_logo).to be false
+      end
+    end
+  
+    context 'When collection matches configuration' do
+      it 'returns configured values' do
+        ESSI.config[:essi][:campus_logos][@snake] = { title: @title, url: @url }
+        expect(subject.campus_logo).to include(@title)
+        expect(subject.campus_logo).to include(@url)
+      end
+    end
+  
+    after do
+      ESSI.config[:essi][:campus_logos] = @campus_logos
     end
   end
 
-  context 'When campus_logos is not configured' do
-    it '.campus_logo returns false' do
-      ESSI.config[:essi][:campus_logos] = nil
-      expect(subject.campus_logo).to be false
+  describe '#banner_file' do
+    before do
+      allow(subject).to receive(:id).and_return('1')
+    end
+    context 'without a banner available' do
+      it 'returns nil' do
+        expect(subject.banner_file).to be_blank
+      end
+    end
+    context 'with a banner available' do
+      before do
+        allow(CollectionBrandingInfo).to receive(:where).with(collection_id: '1', role: 'banner').and_return([banner])
+      end
+      it 'returns the image path' do
+        expect(subject.banner_file).to be_present
+      end
     end
   end
 
-  context 'When collection matches configuration' do
-    it '.campus_logo returns configured values' do
-      ESSI.config[:essi][:campus_logos][@snake] = { title: @title, url: @url }
-      expect(subject.campus_logo).to include(@title)
-      expect(subject.campus_logo).to include(@url)
+  describe '#logo_record' do
+    before do
+      allow(subject).to receive(:id).and_return('1')
+    end
+    context 'without logos available' do
+      it 'returns an empty array' do
+        expect(subject.logo_record).to be_empty   
+      end
+    end
+    context 'with logos available' do
+      before do
+        allow(CollectionBrandingInfo).to receive(:where).with(collection_id: '1', role: 'logo').and_return([banner])
+      end
+      it 'returns an array of display value hashes' do
+        expect(subject.logo_record).not_to be_empty   
+      end
     end
   end
-
-  after do
-    ESSI.config[:essi][:campus_logos] = @campus_logos
-  end
-
 end


### PR DESCRIPTION
Changes `CollectionBrandingInfo` from managing uploaded image files in the `/public/branding` subtree, to managing them via `FileSet` objects and retrieving their display images from the IIIF server.

The approach I took to modifying the 4 interrelated Hyrax components was to monkeypatch the controller, presenter, and form, but completely override the `CollectionBrandingInfo` model as that is changed drastically (and I originally tried it via monkeypatches, but that got messy, with the super calls.).

A few other notes:
- the `FileSet` gets created promptly as a stub and associated to the `CollectionbrandingInfo`, but its fleshing out is handled by the actor/job stack, so the images may not actually show up for awhile, until that process has completed.
  - `CollectionbrandingInfo` will update the `image_path` on-demand when the IIIF image URL actually becomes available
- In stock Hyrax, `CollectionBrandingInfo` has `width` and `height` fields, but they are never actually used; I left a comment about using dimensions other than default, but the views already enforce specific rendering dimensions
- there's another comment about whether to tweak the default visibility permissions on the `FileSet`
- I'm missing controller/feature coverage of all the actions to interact with adding/removing/updating `CollectionBrandingInfo` objects -- but then, that coverage wasn't present in stock Hyrax, in the first place