### PR TITLE
[ESSI-831] Turn source_metadata_identifier errors into alerts

### DIFF
--- a/app/controllers/concerns/essi/remote_metadata_lookup_behavior.rb
+++ b/app/controllers/concerns/essi/remote_metadata_lookup_behavior.rb
@@ -16,6 +16,7 @@ module ESSI
     end
 
     def remote_attributes
+      return {} if remote_data.nil?
       @remote_attributes ||= begin
          remote_attributes = remote_data.raw_attributes
          remote_attributes['source_metadata'] = remote_data.source.dup.try(:force_encoding, 'utf-8') if remote_data.source
@@ -33,8 +34,12 @@ module ESSI
       end
 
       def remote_data
-        @remote_data ||=
+        @remote_data ||= begin
           remote_metadata_factory.retrieve(source_metadata_identifier)
+          rescue JSONLDRecord::MissingRemoteRecordError
+            flash[:alert] = I18n.t('services.remote_metadata.no_results')
+            nil
+        end
       end
 
       def remote_metadata_factory

--- a/app/controllers/concerns/essi/remote_metadata_lookup_behavior.rb
+++ b/app/controllers/concerns/essi/remote_metadata_lookup_behavior.rb
@@ -43,7 +43,8 @@ module ESSI
         elsif source_metadata_identifier.blank?
           RemoteRecord
         else
-          raise RemoteRecord::BibdataError, RemoteRecord.bibdata_error_message
+          flash[:alert] = I18n.t('services.remote_metadata.invalid_identifier').to_s + (I18n.t('services.remote_metadata.validation') || RemoteRecord.bibdata_error_message).to_s
+          RemoteRecord
         end
     end
   end

--- a/app/models/remote_record.rb
+++ b/app/models/remote_record.rb
@@ -5,7 +5,7 @@
 class RemoteRecord < SimpleDelegator
   class << self
     def retrieve(id)
-      if id.present?
+      if id.present? && bibdata?(id)
         # FIXME: below will always raise an Argument error -- but this action
         # should also be short-cutted by raising the Bibdata error earlier, so
         # this is probably vestigial at this point

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
     metadata: "IUCAT"
     remote_metadata:
       invalid_identifier: "The provided Source Metadata ID value was saved, but not used for remote metadata lookup as it was did not pass validation.  "
-      validation: "A valid metadata identifier may contain only alphanumeric and underscore characters."
+      validation: "A valid metadata identifier may contain only alphanumeric, underscore, hyphen, and period characters."
   simple_form:
     options:
       file_set:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,9 @@ en:
   hello: "Hello world"
   services:
     metadata: "IUCAT"
+    remote_metadata:
+      invalid_identifier: "The provided Source Metadata ID value was saved, but not used for remote metadata lookup as it was did not pass validation.  "
+      validation: "A valid metadata identifier may contain only alphanumeric and underscore characters."
   simple_form:
     options:
       file_set:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
     remote_metadata:
       invalid_identifier: "The provided Source Metadata ID value was saved, but not used for remote metadata lookup as it was did not pass validation.  "
       validation: "A valid metadata identifier may contain only alphanumeric, underscore, hyphen, and period characters."
+      no_results: "The provided Source Metadata ID value was saved, but did not return any results from remote metadata lookup."
   simple_form:
     options:
       file_set:

--- a/lib/iu_metadata/client.rb
+++ b/lib/iu_metadata/client.rb
@@ -22,11 +22,12 @@ module IuMetadata
 
     # Used for validating metadata identifiers in URLs
     def self.bibdata?(source_metadata_id)
-      (source_metadata_id =~ /\A\w+\z/)&.zero? || false
+      (source_metadata_id =~ /\A[a-zA-Z0-9\-\.]+\z/)&.zero? || false
     end
 
     BIBDATA_ERROR_MESSAGE = 'A valid metadata identifier may contain only ' \
-                            'alphanumeric and underscore characters.'.freeze
+                            'alphanumeric, underscore, hyphen, and period ' \
+                            'characters.'.freeze
 
     # Extracts the data payload from a YAZ Proxy response
     private_class_method def self.strip_yaz(src)

--- a/spec/fixtures/marc_VAD5427.xml
+++ b/spec/fixtures/marc_VAD5427.xml
@@ -1,0 +1,118 @@
+<record xmlns="http://www.loc.gov/MARC21/slim">
+  <!-- Length implementation at offset 22 should hold a digit. Assuming 0 -->
+  <leader>01315 cm a2200361I  4500</leader>
+  <controlfield tag="001">ocm05815912</controlfield>
+  <controlfield tag="003">OCoLC</controlfield>
+  <controlfield tag="005">20150409175040.8</controlfield>
+  <controlfield tag="008">791220nuuuuuuuunyuzza         n    ger d</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)ocm05815912</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)5815912</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">ION</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="c">ION</subfield>
+    <subfield code="d">OCL</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">OCLCG</subfield>
+    <subfield code="d">TXJ</subfield>
+    <subfield code="d">RES</subfield>
+    <subfield code="d">OCLCQ</subfield>
+    <subfield code="d">OCLCA</subfield>
+    <subfield code="d">OCLCF</subfield>
+    <subfield code="d">OCLCO</subfield>
+    <subfield code="d">OCLCQ</subfield>
+  </datafield>
+  <datafield tag="041" ind1="1" ind2=" ">
+    <subfield code="a">ger</subfield>
+    <subfield code="h">eng</subfield>
+  </datafield>
+  <datafield tag="048" ind1=" " ind2=" ">
+    <subfield code="a">oa01</subfield>
+  </datafield>
+  <datafield tag="050" ind1="1" ind2="4">
+    <subfield code="a">M1510.M53</subfield>
+    <subfield code="b">S6</subfield>
+  </datafield>
+  <datafield tag="049" ind1=" " ind2=" ">
+    <subfield code="a">IULA</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Mendelssohn-Bartholdy, Felix,</subfield>
+    <subfield code="d">1809-1847.</subfield>
+  </datafield>
+  <datafield tag="240" ind1="1" ind2="0">
+    <subfield code="a">Sommernachtstraum.</subfield>
+    <subfield code="l">English &amp; German</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="2">
+    <subfield code="a">A midsummer night's dream,</subfield>
+    <subfield code="b">op. 61.</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">New York,</subfield>
+    <subfield code="b">Kalmus,</subfield>
+    <subfield code="c">[date of publication not identified]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 score (174 pages).</subfield>
+    <subfield code="c">33 cm.</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">notated music</subfield>
+    <subfield code="b">ntm</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="490" ind1="0" ind2=" ">
+    <subfield code="a">Kalmus orchestra library</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Incidental music to the play by William Shakespeare.</subfield>
+  </datafield>
+  <datafield tag="546" ind1=" " ind2=" ">
+    <subfield code="a">German words with English underlay.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Incidental music</subfield>
+    <subfield code="v">Scores.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Shakespeare, William,</subfield>
+    <subfield code="d">1564-1616.</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="1">
+    <subfield code="a">Bloomington</subfield>
+    <subfield code="u">http://purl.dlib.indiana.edu/iudl/variations/score/VAD5427</subfield>
+    <subfield code="z">Available to authorized users</subfield>
+  </datafield>
+  <datafield tag="596" ind1=" " ind2=" ">
+    <subfield code="a">20</subfield>
+  </datafield>
+  <datafield tag="926" ind1=" " ind2=" ">
+    <subfield code="a">B-MUSIC</subfield>
+    <subfield code="b">STACKS</subfield>
+    <subfield code="c">M1510.M53 S6 K22</subfield>
+    <subfield code="d">NORMAL</subfield>
+    <subfield code="f">1</subfield>
+  </datafield>
+  <datafield tag="926" ind1=" " ind2=" ">
+    <subfield code="a">B-MUSIC</subfield>
+    <subfield code="b">_MUVARIA</subfield>
+    <subfield code="c"/>
+    <subfield code="d">NONCIRC</subfield>
+    <subfield code="f">1</subfield>
+  </datafield>
+</record>

--- a/spec/fixtures/mods_VAD5427.xml
+++ b/spec/fixtures/mods_VAD5427.xml
@@ -1,0 +1,68 @@
+<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.2" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-2.xsd">
+  <titleInfo>
+    <nonSort>A </nonSort>
+    <title>midsummer night's dream</title>
+    <subTitle>op. 61</subTitle>
+  </titleInfo>
+  <titleInfo type="uniform">
+    <title>Sommernachtstraum. English &amp; German</title>
+  </titleInfo>
+  <name type="personal">
+    <namePart>Mendelssohn-Bartholdy, Felix</namePart>
+    <namePart type="date">1809-1847</namePart>
+    <role>
+      <roleTerm authority="marcrelator" type="text">creator</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart>Shakespeare, William</namePart>
+    <namePart type="date">1564-1616</namePart>
+  </name>
+  <typeOfResource>notated music</typeOfResource>
+  <originInfo>
+    <place>
+      <placeTerm type="code" authority="marccountry">nyu</placeTerm>
+    </place>
+    <place>
+      <placeTerm type="text">New York</placeTerm>
+    </place>
+    <publisher>Kalmus</publisher>
+    <dateIssued>[date of publication not identified]</dateIssued>
+    <issuance>monographic</issuance>
+  </originInfo>
+  <language>
+    <languageTerm authority="iso639-2b" type="code">ger</languageTerm>
+  </language>
+  <language objectPart="translation">
+    <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+  </language>
+  <physicalDescription>
+    <form authority="marcform">print</form>
+    <extent>1 score (174 pages). 33 cm.</extent>
+  </physicalDescription>
+  <note>Incidental music to the play by William Shakespeare.</note>
+  <note>German words with English underlay.</note>
+  <subject authority="lcsh">
+    <topic>Incidental music</topic>
+    <genre>Scores</genre>
+  </subject>
+  <classification authority="lcc">M1510.M53 S6</classification>
+  <relatedItem type="series">
+    <titleInfo>
+      <title>Kalmus orchestra library</title>
+    </titleInfo>
+  </relatedItem>
+  <identifier type="uri">http://purl.dlib.indiana.edu/iudl/variations/score/VAD5427</identifier>
+  <location>
+    <url usage="primary display" note="Available to authorized users">http://purl.dlib.indiana.edu/iudl/variations/score/VAD5427</url>
+  </location>
+  <recordInfo>
+    <recordContentSource authority="marcorg">ION</recordContentSource>
+    <recordCreationDate encoding="marc">791220</recordCreationDate>
+    <recordChangeDate encoding="iso8601">20150409175040.8</recordChangeDate>
+    <recordIdentifier source="OCoLC">ocm05815912</recordIdentifier>
+    <languageOfCataloging>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+    </languageOfCataloging>
+  </recordInfo>
+</mods>

--- a/spec/fixtures/vcr_cassettes/bibdata.yml
+++ b/spec/fixtures/vcr_cassettes/bibdata.yml
@@ -206,4 +206,68 @@ http_interactions:
         </mods></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records></zs:searchRetrieveResponse>
     http_version: 
   recorded_at: Tue, 19 Mar 2019 17:47:53 GMT
+- request:
+    method: get
+    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAC1741-00231&recordSchema=marcxml&version=1.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '188'
+      Server:
+      - YAZ/3.0.44
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>0</zs:numberOfRecords></zs:searchRetrieveResponse>
+    http_version: 
+  recorded_at: Thu, 14 May 2020 18:21:18 GMT
+- request:
+    method: get
+    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAC1741-00231&recordSchema=mods&version=1.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '188'
+      Server:
+      - YAZ/3.0.44
+      Content-Type:
+      - text/xml
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>0</zs:numberOfRecords></zs:searchRetrieveResponse>
+    http_version: 
+  recorded_at: Thu, 14 May 2020 18:21:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/marc_VAD5427.yml
+++ b/spec/fixtures/vcr_cassettes/marc_VAD5427.yml
@@ -1,0 +1,151 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=marcxml&version=1.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '5042'
+      Server:
+      - YAZ/3.0.44
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>info:srw/schema/1/marcxml-v1.1</zs:recordSchema><zs:recordPacking>xml</zs:recordPacking><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+        <!-- Length implementation at offset 22 should hold a digit. Assuming 0 -->
+          <leader>01315 cm a2200361I  4500</leader>
+          <controlfield tag="001">ocm05815912</controlfield>
+          <controlfield tag="003">OCoLC</controlfield>
+          <controlfield tag="005">20150409175040.8</controlfield>
+          <controlfield tag="008">791220nuuuuuuuunyuzza         n    ger d</controlfield>
+          <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)ocm05815912</subfield>
+          </datafield>
+          <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)5815912</subfield>
+          </datafield>
+          <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">ION</subfield>
+            <subfield code="b">eng</subfield>
+            <subfield code="c">ION</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCG</subfield>
+            <subfield code="d">TXJ</subfield>
+            <subfield code="d">RES</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCA</subfield>
+            <subfield code="d">OCLCF</subfield>
+            <subfield code="d">OCLCO</subfield>
+            <subfield code="d">OCLCQ</subfield>
+          </datafield>
+          <datafield tag="041" ind1="1" ind2=" ">
+            <subfield code="a">ger</subfield>
+            <subfield code="h">eng</subfield>
+          </datafield>
+          <datafield tag="048" ind1=" " ind2=" ">
+            <subfield code="a">oa01</subfield>
+          </datafield>
+          <datafield tag="050" ind1="1" ind2="4">
+            <subfield code="a">M1510.M53</subfield>
+            <subfield code="b">S6</subfield>
+          </datafield>
+          <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">IULA</subfield>
+          </datafield>
+          <datafield tag="100" ind1="1" ind2=" ">
+            <subfield code="a">Mendelssohn-Bartholdy, Felix,</subfield>
+            <subfield code="d">1809-1847.</subfield>
+          </datafield>
+          <datafield tag="240" ind1="1" ind2="0">
+            <subfield code="a">Sommernachtstraum.</subfield>
+            <subfield code="l">English &amp; German</subfield>
+          </datafield>
+          <datafield tag="245" ind1="1" ind2="2">
+            <subfield code="a">A midsummer night's dream,</subfield>
+            <subfield code="b">op. 61.</subfield>
+          </datafield>
+          <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">New York,</subfield>
+            <subfield code="b">Kalmus,</subfield>
+            <subfield code="c">[date of publication not identified]</subfield>
+          </datafield>
+          <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">1 score (174 pages).</subfield>
+            <subfield code="c">33 cm.</subfield>
+          </datafield>
+          <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">notated music</subfield>
+            <subfield code="b">ntm</subfield>
+            <subfield code="2">rdacontent</subfield>
+          </datafield>
+          <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+          </datafield>
+          <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+          </datafield>
+          <datafield tag="490" ind1="0" ind2=" ">
+            <subfield code="a">Kalmus orchestra library</subfield>
+          </datafield>
+          <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Incidental music to the play by William Shakespeare.</subfield>
+          </datafield>
+          <datafield tag="546" ind1=" " ind2=" ">
+            <subfield code="a">German words with English underlay.</subfield>
+          </datafield>
+          <datafield tag="650" ind1=" " ind2="0">
+            <subfield code="a">Incidental music</subfield>
+            <subfield code="v">Scores.</subfield>
+          </datafield>
+          <datafield tag="700" ind1="1" ind2=" ">
+            <subfield code="a">Shakespeare, William,</subfield>
+            <subfield code="d">1564-1616.</subfield>
+          </datafield>
+          <datafield tag="856" ind1="4" ind2="1">
+            <subfield code="a">Bloomington</subfield>
+            <subfield code="u">http://purl.dlib.indiana.edu/iudl/variations/score/VAD5427</subfield>
+            <subfield code="z">Available to authorized users</subfield>
+          </datafield>
+          <datafield tag="596" ind1=" " ind2=" ">
+            <subfield code="a">20</subfield>
+          </datafield>
+          <datafield tag="926" ind1=" " ind2=" ">
+            <subfield code="a">B-MUSIC</subfield>
+            <subfield code="b">STACKS</subfield>
+            <subfield code="c">M1510.M53 S6 K22</subfield>
+            <subfield code="d">NORMAL</subfield>
+            <subfield code="f">1</subfield>
+          </datafield>
+          <datafield tag="926" ind1=" " ind2=" ">
+            <subfield code="a">B-MUSIC</subfield>
+            <subfield code="b">_MUVARIA</subfield>
+            <subfield code="c"/>
+            <subfield code="d">NONCIRC</subfield>
+            <subfield code="f">1</subfield>
+          </datafield>
+        </record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records></zs:searchRetrieveResponse>
+    http_version: 
+  recorded_at: Wed, 13 May 2020 18:52:21 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/mods_VAD5427.yml
+++ b/spec/fixtures/vcr_cassettes/mods_VAD5427.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=mods&version=1.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '3079'
+      Server:
+      - YAZ/3.0.44
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>info:srw/schema/1/mods-v3.2</zs:recordSchema><zs:recordPacking>xml</zs:recordPacking><zs:recordData><mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.2" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-2.xsd">
+          <titleInfo>
+            <nonSort>A </nonSort>
+            <title>midsummer night's dream</title>
+            <subTitle>op. 61</subTitle>
+          </titleInfo>
+          <titleInfo type="uniform">
+            <title>Sommernachtstraum. English &amp; German</title>
+          </titleInfo>
+          <name type="personal">
+            <namePart>Mendelssohn-Bartholdy, Felix</namePart>
+            <namePart type="date">1809-1847</namePart>
+            <role>
+              <roleTerm authority="marcrelator" type="text">creator</roleTerm>
+            </role>
+          </name>
+          <name type="personal">
+            <namePart>Shakespeare, William</namePart>
+            <namePart type="date">1564-1616</namePart>
+          </name>
+          <typeOfResource>notated music</typeOfResource>
+          <originInfo>
+            <place>
+              <placeTerm type="code" authority="marccountry">nyu</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">New York</placeTerm>
+            </place>
+            <publisher>Kalmus</publisher>
+            <dateIssued>[date of publication not identified]</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <language>
+            <languageTerm authority="iso639-2b" type="code">ger</languageTerm>
+          </language>
+          <language objectPart="translation">
+            <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+          </language>
+          <physicalDescription>
+            <form authority="marcform">print</form>
+            <extent>1 score (174 pages). 33 cm.</extent>
+          </physicalDescription>
+          <note>Incidental music to the play by William Shakespeare.</note>
+          <note>German words with English underlay.</note>
+          <subject authority="lcsh">
+            <topic>Incidental music</topic>
+            <genre>Scores</genre>
+          </subject>
+          <classification authority="lcc">M1510.M53 S6</classification>
+          <relatedItem type="series">
+            <titleInfo>
+              <title>Kalmus orchestra library</title>
+            </titleInfo>
+          </relatedItem>
+          <identifier type="uri">http://purl.dlib.indiana.edu/iudl/variations/score/VAD5427</identifier>
+          <location>
+            <url usage="primary display" note="Available to authorized users">http://purl.dlib.indiana.edu/iudl/variations/score/VAD5427</url>
+          </location>
+          <recordInfo>
+            <recordContentSource authority="marcorg">ION</recordContentSource>
+            <recordCreationDate encoding="marc">791220</recordCreationDate>
+            <recordChangeDate encoding="iso8601">20150409175040.8</recordChangeDate>
+            <recordIdentifier source="OCoLC">ocm05815912</recordIdentifier>
+            <languageOfCataloging>
+              <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+            </languageOfCataloging>
+          </recordInfo>
+        </mods></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records></zs:searchRetrieveResponse>
+    http_version: 
+  recorded_at: Wed, 13 May 2020 18:52:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/mods_deadbeef.yml
+++ b/spec/fixtures/vcr_cassettes/mods_deadbeef.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=missingrecorddeadbeef&recordSchema=mods&version=1.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '188'
+      Server:
+      - YAZ/3.0.44
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>0</zs:numberOfRecords></zs:searchRetrieveResponse>
+    http_version: 
+  recorded_at: Wed, 13 May 2020 18:52:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/iu_metadata/client_spec.rb
+++ b/spec/iu_metadata/client_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe IuMetadata::Client do
+  let(:fixture_path) { File.expand_path('../../fixtures', __FILE__) }
+  let(:marc) {
+    File.open(File.join(fixture_path, 'marc_VAD5427.xml')).read.strip
+  }
+  let(:mods) {
+    File.open(File.join(fixture_path, 'mods_VAD5427.xml')).read.strip
+  }
+
+  context 'with an IUCAT id' do
+    it 'makes MARC requests to IUCAT',
+       vcr: { cassette_name: 'marc_VAD5427' } do
+      expect(described_class.retrieve('VAD5427', :marc).source).to eq marc
+    end
+
+    it 'makes MODS requests to IUCAT',
+       vcr: { cassette_name: 'mods_VAD5427' } do
+      expect(described_class.retrieve('VAD5427', :mods).source).to eq mods
+    end
+
+    it 'returns an empty obj when a record is not found',
+       vcr: { cassette_name: 'mods_deadbeef' } do
+      expect(
+        described_class.retrieve('missingrecorddeadbeef', :mods).source.blank?
+      ).to be true
+    end
+
+    it 'raises errors when an invalid format is specified' do
+      expect {
+        described_class.retrieve('VAD5427', :unknownformat).source
+      }.to raise_error('Invalid format argument')
+    end
+
+    it 'recognizes valid identifiers' do
+      expect(described_class.bibdata?('abc-.123')).to be true
+    end
+
+    it 'recognizes invalid identifiers' do
+      expect(described_class.bibdata?('abc&123')).to be false
+    end
+
+    it 'validates identifiers when retrieving' do
+      expect {
+        described_class.retrieve('abc&123', :marc).source
+      }.to raise_error('Invalid id argument')
+    end
+  end
+end

--- a/spec/support/shared_examples/remote_metadata.rb
+++ b/spec/support/shared_examples/remote_metadata.rb
@@ -19,6 +19,12 @@ RSpec.shared_examples 'update metadata remotely' do |resource_symbol|
           source_metadata_identifier: 'BHR9405'
         }
       }
+      let(:invalid_identifier_attributes) {
+        {
+          description: ['a description'],
+          source_metadata_identifier: 'BHR9405%INVALID$CHARACTERS'
+        }
+      }
 
       context 'without remote refresh flag' do
         it 'updates the record but does not refresh the external metadata' do
@@ -31,13 +37,32 @@ RSpec.shared_examples 'update metadata remotely' do |resource_symbol|
       end
   
       context 'with remote refresh flag', vcr: { cassette_name: 'bibdata', record: :new_episodes } do
-        it 'updates the record and refreshes the external metadata' do
-          patch :update,
-               params: { id: resource.id,
-                         resource_symbol => static_attributes,
-                         refresh_remote_metadata: true }
-          expect(reloaded.title).to eq ['Fontane di Roma ; poema sinfonico per orchestra']
-          expect(reloaded.description).to eq ['a description']
+        context 'with an invalid identifier' do
+          it 'updates the record' do
+            patch :update,
+                 params: { id: resource.id,
+                           resource_symbol => invalid_identifier_attributes,
+                           refresh_remote_metadata: true }
+            expect(reloaded.description).to eq ['a description']
+          end
+          it 'flashes an alert about not refreshing the external metadata' do
+            patch :update,
+                 params: { id: resource.id,
+                           resource_symbol => invalid_identifier_attributes,
+                           refresh_remote_metadata: true }
+            expect(flash[:alert]).to match I18n.t('services.remote_metadata.invalid_identifier')
+            expect(flash[:alert]).to match I18n.t('services.remote_metadata.validation')
+          end
+        end
+        context 'with a valid, matching source metadata ID' do
+          it 'updates the record and refreshes the external metadata' do
+            patch :update,
+                 params: { id: resource.id,
+                           resource_symbol => static_attributes,
+                           refresh_remote_metadata: true }
+            expect(reloaded.title).to eq ['Fontane di Roma ; poema sinfonico per orchestra']
+            expect(reloaded.description).to eq ['a description']
+          end
         end
       end
     end

--- a/spec/support/shared_examples/remote_metadata.rb
+++ b/spec/support/shared_examples/remote_metadata.rb
@@ -25,6 +25,12 @@ RSpec.shared_examples 'update metadata remotely' do |resource_symbol|
           source_metadata_identifier: 'BHR9405%INVALID$CHARACTERS'
         }
       }
+      let(:no_results_identifier_attributes) {
+        {
+            description: ['a description'],
+            source_metadata_identifier: 'VAC1741-00231'
+        }
+      }
 
       context 'without remote refresh flag' do
         it 'updates the record but does not refresh the external metadata' do
@@ -52,6 +58,22 @@ RSpec.shared_examples 'update metadata remotely' do |resource_symbol|
                            refresh_remote_metadata: true }
             expect(flash[:alert]).to match I18n.t('services.remote_metadata.invalid_identifier')
             expect(flash[:alert]).to match I18n.t('services.remote_metadata.validation')
+          end
+        end
+        context 'with a valid, non-matching source metadata ID' do
+          it 'updates the record' do
+            patch :update,
+                  params: { id: resource.id,
+                            resource_symbol => no_results_identifier_attributes,
+                            refresh_remote_metadata: true }
+            expect(reloaded.description).to eq ['a description']
+          end
+          it 'flashes an alert about no results found' do
+            patch :update,
+                  params: { id: resource.id,
+                            resource_symbol => no_results_identifier_attributes,
+                            refresh_remote_metadata: true }
+            expect(flash[:alert]).to match I18n.t('services.remote_metadata.no_results')
           end
         end
         context 'with a valid, matching source metadata ID' do


### PR DESCRIPTION
The remote source metadata logic we pulled from pumpkin was missing error handling for two cases:
* supplying an invalid `source_metadata_identifier`
* attempting to pull remote metadata and getting no results for the identifier

This PR handles both cases, but whereas in pumpkin these cases blocked saving the work and flashed a _failure_ message to the user, in ESSI both cases succeed and merely flash an _alert_ to the user.  The validation logic for a `source_metadata_identifier` is also loosened to allow periods and hyphens.