### PR TITLE
Essi-830 Enable update/destroy in PerformLaterActor

### DIFF
--- a/app/actors/essi/actors/perform_later_actor.rb
+++ b/app/actors/essi/actors/perform_later_actor.rb
@@ -10,6 +10,26 @@ module ESSI
           PerformLaterActorJob.perform_later('create', env.curation_concern.class.to_s, env.current_ability.current_user, env.attributes)
         end
       end
+
+      def update(env)
+        # Short circuit to next actor if we are running from a job.
+        if env.attributes.delete 'in_perform_later_actor_job'
+          super
+        else
+          env.attributes['in_perform_later_actor_job'] = true
+          PerformLaterActorJob.perform_later('update', env.curation_concern, env.current_ability.current_user, env.attributes)
+        end
+      end
+
+      def destroy(env)
+        # Short circuit to next actor if we are running from a job.
+        if env.attributes.delete 'in_perform_later_actor_job'
+          super
+        else
+          env.attributes['in_perform_later_actor_job'] = true
+          PerformLaterActorJob.perform_later('destroy', env.curation_concern, env.current_ability.current_user, env.attributes)
+        end
+      end
     end
   end
 end

--- a/app/jobs/perform_later_actor_job.rb
+++ b/app/jobs/perform_later_actor_job.rb
@@ -1,7 +1,10 @@
 class PerformLaterActorJob < ActiveJob::Base
   def perform(action, curation_concern, ability_user, attributes_for_actor)
-    # Rebuild the actor environment
-    env = Hyrax::Actors::Environment.new(curation_concern.constantize.new, ::Ability.new(ability_user), attributes_for_actor)
+    # create action needs a new object, update/destroy should pass in the existing object.
+    curation_concern = curation_concern.constantize.new if curation_concern.is_a? String
+
+    # Rebuild the actor environment and send it down the actor stack.
+    env = Hyrax::Actors::Environment.new(curation_concern, ::Ability.new(ability_user), attributes_for_actor)
     Hyrax::CurationConcern.actor.send(action, env)
   end
 end

--- a/spec/actors/essi/actors/perform_later_actor_spec.rb
+++ b/spec/actors/essi/actors/perform_later_actor_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe ESSI::Actors::PerformLaterActor do
+  before :all do
+    RSpec::Mocks.with_temporary_scope do
+      @work = FactoryBot.create(:paged_resource)
+      @user = FactoryBot.create(:user)
+      @ability = ::Ability.new(@user)
+    end
+  end
+
+  let(:env) { Hyrax::Actors::Environment.new(@work, @ability, attributes) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:attributes) { {title: 'Procrastination Test'} }
+
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  describe "#create" do
+    context 'when called directly' do
+      it 'enqueues a PerformLaterActorJob' do
+        expect { middleware.create(env) }.to have_enqueued_job(PerformLaterActorJob).with {
+            |action, curation_concern, ability_user, attributes_for_actor|
+          expect(action).to eq 'create'
+          expect(curation_concern).to eq 'PagedResource'
+          expect(ability_user).to eq @user
+          expect(attributes_for_actor).to match( 'title': 'Procrastination Test', 'in_perform_later_actor_job': true )
+        }
+      end
+    end
+
+    context 'when called from PerformLaterActorJob' do
+      let(:attributes) { {title: 'Procrastination Test', 'in_perform_later_actor_job': true} }
+
+      it 'continues down the Actor stack' do
+        expect(terminator).to receive(:create).with(
+            having_attributes(:attributes => hash_excluding('in_perform_later_actor_job'))
+        )
+        expect { middleware.create(env) }.not_to have_enqueued_job(PerformLaterActorJob)
+      end
+    end
+  end
+
+  describe "#update" do
+    context 'by default' do
+      it 'enqueues a PerformLaterActorJob' do
+        expect { middleware.update(env) }.to have_enqueued_job(PerformLaterActorJob).with {
+            |action, curation_concern, ability_user, attributes_for_actor|
+          expect(action).to eq 'update'
+          expect(curation_concern).to eq(@work).and(be_a PagedResource)
+          expect(ability_user).to eq @user
+          expect(attributes_for_actor).to match( 'title': 'Procrastination Test', 'in_perform_later_actor_job': true )
+        }
+      end
+    end
+
+    context 'when called from PerformLaterActorJob' do
+      let(:attributes) { {title: 'Procrastination Test', 'in_perform_later_actor_job': true} }
+
+      it 'continues down the Actor stack' do
+        expect(terminator).to receive(:update).with(
+            having_attributes(:attributes => hash_excluding('in_perform_later_actor_job'))
+        )
+        expect { middleware.update(env) }.not_to have_enqueued_job(PerformLaterActorJob)
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context 'by default' do
+      it 'enqueues a PerformLaterActorJob' do
+        expect { middleware.destroy(env) }.to have_enqueued_job(PerformLaterActorJob).with {
+            |action, curation_concern, ability_user, attributes_for_actor|
+          expect(action).to eq 'destroy'
+          expect(curation_concern).to eq(@work).and(be_a PagedResource)
+          expect(ability_user).to eq @user
+          expect(attributes_for_actor).to match( 'title': 'Procrastination Test', 'in_perform_later_actor_job': true )
+        }
+      end
+    end
+
+    context 'when called from PerformLaterActorJob' do
+      let(:attributes) { {title: 'Procrastination Test', 'in_perform_later_actor_job': true} }
+
+      it 'continues down the Actor stack' do
+        expect(terminator).to receive(:destroy).with(
+            having_attributes(:attributes => hash_excluding('in_perform_later_actor_job'))
+        )
+        expect { middleware.destroy(env) }.not_to have_enqueued_job(PerformLaterActorJob)
+      end
+    end
+  end
+end

--- a/spec/jobs/perform_later_actor_job_spec.rb
+++ b/spec/jobs/perform_later_actor_job_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe PerformLaterActorJob do
+  let(:action) { 'arbitrary' }
+  let(:ability_user) { FactoryBot.create(:user) }
+  let(:attributes_for_actor) { {'title': 'A Title for Future Me'} }
+  let(:actor_stack) { double 'actor stack' }
+
+  describe '#perform' do
+    subject { described_class.perform_now(action, curation_concern, @ability_user, attributes_for_actor) }
+
+    before do
+      allow(Hyrax::CurationConcern).to receive(:actor).and_return actor_stack
+    end
+
+    context 'with a curation_concern class string' do
+      let(:curation_concern) { 'PagedResource' }
+
+      it 'calls the actor stack with an actor environment' do
+        expect(actor_stack).to receive(:arbitrary).with(instance_of(Hyrax::Actors::Environment))
+        subject
+      end
+
+      it 'calls the actor stack using a new curation_concern instance' do
+        expect(actor_stack).to receive(:arbitrary).with(having_attributes(:curation_concern => instance_of(PagedResource)))
+        subject
+      end
+    end
+
+    context 'with a curation_concern instance' do
+      let(:curation_concern) { FactoryBot.create(:paged_resource) }
+
+      it 'calls the actor stack with an actor environment' do
+        expect(actor_stack).to receive(:arbitrary).with(instance_of(Hyrax::Actors::Environment))
+        subject
+      end
+
+      it 'calls the actor stack using the existing curation_concern instance' do
+        expect(actor_stack).to receive(:arbitrary).with(having_attributes(:curation_concern => curation_concern))
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sends calls to the actor stack update and destroy methods to sidekiq for async processing.