### PR TITLE
[ESSI-921] Pass volume, page (m, cv) arguments to universal viewer

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -59,7 +59,7 @@ class PurlController < ApplicationController
         subfolder = klass.to_s.pluralize.underscore
         url = "#{request.protocol}#{request.host_with_port}" \
           "#{config.relative_url_root}/concern/#{subfolder}/#{solr_hit.id}"
-        url += "#?m=#{volume}&cv=#{page}" if volume.positive? || page.positive?
+        url += "?m=#{volume}&cv=#{page}" if volume.positive? || page.positive?
       rescue StandardError
         url = rescue_url
       end
@@ -78,11 +78,12 @@ class PurlController < ApplicationController
       end
     end
 
+    # remove any volume, page arguments before adding manifest call
     def manifest_url(url)
       if url == rescue_url
         nil
       else
-        url = url + '/manifest'
+        url = url.sub(/\?.*$/, '') + '/manifest'
       end
     end
 

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,7 +1,8 @@
 <%# override file ported from Hyrax master (slated for 3.x) @todo remove on upgrade to Hyrax 3.x %>
+<%# @todo refactor or recreate volume (m), page (cv) argument passing %>
 <div class="viewer-wrapper <%= "fullscreen" if local_assigns.fetch(:fullscreen, false) %>">
   <iframe
-    src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url([main_app, :manifest, presenter], { locale: nil }) %>&config=<%= universal_viewer_config_url %>" 
+    src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url([main_app, :manifest, presenter], { locale: nil }) %>&config=<%= universal_viewer_config_url %>&m=<%= params[:m].to_i %>&cv=<%= params[:cv].to_i %>" 
     allowfullscreen="true" 
     frameborder="0" 
   ></iframe>

--- a/spec/controllers/purl_controller_spec.rb
+++ b/spec/controllers/purl_controller_spec.rb
@@ -47,18 +47,20 @@ describe PurlController do
           let(:format) { 'iiif' }
 
           it 'redirects to the IIIF manifest' do
-            expect(response).to redirect_to target_path + '/manifest'
+            expect(response).to redirect_to manifest_path
           end
         end
       end
       context 'when for a PagedResource' do
         let(:id) { paged_resource.source_metadata_identifier }
         let(:target_path) { paged_resource_path }
+        let(:manifest_path) { paged_resource_path + '/manifest' }
         include_examples 'responses for matches'
       end
       context 'when for a specific page' do
         let(:id) { paged_resource.source_metadata_identifier + '-9-0042' }
-        let(:target_path) { paged_resource_path + '#?m=8&cv=41' }
+        let(:target_path) { paged_resource_path + '?m=8&cv=41' }
+        let(:manifest_path) { paged_resource_path + '/manifest' }
 
         include_examples 'responses for matches'
       end


### PR DESCRIPTION
In pumpkin, you can like to a specific page with the 'cv' argument:
https://pages.dlib.indiana.edu/concern/scanned_resources/ddv13zt864#?m=0&cv=60&c=0&s=0&xywh=0%2C-547%2C7449%2C6092
it will (1) load up the specified page, and
(2) you'll notice that if you click around to different pages in UV, the URL will live-update the cv value to reflect the page currently being displayed.

ESSI currently has neither behavior.

This PR adds the first behavior, only.