### PR TITLE
[ESSI-822] Revise collection thumbnails

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -9,6 +9,7 @@ module CatalogHelper
   # @param [SolrDocument, Presenter] document
   # @return [String]
   def thumbnail_url document
+    return document.thumbnail_path if document.try(:thumbnail_path).present?
     if document.id == document.thumbnail_id
       representative_document = document
     else

--- a/app/indexers/concerns/essi/iiif_collection_thumbnail_behavior.rb
+++ b/app/indexers/concerns/essi/iiif_collection_thumbnail_behavior.rb
@@ -1,0 +1,9 @@
+module ESSI
+  module IIIFCollectionThumbnailBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      self.thumbnail_path_service = IIIFCollectionThumbnailPathService
+    end
+  end
+end

--- a/app/services/iiif_collection_thumbnail_path_service.rb
+++ b/app/services/iiif_collection_thumbnail_path_service.rb
@@ -1,0 +1,17 @@
+class IIIFCollectionThumbnailPathService < Hyrax::CollectionThumbnailPathService
+  class << self
+    # @return the network path to the thumbnail
+    # @param [FileSet] thumbnail the object that is the thumbnail
+    def thumbnail_path(thumbnail)
+      Hyrax.config.iiif_image_url_builder.call(thumbnail.original_file.id, nil, '250,')
+      # Hyrax::Engine.routes.url_helpers.download_path(thumbnail.id,
+      #                                                file: 'thumbnail')
+    end
+
+    # @return true if there a file in fedora for this object, otherwise false
+    # @param [FileSet] thumb - the object that is the thumbnail
+    def thumbnail?(thumb)
+      thumb.files.size > 0
+    end
+  end
+end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -26,5 +26,9 @@ Hyrax::WorkShowPresenter.include Extensions::Hyrax::WorkShowPresenter::Collectio
 # primary fields support
 Hyrax::Forms::WorkForm.include Extensions::Hyrax::Forms::WorkForm::PrimaryFields
 
+# IIIF Thumbnails for both types of Collections
+Hyrax::AdminSetIndexer.include ESSI::IIIFCollectionThumbnailBehavior
+Hyrax::CollectionIndexer.include ESSI::IIIFCollectionThumbnailBehavior
+
 Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest, ESSI::Actors::PerformLaterActor
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesActor, ESSI::Actors::CreateWithRemoteFilesActor


### PR DESCRIPTION
The first commit uses IIIF Thumbnails for both collection types (User Collections, Admin Sets), as is already done for works.

The second one tweaks `#thumbnail_url` logic in `CatalogHelper`, but I'm less confident it's the right change.  The overall context for this, is: Hyrax uses a mix of two paradigms for displaying thumbnails:
* **Blacklight-based**, doing a `render_thumbnail_tag` call on a `SolrDocument` _document_ record
* **Presenter-based**, calling `thumbnail_path` on the _presenter_
This is why, for objects with no `thumbnail_id`, we got a mix of the `default.png` display of a dogeared page (when using the Blacklight methodology) that's agnostic of the object's class, versus displaying generic 'work.png' (a single box) or 'collection.png' (a stack of 3 boxes) -- the indexers for works and collections know to default to those more specific generic images, instead of `default.png`  (Note that in all 3 of these cases, the `thumbnail_url` returned is a raw link to public assets, rather than the IIIF server.  Presumably that's okay?)

@dlpierce This probably merits your review as it's touching thumbnail content you've worked on quite recently.
