### PR TITLE
Essi-357 Use buster docker image, save dev rails cache 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN bundle install -j 2 --retry=3
 
 COPY --chown=essi:essi . .
 
+RUN mkdir /app/tmp/cache
+
 ENV RAILS_LOG_TO_STDOUT true
 
 ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
 # system dependency image
-FROM ruby:2.5-stretch AS essi-sys-deps
+FROM ruby:2.5-buster AS essi-sys-deps
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
 RUN groupadd -g ${GROUP_ID} essi && \
     useradd -m -l -g essi -u ${USER_ID} essi && \
-    apt-get update -qq && \
-    apt-get -y install apt-transport-https && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    echo "deb http://http.us.debian.org/debian/ testing non-free contrib main" | tee -a /etc/apt/sources.list && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get update -qq && \
     apt-get install -y build-essential default-jre-headless libpq-dev nodejs \
-      libreoffice-writer libreoffice-impress imagemagick unzip ghostscript && \
-    apt-get install -y libtesseract-dev libleptonica-dev liblept5 tesseract-ocr -t testing \
-    yarn && \
+      libreoffice-writer libreoffice-impress imagemagick unzip ghostscript \
+      libtesseract-dev libleptonica-dev liblept5 tesseract-ocr \
+      yarn libopenjp2-tools && \
     rm -rf /var/lib/apt/lists/*
 RUN yarn && \
     yarn config set no-progress && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ x-app:
     - .env.development
     - .env
   volumes:
-    - .:/app
+    - .:/app:cached
+    - rails_cache:/app/tmp/cache
     - ./config/essi_config.docker.yml:/run/secrets/essi_config.yml
   depends_on:
     - redis
@@ -43,7 +44,7 @@ services:
 
   app:
     << : *default-app
-    command: bash -l -c "rake db:migrate db:seed && yarn install && bundle exec puma -b tcp://0.0.0.0:3000"
+    command: bash -l -c "bundle exec rake db:migrate db:seed yarn:install && bundle exec puma -b tcp://0.0.0.0:3000"
     environment:
       VIRTUAL_HOST: essi.docker
       VIRTUAL_PORT: 3000
@@ -154,3 +155,4 @@ volumes:
   redis:
   solr:
   minio:
+  rails_cache:


### PR DESCRIPTION
This uses the debian buster image as the base for the essi docker image. Previously it was pinned to stretch because IU CAS SSL was incompatible.

This also adds an enhancement to the dev docker compose stack that saves the rails application cache between restarts.