### PR TITLE
[ESSI-761] Apply jp2 image conversion, if configured

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -22,16 +22,21 @@ module Hyrax
       # @see IngestJob
       # @todo create a job to monitor the temp directory (or in a multi-worker system, directories!) to prune old files that have made it into the repo
       def ingest_file(io)
-        # FIXME: pass along mimetype, filename options?
+        infer_source_metadata_identifier(file_set, io)
         if store_files?
+          transform_to_jp2(io) if transform_to_jp2?
+
           Hydra::Works::AddFileToFileSet.call(file_set,
                                               io,
                                               relation,
                                               versioning: false)
-        else
+        end
+        if store_masters?
+          url = master_url_for_file_set(file_set) || master_file_service_url
+          file_use = (store_files? ? :preservation_master_file : :original_file)
           Hydra::Works::AddExternalFileToFileSet.call(file_set,
-                                                      master_file_service_url,
-                                                      relation,
+                                                      url,
+                                                      file_use,
                                                       versioning: false)
         end
         return false unless file_set.save
@@ -70,12 +75,54 @@ module Hyrax
           store_files? && !file_set.collection_branding?
         end
 
+        def infer_source_metadata_identifier(file_set, io)
+          if file_set.source_metadata_identifier.blank? && io.path.present?
+            file_set.source_metadata_identifier = File.basename(io.path, File.extname(io.path))
+          end
+        end
+
+        def master_file_service_url
+          ESSI.config.dig :essi, :master_file_service_url
+        end
+
+        def master_url_for_file_set(file_set)
+          return nil unless master_file_service_url.present?
+          return nil unless file_set.source_metadata_identifier.present?
+          master_file_service_url + '/' + file_set.source_metadata_identifier
+        end
+
         def store_files?
           ESSI.config.dig :essi, :store_original_files
         end
-    
-        def master_file_service_url
-          ESSI.config.dig :essi, :master_file_service_url
+
+        def store_masters?
+          master_file_service_url.present?
+        end
+
+        def transform_to_jp2?
+          ESSI.config.dig :essi, :store_files_as_jp2
+        end
+
+        def transform_to_jp2(io)
+          # FIXME: only transform tiffs?
+          return unless io.path.match /\.tif+$/
+          original_path = io.path
+          dir = Dir.mktmpdir
+          new_file = File.basename(original_path).sub(/\.tif+$/, '.jp2')
+          new_path = "#{dir}/#{new_file}"
+          if Hydra::Derivatives.kdu_compress_path.present?
+            url = URI("file://#{new_path}").to_s
+            # FIXME: chokes on compressed tiffs
+            # FIXME: chokes on small tiffs that generate a negative compression value
+            Hydra::Derivatives::Jpeg2kImageDerivatives.create(original_path, { outputs: [ url: url, recipe: :default ]})
+          else
+            MiniMagick::Tool::Convert.new do |convert|
+              convert << original_path
+              convert << new_path
+            end
+          end
+          io.path = new_path
+          io.mime_type = MIME::Types.type_for('jp2').first.to_s
         end
     end
   end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -4,6 +4,8 @@ class FileSet < ActiveFedora::Base
   include ESSI::RemoteLookupMetadata
   include ::Hyrax::FileSetBehavior
 
+  directly_contains_one :preservation_master_file, through: :files, type: ::RDF::URI('http://pcdm.org/use#PreservationMasterFile'), class_name: 'Hydra::PCDM::File'
+
   self.indexer = ESSI::FileSetIndexer
 
   def collection_branding_info

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -71,8 +71,9 @@ default: &default
     iiif_host: essi.docker  # riiif only
     notifier_email: example@test.test
     store_original_files: true
+    store_files_as_jp2: true
+    kdu_compress_path: 'opj_compress' # set as kdu_compress or opj_compress, or '' to use ImageMagick
     master_file_service_url: http://purl.dlib.indiana.edu/iudl/variations/master
-    access_file_service_url: http://purl.dlib.indiana.edu/iudl/variations/access
     purl_redirect_url: http://server1.variations2.indiana.edu/cgi-bin/access?%s
     ocr_language: [eng]
     create_ocr_files: true

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -69,8 +69,9 @@ default: &default
     iiif_host: localhost:3000  # riiif only
     notifier_email: example@test.test
     store_original_files: true
+    store_files_as_jp2: true
+    kdu_compress_path: 'opj_compress' # set as kdu_compress or opj_compress, or '' to use ImageMagick
     master_file_service_url: http://purl.dlib.indiana.edu/iudl/variations/master
-    access_file_service_url: http://purl.dlib.indiana.edu/iudl/variations/access
     purl_redirect_url: http://server1.variations2.indiana.edu/cgi-bin/access?%s
     skip_derivatives: false
     derivatives_folder: false

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -40,3 +40,9 @@ Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::SourceMetad
 
 Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest, ESSI::Actors::PerformLaterActor
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesActor, ESSI::Actors::CreateWithRemoteFilesActor
+
+# .jp2 conversion settings
+Hydra::Derivatives.kdu_compress_path = ESSI.config.dig(:essi, :kdu_compress_path)
+Hydra::Derivatives.kdu_compress_recipes =
+  Hydra::Derivatives.kdu_compress_recipes.with_indifferent_access
+                    .merge(ESSI.config.dig(:essi, :jp2_recipes) || {})


### PR DESCRIPTION
Some notes:
* I took out the kakadu Docker stuff, and [stashed it in a gist](https://gist.github.com/aploshay/10e4fa4c410c00577bd9b80b7b70f6a4).
* The ingest logic now attempts to infer the `source_metadata_identifier` value from a `FileSet` from the uploaded filename
* This also includes a change to the logic on storing a link to preservation masters -- whether to do it, and how.  
  * Previously, this was an either/or against the config value for `store_original_files` -- now, it looks at whether a value is present for `master_file_service_url`, and infers the presence of a value to indicate storing a link to masters.  Consequences are:
    * You'll get empty `FileSet` objects unless you set at _least_ one of `store_original_files`, `master_file_service_url`; presumably you don't want that, and should set either, or both
    * If storing a link to the master, the file use is still `original_file` if we're not storing original files, _or_ `preservation_master_file` if we are storing both original files and masters.  (Consistently storing the link as `preservation_master_file` is problematic because there are baked-in assumptions that a `FileSet` has an `original_file` -- so it switches to that use when `store_original_files` is false.)