### PR TITLE
essi-910 Generate pdfs 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ gem 'iiif_manifest'
 gem 'i18n-js'
 gem 'bagit'
 gem 'validatable'
+gem 'prawn'
 
 # Bulk Import / Export
 #TODO: N8 specific - use local for dev; use github for test/staging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,10 +611,14 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
+    pdf-core (0.7.0)
     phantomjs (2.1.1.0)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.2)
+    prawn (2.2.2)
+      pdf-core (~> 0.7.0)
+      ttfunk (~> 1.5)
     public_suffix (4.0.4)
     pul_uv_rails (2.0.1)
     puma (3.12.6)
@@ -871,6 +875,7 @@ GEM
     tilt (2.0.8)
     tinymce-rails (4.9.6)
       railties (>= 3.1.1)
+    ttfunk (1.6.2.1)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -948,6 +953,7 @@ DEPENDENCIES
   mysql2
   omniauth
   omniauth-iu-cas
+  prawn
   puma
   rails (~> 5.1.6)
   rails-controller-testing

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -27,26 +27,28 @@ module Hyrax
         disposition: 'inline'
     end
 
-     private
+    private
 
-     def generate_pdf(resource)
-       path = Rails.root.join('tmp', 'pdfs')
-       FileUtils.mkdir_p path unless File.exist?(path)
-       file_name = "#{resource.id}.pdf"
-       pdf_file = nil
-       file_path = Rails.root.join('tmp', 'pdfs', file_name)
-       File.delete(file_path) if File.exists?(file_path)
-       Prawn::Document.generate(Rails.root.join('tmp', 'pdfs', file_name)) do |pdf|
-         resource.file_sets.each do |fs|
-           pdf_file = Tempfile.create(fs.original_file.file_name.first, path) do |file|
-             file.binmode
-             file.write(fs.original_file.content)
-             pdf.image(file)
-           end
-         end
-       end
+    def generate_pdf(resource)
+      path = Rails.root.join('tmp', 'pdfs')
+      FileUtils.mkdir_p path unless File.exist?(path)
+      file_name = "#{resource.id}.pdf"
+      pdf_file = nil
+      file_path = Rails.root.join('tmp', 'pdfs', file_name)
+      File.delete(file_path) if File.exists?(file_path)
+      Prawn::Document.generate(Rails.root.join('tmp', 'pdfs', file_name), margin: [0,0,0,0]) do |pdf|
+        num_of_images = resource.file_sets.count
+        resource.file_sets.each.with_index(1) do |fs, i|
+          pdf_file = Tempfile.create(fs.original_file.file_name.first, path) do |file|
+            file.binmode
+            file.write(fs.original_file.content)
+            pdf.image(file, fit: [612, pdf.y])
+          end
+          pdf.start_new_page unless num_of_images == i
+        end
+      end
 
-       { path: file_path, file_name: file_name }
-     end
+      { path: file_path, file_name: file_name }
+    end
   end
 end

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -16,5 +16,27 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::PagedResourcePresenter
+
+    def pdf
+      # PagedResourcePDF.new(presenter, quality: params[:pdf_quality]).render(pdf_hyrax_paged_resource_path)
+      # redirect_to main_app.download_path(presenter)
+
+      resource = PagedResource.find(params[:id])
+      # TODO: if tmp/pdfs/ doesn't exist, mkdir it
+      Prawn::Document.generate(Rails.root.join("tmp", "pdfs", "#{resource.id}.pdf")) do |pdf|
+        resource.file_sets.each do |fs|
+          Tempfile.create(fs.original_file.file_name.first, binmode: true) do |file|
+            file.write(fs.original_file.content)
+            pdf.image file.path
+          end
+        end
+      end
+    end
+
+    # private
+
+    # def pdf_type
+      # "#{params[:pdf_quality]}-pdf"
+    # end
   end
 end

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -18,25 +18,29 @@ module Hyrax
     self.show_presenter = Hyrax::PagedResourcePresenter
 
     def pdf
-      # PagedResourcePDF.new(presenter, quality: params[:pdf_quality]).render(pdf_hyrax_paged_resource_path)
+      # PagedResourcePDF.new(presenter).render(pdf_hyrax_paged_resource_path)
       # redirect_to main_app.download_path(presenter)
 
       resource = PagedResource.find(params[:id])
-      # TODO: if tmp/pdfs/ doesn't exist, mkdir it
-      Prawn::Document.generate(Rails.root.join("tmp", "pdfs", "#{resource.id}.pdf")) do |pdf|
-        resource.file_sets.each do |fs|
-          Tempfile.create(fs.original_file.file_name.first, binmode: true) do |file|
-            file.write(fs.original_file.content)
-            pdf.image file.path
-          end
-        end
-      end
+      generate_pdf(resource)
     end
 
-    # private
+     private
 
-    # def pdf_type
-      # "#{params[:pdf_quality]}-pdf"
-    # end
+     def generate_pdf(resource)
+       # TODO: if tmp/pdfs/ doesn't exist, mkdir it
+       path = Rails.root.join('tmp', 'pdfs')
+       FileUtils.mkdir_p path unless File.exist?(path)
+       pdf_file = Prawn::Document.generate(Rails.root.join("tmp", "pdfs", "#{resource.id}.pdf")) do |pdf|
+         resource.file_sets.each do |fs|
+           Tempfile.create(fs.original_file.file_name.first, binmode: true) do |file|
+             file.write(fs.original_file.content)
+             pdf.image file.path
+           end
+         end
+       end
+       pdf_file
+       raise 'hell'
+     end
   end
 end

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -19,28 +19,33 @@ module Hyrax
 
     def pdf
       # PagedResourcePDF.new(presenter).render(pdf_hyrax_paged_resource_path)
-      # redirect_to main_app.download_path(presenter)
-
       resource = PagedResource.find(params[:id])
       generate_pdf(resource)
+
+      #raise 'hell'
+      redirect_to hyrax.download_path(presenter)
     end
 
      private
 
      def generate_pdf(resource)
-       # TODO: if tmp/pdfs/ doesn't exist, mkdir it
        path = Rails.root.join('tmp', 'pdfs')
        FileUtils.mkdir_p path unless File.exist?(path)
-       pdf_file = Prawn::Document.generate(Rails.root.join("tmp", "pdfs", "#{resource.id}.pdf")) do |pdf|
+       file_name = "#{resource.id}.pdf"
+       pdf_file = nil
+       Prawn::Document.generate(Rails.root.join("tmp", "pdfs", file_name)) do |pdf|
          resource.file_sets.each do |fs|
-           Tempfile.create(fs.original_file.file_name.first, binmode: true) do |file|
+           # TODO: check if tmpfile exists
+           pdf_file = Tempfile.create(fs.original_file.file_name.first, path) do |file|
+             file.binmode
              file.write(fs.original_file.content)
-             pdf.image file.path
+             pdf.image(file)
            end
          end
        end
+
+      raise 'hell'
        pdf_file
-       raise 'hell'
      end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       member do
         get :structure
         post :structure, action: :save_structure
+        get '/pdf', action: :pdf, as: :pdf
       end
     end
   end


### PR DESCRIPTION
JIRA: https://bugs.dlib.indiana.edu/browse/ESSI-910

**//TODO:**

- [ ] Handle image size
- [ ] Create a service and specs for generating the pdf. The service will pass the path of the generated pdf to the pdf endpoint of the paged_resource controller. Use a redirect for the hyrax downloads path to render the pdf for download in the browser. 