### PR TITLE
WIP [ESSI-120] On Work show page, provide link to catalog

### DIFF
--- a/app/presenters/concerns/essi/presents_remote_metadata.rb
+++ b/app/presenters/concerns/essi/presents_remote_metadata.rb
@@ -1,0 +1,5 @@
+module ESSI
+  module PresentsRemoteMetadata
+    delegate :source_metadata_identifier, :source_metadata, to: :solr_document
+  end
+end

--- a/app/presenters/hyrax/bib_record_presenter.rb
+++ b/app/presenters/hyrax/bib_record_presenter.rb
@@ -4,6 +4,7 @@ module Hyrax
   class BibRecordPresenter < Hyrax::WorkShowPresenter
     include ESSI::PresentsNumPages
     include ESSI::PresentsOCR
+    include ESSI::PresentsRemoteMetadata
     include ESSI::PresentsStructure
     delegate :series, to: :solr_document
   end

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -3,6 +3,7 @@
 module Hyrax
   class PagedResourcePresenter < Hyrax::WorkShowPresenter
     include ESSI::PresentsOCR
+    include ESSI::PresentsRemoteMetadata
     include ESSI::PresentsStructure
     delegate :series, :viewing_direction, :viewing_hint,
              to: :solr_document

--- a/app/views/hyrax/base/_misc_links.html.erb
+++ b/app/views/hyrax/base/_misc_links.html.erb
@@ -1,3 +1,4 @@
 <h2>
+  <%= link_to(t('services.metadata_link') + t('services.metadata'), ESSI.config.dig(:essi, :metadata, :url).to_s % @presenter.source_metadata_identifier, class: "fa fa-external-link link_font") if @presenter.try(:source_metadata_identifier).present? %>
   <%= link_to( t('hyrax.works.link.large_viewer'), polymorphic_path([main_app, @presenter], format: :uv), class: "fa fa-external-link link_font") %>
 </h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@
 en:
   hello: "Hello world"
   services:
+    metadata_link: "View record in "
     metadata: "IUCAT"
     remote_metadata:
       invalid_identifier: "The provided Source Metadata ID value was saved, but not used for remote metadata lookup as it was did not pass validation.  "

--- a/spec/presenters/hyrax/bib_record_presenter_spec.rb
+++ b/spec/presenters/hyrax/bib_record_presenter_spec.rb
@@ -3,5 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::BibRecordPresenter do
-  # "Add your tests here"
+  subject { described_class.new(double, double) }
+
+  include_examples "presents remote metadata" do
+    let(:presenter) { subject }
+  end
 end

--- a/spec/presenters/hyrax/paged_resource_presenter_spec.rb
+++ b/spec/presenters/hyrax/paged_resource_presenter_spec.rb
@@ -1,10 +1,12 @@
-# Generated via
-#  `rails generate hyrax:work PagedResource`
 require 'rails_helper'
 
 RSpec.describe Hyrax::PagedResourcePresenter do
 
   subject { described_class.new(double, double) }
+
+  include_examples "presents remote metadata" do
+    let(:presenter) { subject } 
+  end
 
   context "When the resource has extracted text indexed for searching" do
     it "responds to search_service" do

--- a/spec/support/shared_examples/presenter_remote_metadata.rb
+++ b/spec/support/shared_examples/presenter_remote_metadata.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples "presents remote metadata" do
+  [:source_metadata_identifier, :source_metadata].each do |method|
+    describe "##{method}" do
+      it "delegates to solr_document" do
+        expect(presenter.solr_document).to receive(method)
+        presenter.send(method)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For work types that have a `source_metadata_identifier` (currently BibRecord, PagedResource), and a value populated, provides an IUCAT link.

UPDATE: changing to WIP pending completion of the new subtask that came out of discussion with nhomenda and @randalldfloyd 