### PR TITLE
WIP [ESSI-763] Image QC libraries for uploaded files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN groupadd -g ${GROUP_ID} essi && \
     apt-get update -qq && \
     apt-get install -y build-essential default-jre-headless libpq-dev nodejs \
       libreoffice-writer libreoffice-impress imagemagick unzip ghostscript && \
+# FIXME: install graphicsmagick, exiftool?
     apt-get install -y libtesseract-dev libleptonica-dev liblept5 tesseract-ocr -t testing \
     yarn && \
     rm -rf /var/lib/apt/lists/*

--- a/app/actors/essi/actors/quality_control_uploaded_files_actor.rb
+++ b/app/actors/essi/actors/quality_control_uploaded_files_actor.rb
@@ -1,0 +1,58 @@
+module ESSI
+  module Actors
+    class QualityControlUploadedFilesActor < Hyrax::Actors::AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        uploaded_file_ids = filter_file_ids(env.attributes.dig(:uploaded_files))
+        files = uploaded_files(uploaded_file_ids)
+        validate_files(files, env) && next_actor.create(env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        uploaded_file_ids = filter_file_ids(env.attributes.dig(:uploaded_files))
+        files = uploaded_files(uploaded_file_ids)
+        validate_files(files, env) && next_actor.update(env)
+      end
+
+      private
+        def validator_class
+          ESSI.config.dig(:essi, :image_qc, :validator).constantize rescue nil
+        end
+
+        # FIXME: make image QC configurable
+        # FIXME: only validate _image_ files
+        # FIXME: exempt branding images from QC?
+        def validate_files(files, env)
+          return true unless validator_class.present?
+          error_string = ""
+          files.each do |uf|
+            file_path = uf.file.to_s
+            filename = file_path.split('/').last
+            image = MiniMagick::Image.new(file_path)
+            metadata_reader = ImageQC::ImageMetadata.metadata_reader.new(image)
+            metadata_validator = ImageQC::ImageValidator::IUBImageValidator.new(metadata_reader)
+            errors = metadata_validator.validation_errors
+            if errors.any?
+              error_string = "File validation errors for #{filename}: #{errors.join('; ')}"
+              env.curation_concern.errors.add(:base, error_string)
+              break
+            end
+          end
+          error_string.blank?
+        end
+
+        def filter_file_ids(input)
+          Array.wrap(input).select(&:present?)
+        end
+
+        # Fetch uploaded_files from the database
+        def uploaded_files(uploaded_file_ids)
+          return [] if uploaded_file_ids.empty?
+          ::Hyrax::UploadedFile.find(uploaded_file_ids)
+        end
+    end
+  end
+end

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -162,7 +162,7 @@ default: &default
         title: Example title
         url: https://example.com
     image_qc:
-      validator: '' # ex: 'ImageQC::ImageValidator::IUBImageValidator'
+      validator: 'ImageQC::ImageValidator::IUBImageValidator'
         
 development:
   <<: *default

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -161,6 +161,8 @@ default: &default
       example_admin_set:
         title: Example title
         url: https://example.com
+    image_qc:
+      validator: '' # ex: 'ImageQC::ImageValidator::IUBImageValidator'
         
 development:
   <<: *default

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -168,7 +168,7 @@ default: &default
         title: Example title
         url: https://example.com
     image_qc:
-      validator: '' # ex: 'ImageQC::ImageValidator::IUBImageValidator'
+      validator: 'ImageQC::ImageValidator::IUBImageValidator'
 
 development:
   <<: *default

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -167,6 +167,8 @@ default: &default
       example_admin_set:
         title: Example title
         url: https://example.com
+    image_qc:
+      validator: '' # ex: 'ImageQC::ImageValidator::IUBImageValidator'
 
 development:
   <<: *default

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -35,5 +35,7 @@ Hyrax::Forms::CollectionForm.prepend Extensions::Hyrax::Forms::CollectionForm::F
 Hyrax::CollectionPresenter.prepend Extensions::Hyrax::CollectionPresenter::FileSetBackedBranding
 Hyrax::Dashboard::CollectionsController.prepend Extensions::Hyrax::Dashboard::CollectionsController::FileSetBackedBranding
 
+
 Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest, ESSI::Actors::PerformLaterActor
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesActor, ESSI::Actors::CreateWithRemoteFilesActor
+Hyrax::CurationConcern.actor_factory.insert ESSI::Actors::PerformLaterActor, ESSI::Actors::QualityControlUploadedFilesActor

--- a/lib/image_qc.rb
+++ b/lib/image_qc.rb
@@ -1,0 +1,2 @@
+module ImageQC
+end

--- a/lib/image_qc/image_metadata.rb
+++ b/lib/image_qc/image_metadata.rb
@@ -1,0 +1,15 @@
+module ImageQC
+  module ImageMetadata
+    def self.metadata_reader
+      cli = MiniMagick.configure { |config| config.cli }
+      case cli
+      when :graphicsmagick
+        GraphicsMagickMetadata
+      when :imagemagick
+        ImageMagickMetadata
+      else
+        raise "No metadata reader defined for CLI :#{cli}"
+      end
+    end
+  end
+end

--- a/lib/image_qc/image_metadata.rb
+++ b/lib/image_qc/image_metadata.rb
@@ -7,6 +7,8 @@ module ImageQC
         GraphicsMagickMetadata
       when :imagemagick
         ImageMagickMetadata
+      when :imagemagick7
+        raise "ImageMagick7 support not implemented"
       else
         raise "No metadata reader defined for CLI :#{cli}"
       end

--- a/lib/image_qc/image_metadata/graphics_magick_metadata.rb
+++ b/lib/image_qc/image_metadata/graphics_magick_metadata.rb
@@ -1,0 +1,59 @@
+module ImageQC
+  module ImageMetadata
+    class GraphicsMagickMetadata
+      attr_accessor :metadata
+
+      def initialize(image)
+        cli = MiniMagick.configure { |config| config.cli }
+        unless cli == :graphicsmagick
+          raise "This image metadata reader requires :graphicsmagick for the CLI but was given :#{cli}"
+        end
+        @metadata = image.details
+        @metadata['colorspace'] = image.colorspace
+        @metadata['page_count'] = image.pages.count
+      end
+
+      def format
+        metadata['Format'].match(/^(.*) \(/)[1] rescue nil
+      end
+
+      def format_description
+        metadata['Format'].match(/\((.*)\)/)[1] rescue nil
+      end
+
+      def compression
+        metadata['Compression']
+      end
+
+      def image_resolution
+        x, y = metadata['Geometry'].split('x').map(&:to_i)
+        { x: x, y: y }.with_indifferent_access
+      end
+
+      def print_resolution
+        dimensions, units = metadata['Resolution'].to_s.split
+        dimensions ||= '0x0'
+        x, y = dimensions.split('x').map(&:to_f)
+        units = begin
+          case units
+          when 'pixels/inch'
+             'PixelsPerInch'
+          when 'pixels/centimeter'
+             x = (x * 2.54).round
+             y = (y * 2.54).round
+             'PixelsPerInch'
+          when 'pixels'
+             'Undefined'
+          else
+             'Undefined'
+          end      
+        end
+        { units: units, x: x, y: y }.with_indifferent_access
+      end
+
+      def page_count
+        metadata['page_count']       
+      end
+    end
+  end
+end

--- a/lib/image_qc/image_metadata/graphics_magick_metadata.rb
+++ b/lib/image_qc/image_metadata/graphics_magick_metadata.rb
@@ -1,3 +1,4 @@
+# FIXME: this would require installing graphicsmagick in docker build
 module ImageQC
   module ImageMetadata
     class GraphicsMagickMetadata
@@ -8,9 +9,18 @@ module ImageQC
         unless cli == :graphicsmagick
           raise "This image metadata reader requires :graphicsmagick for the CLI but was given :#{cli}"
         end
+        # FIXME: rescue error reading 48-bit image?
         @metadata = image.details
         @metadata['colorspace'] = image.colorspace
         @metadata['page_count'] = image.pages.count
+
+        # get ICC from shell extraction as it's not returned by #details?
+
+        # FIXME: this will require installing exiftool in docker build
+        require 'open3'
+        require 'shellwords'
+        @metadata['icc_description'] = \
+          Open3.capture2("gm convert #{Shellwords.escape(image.path)} icc:- | exiftool - | grep 'Profile Description' | sed -e 's/^.*: //g'").first.chomp
       end
 
       def format
@@ -22,12 +32,30 @@ module ImageQC
       end
 
       def compression
+        return 'None' if metadata['Compression'] == 'No'
         metadata['Compression']
+      end
+
+      # FIXME: this returns different results than ImageMagick -- values, not just formatting
+      def color_bit_depth
+        metadata['Depth'].split.first.to_i
+      end
+
+      def icc_description
+        metadata['icc_description']
       end
 
       def image_resolution
         x, y = metadata['Geometry'].split('x').map(&:to_i)
         { x: x, y: y }.with_indifferent_access
+      end
+
+      def horizontal_resolution
+       image_resolution[:x]
+      end 
+
+      def vertical_resolution
+       image_resolution[:y]
       end
 
       def print_resolution
@@ -49,6 +77,18 @@ module ImageQC
           end      
         end
         { units: units, x: x, y: y }.with_indifferent_access
+      end
+
+      def print_resolution_units
+        print_resolution[:units]
+      end
+
+      def horizontal_print_resolution
+        print_resolution[:x]
+      end
+
+      def vertical_print_resolution
+        print_resolution[:y]
       end
 
       def page_count

--- a/lib/image_qc/image_metadata/image_magick_metadata.rb
+++ b/lib/image_qc/image_metadata/image_magick_metadata.rb
@@ -1,0 +1,51 @@
+module ImageQC
+  module ImageMetadata
+    class ImageMagickMetadata
+      attr_accessor :metadata
+
+      # image: ImageMagick::Image
+      def initialize(image)
+        cli = MiniMagick.configure { |config| config.cli }
+        unless cli == :imagemagick
+          raise "This image metadata reader requires :imagemagick for the CLI but was given :#{cli}"
+        end
+        @metadata = image.data
+        @metadata['page_count'] = image.pages.count
+      end
+
+      def format
+        metadata['format']
+      end
+
+      def format_description
+        metadata['formatDescription']
+      end
+
+      def compression
+        metadata['compression']
+      end
+
+      def image_resolution
+        { x: metadata.dig('geometry', 'width').to_i,
+          y: metadata.dig('geometry', 'height').to_i
+        }.with_indifferent_access
+      end
+
+      def print_resolution
+        units = metadata['units'] || 'Undefined'
+        x = metadata.dig('resolution', 'x').to_f
+        y = metadata.dig('resolution', 'y').to_f
+        if units == 'PixelsPerCentimeter'
+          x = (x * 2.54).round
+          y = (y * 2.54).round
+          units = 'PixelsPerInch'
+        end
+        { units: units, x: x, y: y }.with_indifferent_access
+      end
+
+      def page_count
+        metadata['page_count']     
+      end
+    end
+  end
+end

--- a/lib/image_qc/image_metadata/image_magick_metadata.rb
+++ b/lib/image_qc/image_metadata/image_magick_metadata.rb
@@ -9,6 +9,7 @@ module ImageQC
         unless cli == :imagemagick
           raise "This image metadata reader requires :imagemagick for the CLI but was given :#{cli}"
         end
+        # FIXME: rescue error reading 48-bit image?
         @metadata = image.data
         @metadata['page_count'] = image.pages.count
       end
@@ -25,10 +26,26 @@ module ImageQC
         metadata['compression']
       end
 
+      def color_bit_depth
+        metadata['baseDepth']
+      end
+
+      def icc_description
+        metadata.dig('profile', 'icc:description')
+      end
+
       def image_resolution
         { x: metadata.dig('geometry', 'width').to_i,
           y: metadata.dig('geometry', 'height').to_i
         }.with_indifferent_access
+      end
+
+      def horizontal_resolution
+       image_resolution[:x]
+      end
+
+      def vertical_resolution
+       image_resolution[:y]
       end
 
       def print_resolution
@@ -41,6 +58,18 @@ module ImageQC
           units = 'PixelsPerInch'
         end
         { units: units, x: x, y: y }.with_indifferent_access
+      end
+
+      def print_resolution_units
+        print_resolution[:units]
+      end
+
+      def horizontal_print_resolution
+        print_resolution[:x]
+      end
+
+      def vertical_print_resolution
+        print_resolution[:y]
       end
 
       def page_count

--- a/lib/image_qc/image_validator.rb
+++ b/lib/image_qc/image_validator.rb
@@ -1,0 +1,4 @@
+module ImageQC
+  module ImageValidator
+  end
+end

--- a/lib/image_qc/image_validator/customizable_image_validator.rb
+++ b/lib/image_qc/image_validator/customizable_image_validator.rb
@@ -1,0 +1,105 @@
+module ImageQC
+  module ImageValidator
+    class CustomizableImageValidator
+      attr_reader :metadata_reader, :validations
+
+      # Validations schema hash format:
+      # Keys are property names, with corresponding methods in @metadata_reader
+      # Values used for validation may be:
+      # - a single literal, for a required value; a convenient equivalent to a single-valued Array
+      # - an Array of literals, for a set of allowed values 
+      #     Note that an empty Array is equivalent to not providing the rule at all,
+      #     but may be useful for explicit clarity or overriding an inherited rule
+      # - a Symbol, for a method name to use for validation (instead of literals)
+      # - another validations schema Hash, for conditional validation (see below)
+      #
+      # Without a nested Hash as the value, a key/value pair runs a standalone rule, like:
+      #   print_resolution: :validate_600dpi_minimum # calls the specified method name
+      #   color_bit_depth: [1, 8, 24] # accepts a bit depth of 1, 8, or 24; rejects others
+      # whereas a nested Hash may apply case-specific if/then logic, such as:
+      #   color_bit_depth: { 1 => {}, 8 => {}, 24 => { icc_description: 'Adobe RGB (1998)' }
+      # which would still accept only 1/8/24-bit values as in the previous rule, but also:
+      # - for the 1-bit and 8-bit cases, apply no further rules (implied by the empty Hash)
+      # - for the 24-bit case, apply the provided icc_description validation rule
+      # 
+      # Hashes of if-then rules may be nested to theoretically arbitrary depth
+      DEFAULT_VALIDATIONS = { format: 'TIFF',
+                              compression: ['No', 'None', ''],
+                              page_count: [1],
+                              horizontal_resolution: [],
+                              vertical_resolution: [],
+                              color_bit_depth: [1, 8, 24]
+                            }
+
+      def initialize(metadata_reader, validations: {})
+        @metadata_reader = metadata_reader
+        @validations = default_validations.merge(validations)
+      end
+
+      def default_validations
+        self.class.const_get(:DEFAULT_VALIDATIONS) || {}
+      end
+
+      # Validation error messages, or an empty Array if none
+      #
+      # @return [String] invalidation error messages
+      def validation_errors
+        validate_properties(validations).select(&:present?)
+      end
+
+      private
+ 
+        # Retrieves results of validation checks against supplied schema
+        #
+        # @param [Hash] 
+        # @return [Array<Nil, String>] invalidation error messages, and nils for successes
+        def validate_properties(property_validations)
+          errors = []
+          property_validations.each do |property, values|
+            validator = to_validator(values)
+            unless validator.empty?
+              actual = metadata_reader.send(property)
+              errors << validate_property(property, actual, validator)
+              if values.is_a?(Hash) && values[actual].present?
+                errors += validate_properties(values[actual])
+              end
+            end
+          end
+          errors
+        end
+ 
+        # Converts input into format usable as a validator:
+        # - an Array of valid values
+        # - a Symbol of a validator method name
+        #
+        # @param values [Hash, String, Integer, Float, Array, Symbol] raw input
+        # @return [Array, Symbol] converted output
+        def to_validator(values)
+          case values
+          when Hash
+            values.keys
+          when String, Integer, Float
+            Array.wrap(values)
+          when Array, Symbol
+            values
+          else
+            raise "Invalid values type #{values.class}: #{values}"
+          end
+        end
+ 
+        # Validates a property given a method name or values list
+        #
+        # @param property [Symbol] the metadata reader property name
+        # @param actual [anything] the metadata reader value
+        # @param validator [Symbol, Array<String, Integer, Float>] a method name for validation, or Array of valid values
+        # @return [Nil, String] the invalidation message, if present
+        def validate_property(property, actual, validator)
+          return self.send(validator, property, actual) if validator.is_a? Symbol
+          unless validator.empty? || validator.include?(actual)
+            "#{property} was #{actual.blank? ? 'undefined' : actual} " \
+            "but must be#{' one of' unless validator.one?}: #{validator.join(', ')}" 
+          end
+        end
+    end
+  end
+end

--- a/lib/image_qc/image_validator/customizable_image_validator.rb
+++ b/lib/image_qc/image_validator/customizable_image_validator.rb
@@ -6,7 +6,9 @@ module ImageQC
       # Validations schema hash format:
       # Keys are property names, with corresponding methods in @metadata_reader
       # Values used for validation may be:
-      # - a single literal, for a required value; a convenient equivalent to a single-valued Array
+      # - a string or numeric literal, for a required value;
+      #   (functionally equivalent equivalent to a single-valued Array)
+      # - a single literal Range, for a range of allowed values
       # - an Array of literals, for a set of allowed values 
       #     Note that an empty Array is equivalent to not providing the rule at all,
       #     but may be useful for explicit clarity or overriding an inherited rule
@@ -69,18 +71,18 @@ module ImageQC
         end
  
         # Converts input into format usable as a validator:
-        # - an Array of valid values
+        # - an Array or Range of valid values
         # - a Symbol of a validator method name
         #
         # @param values [Hash, String, Integer, Float, Array, Symbol] raw input
-        # @return [Array, Symbol] converted output
+        # @return [Array, Range, Symbol] converted output
         def to_validator(values)
           case values
           when Hash
             values.keys
           when String, Integer, Float
             Array.wrap(values)
-          when Array, Symbol
+          when Array, Range, Symbol
             values
           else
             raise "Invalid values type #{values.class}: #{values}"
@@ -91,7 +93,7 @@ module ImageQC
         #
         # @param property [Symbol] the metadata reader property name
         # @param actual [anything] the metadata reader value
-        # @param validator [Symbol, Array<String, Integer, Float>] a method name for validation, or Array of valid values
+        # @param validator [Symbol, Array<String, Integer, Float>, Range] a method name for validation, or Array of valid values
         # @return [Nil, String] the invalidation message, if present
         def validate_property(property, actual, validator)
           return self.send(validator, property, actual) if validator.is_a? Symbol

--- a/lib/image_qc/image_validator/iub_image_validator.rb
+++ b/lib/image_qc/image_validator/iub_image_validator.rb
@@ -1,63 +1,32 @@
 module ImageQC
   module ImageValidator
-    class IUBImageValidator
-      attr_reader :metadata_reader
-      delegate :format, :compression, :page_count, :image_resolution, :print_resolution, to: :metadata_reader
+    class IUBImageValidator < CustomizableImageValidator
+      DEFAULT_VALIDATIONS = { format: 'TIFF',
+                              compression: ['No', 'None', ''],
+                              page_count: [1],
+                              horizontal_resolution: [400, 600, 2400, 3000],
+                              vertical_resolution: [400, 600, 2400, 3000],
+                              image_resolution: :validate_1000px_minimum,
+                              print_resolution: :validate_600dpi_minimum,
+                              color_bit_depth: { 1 => {},
+                                                 8 => {},
+                                                 24 => { icc_description: 'Adobe RGB (1998)' }
+                                               }
+                            }
 
-      def initialize(metadata_reader)
-        @metadata_reader = metadata_reader
+      def validate_600dpi_minimum(_property, print_resolution)
+        unless print_resolution['units'] == 'PixelsPerInch' &&
+               print_resolution['x'] >= 600 &&
+               print_resolution['y'] >= 600
+          "Print resolution must be a minimum of 600dpi, but was #{print_resolution['x']}x#{print_resolution['y']} with units of #{print_resolution['units']}"
+        end
       end
 
-      def validation_properties
-        [:format, :compression, :page_count, :image_resolution, :print_resolution]
-      end
-
-      def validation_errors
-        validation_properties.map do |property|
-          self.send("invalid_#{property}_message") unless self.send("valid_#{property}?")
-        end.select(&:present?)
-      end
-
-      def valid_format?
-        format == 'TIFF'
-      end
-
-      def invalid_format_message
-        "Format: must be TIFF, but was: #{format}"
-      end
-
-      def valid_compression?
-        compression == 'None'
-      end
-
-      def invalid_compression_message
-        "Compression: must be None, but was: #{compression}"
-      end
-
-      def valid_page_count?
-        page_count == 1
-      end
-
-      def invalid_page_count_message
-        "Page count: must be a single-page image, but had #{page_count} pages"
-      end
-
-      def valid_image_resolution?
-        image_resolution.values.select { |v| v >= 1000 }.any?
-      end
-
-      def invalid_image_resolution_message
-        "Image resolution: must be a minimum of 1000px on the longest edge, but current dimensions are #{image_resolution.values.join('x')}"
-      end
-
-      def valid_print_resolution?
-        print_resolution['units'] == 'PixelsPerInch' &&
-        print_resolution['x'] >= 600 &&
-        print_resolution['y'] >= 600
-      end
-
-      def invalid_print_resolution_message
-        "Print resolution: must be a minimum of 600dpi, but was #{print_resolution['x']}x#{print_resolution['y']} with units of #{print_resolution['units']}"
+      def validate_1000px_minimum(_property, image_resolution)
+        unless image_resolution['x'] >= 1000 ||
+               image_resolution['y'] >= 1000
+          "Image resolution must be a minimum of 1000px along the longer edge, but was #{image_resolution['x']}x#{image_resolution['y']}"
+          end
       end
     end
   end

--- a/lib/image_qc/image_validator/iub_image_validator.rb
+++ b/lib/image_qc/image_validator/iub_image_validator.rb
@@ -1,0 +1,64 @@
+module ImageQC
+  module ImageValidator
+    class IUBImageValidator
+      attr_reader :metadata_reader
+      delegate :format, :compression, :page_count, :image_resolution, :print_resolution, to: :metadata_reader
+
+      def initialize(metadata_reader)
+        @metadata_reader = metadata_reader
+      end
+
+      def validation_properties
+        [:format, :compression, :page_count, :image_resolution, :print_resolution]
+      end
+
+      def validation_errors
+        validation_properties.map do |property|
+          self.send("invalid_#{property}_message") unless self.send("valid_#{property}?")
+        end.select(&:present?)
+      end
+
+      def valid_format?
+        format == 'TIFF'
+      end
+
+      def invalid_format_message
+        "Format: must be TIFF, but was: #{format}"
+      end
+
+      def valid_compression?
+        compression == 'None'
+      end
+
+      def invalid_compression_message
+        "Compression: must be None, but was: #{compression}"
+      end
+
+      def valid_page_count?
+        page_count == 1
+      end
+
+      def invalid_page_count_message
+        "Page count: must be a single-page image, but had #{page_count} pages"
+      end
+
+      def valid_image_resolution?
+        image_resolution.values.select { |v| v >= 1000 }.any?
+      end
+
+      def invalid_image_resolution_message
+        "Image resolution: must be a minimum of 1000px on the longest edge, but current dimensions are #{image_resolution.values.join('x')}"
+      end
+
+      def valid_print_resolution?
+        print_resolution['units'] == 'PixelsPerInch' &&
+        print_resolution['x'] >= 600 &&
+        print_resolution['y'] >= 600
+      end
+
+      def invalid_print_resolution_message
+        "Print resolution: must be a minimum of 600dpi, but was #{print_resolution['x']}x#{print_resolution['y']} with units of #{print_resolution['units']}"
+      end
+    end
+  end
+end

--- a/lib/image_qc/image_validator/iupui_image_validator.rb
+++ b/lib/image_qc/image_validator/iupui_image_validator.rb
@@ -1,0 +1,16 @@
+module ImageQC
+  module ImageValidator
+    class IUPUIImageValidator
+      attr_reader :metadata_reader
+      delegate :format, :compression, :image_resolution, :print_resolution, to: :metadata_reader
+
+      def initialize(metadata_reader)
+        @metadata_reader = metadata_reader
+      end
+
+      def validation_errors
+        []
+      end
+    end
+  end
+end

--- a/lib/image_qc/image_validator/iupui_image_validator.rb
+++ b/lib/image_qc/image_validator/iupui_image_validator.rb
@@ -1,16 +1,10 @@
 module ImageQC
   module ImageValidator
-    class IUPUIImageValidator
-      attr_reader :metadata_reader
-      delegate :format, :compression, :image_resolution, :print_resolution, to: :metadata_reader
-
-      def initialize(metadata_reader)
-        @metadata_reader = metadata_reader
-      end
-
-      def validation_errors
-        []
-      end
+    class IUPUIImageValidator < CustomizableImageValidator
+      DEFAULT_VALIDATIONS = { format: 'TIFF',
+                              compression: [],
+                              page_count: [1]
+                            }
     end
   end
 end


### PR DESCRIPTION
Early post of a work-in-progress.  The first two commits are the actual libraries, which may be used in console.  The third commit adds an actor to allow using the qc stack in the UI, for the sake of convenience -- but long-term it's meant to be removed, and QC applied through other means (such as workflow, or possibly in BrowseEverything at time of upload, although it may not performant enough for that application to be practical.)

Overview of the current version of the proposed framework:
* a source-agnostic **metadata reader layer** provides image metadata
* a configurable **validation layer** runs **validation rules** against the available metadata

More detail:
* Metadata reader layer:
  * This is currently provided by classes that read from a MiniMagick::Image, but could also be a simple wrapper around metadata provided by other sources.  (For example, given a Hash of metadata from some 3rd-party tools, the wrapper could pass along method calls as `#fetch` calls to the Hash.)
  * there's support right now for running MiniMagick on either :imagemagick or :graphicsmagick CLI backends, but the :graphicsmagick output is a little incomplete and inconsistent compared to :imagemagick, and there's no support yet for an :imagemagick7 backend
* Validation layer:
  * Exists with the expectation that metadata properties (whether simple, or complex) are provided by the metadata reader layer, and this just applies validation rules against them
  * a validator has a set of default rules which may be extended/overriding by initializing with any new/modified rules
  * the validator can apply simple rules without needing any new methods
    * custom methods can be added when needed; the [IUB validator provides examples of custom methods](https://github.com/aploshay/essi/blob/ESSI-763_file_qc/lib/image_qc/image_validator/iub_image_validator.rb#L17-L29)
  * a validator could also bypass use of the metadata reader layer entirely, and pull validation results directly from some other source, such as ImageProc output files
* Validation rules:
  * exist as a Hash, which may be manually specified, sourced from a YAML file, etc.
  * are [documented along with a sample set in the CustomizableImageValidator](https://github.com/aploshay/essi/blob/ESSI-763_file_qc/lib/image_qc/image_validator/customizable_image_validator.rb#L6-L32), and other working examples are provided in the [IUBImageValidator](https://github.com/aploshay/essi/blob/ESSI-763_file_qc/lib/image_qc/image_validator/iub_image_validator.rb#L4-L15) and [IUPUIImageValidator](https://github.com/aploshay/essi/blob/ESSI-763_file_qc/lib/image_qc/image_validator/iupui_image_validator.rb#L4-L7)
