### PR TITLE
Essi 913 pdf download setting

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,4 @@ RAILS_LOG_TO_STDOUT=true
 REGISTRY_HOST=registry.gitlab.com
 REGISTRY_URI=/notch8/essi
 TAG=dev
+ALLOW_PDF_DOWNLOAD=true

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -18,6 +18,7 @@ module Hyrax
     self.show_presenter = Hyrax::PagedResourcePresenter
 
     def pdf
+      return unless ESSI.config.dig(:essi, :allow_pdf_download) && current_ability.current_user.admin?
       resource = PagedResource.find(params[:id])
       pdf = ESSI::GeneratePdfService.new(resource).generate if resource
 

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -23,7 +23,7 @@ module Hyrax
       renderings = []
       if rendering_ids.present?
         rendering_ids.each do |file_set_id|
-          renderings << manifest_helper.build_pdf_rendering(file_set_id)
+          renderings << manifest_helper.build_pdf_rendering(file_set_id) if ESSI.config.dig(:essi, :allow_pdf_download)
         end
       end
       renderings.flatten.uniq

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -23,7 +23,7 @@ module Hyrax
       renderings = []
       if rendering_ids.present?
         rendering_ids.each do |file_set_id|
-          renderings << manifest_helper.build_pdf_rendering(file_set_id) if ESSI.config.dig(:essi, :allow_pdf_download)
+          renderings << manifest_helper.build_pdf_rendering(file_set_id) if ESSI.config.dig(:essi, :allow_pdf_download) && current_ability.current_user.admin?
         end
       end
       renderings.flatten.uniq

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -78,7 +78,7 @@ default: &default
     create_ocr_files: true
     index_ocr_files: true
     create_word_boundaries: true
-    allow_pdf_download: false
+    allow_pdf_download: <%= ENV["ALLOW_PDF_DOWNLOAD"] || false %>
     manifest_builder:
       see_also_hash:
         id: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=%s&recordSchema=marcxml&version=1.1

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -78,7 +78,7 @@ default: &default
     create_ocr_files: true
     index_ocr_files: true
     create_word_boundaries: true
-    allow_pdf_download: false
+    allow_pdf_download: <%= ENV["ALLOW_PDF_DOWNLOAD"] || false %>
     link_banners: false
     bagit:
       default_upload_dropbox: <%= Rails.root.join("staged_files/uploaded") %>

--- a/spec/presenters/hyrax/paged_resource_presenter_spec.rb
+++ b/spec/presenters/hyrax/paged_resource_presenter_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Hyrax::PagedResourcePresenter do
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:request) { double(host: 'example.org', base_url: 'http://example.org') }
   let(:user_key) { 'a_user_key' }
+  let(:current_user) { FactoryBot.build(:admin) }
 
   let(:attributes) do
     { "id" => '888888',
@@ -15,7 +16,7 @@ RSpec.describe Hyrax::PagedResourcePresenter do
       "date_created_tesim" => ['an unformatted date'],
       "depositor_tesim" => user_key }
   end
-  let(:ability) { double Ability }
+  let(:ability) { Ability.new(current_user) }
   let(:presenter) { described_class.new(solr_document, ability, request) }
 
   subject { described_class.new(double, double) }
@@ -32,11 +33,11 @@ RSpec.describe Hyrax::PagedResourcePresenter do
       before do
         Hydra::Works::AddFileToFileSet.call(work.file_sets.first,
                                             File.open(fixture_path + '/world.png'), :original_file)
+        allow(current_user).to receive(:admin?).and_return(true)
       end
 
       it "returns a hash containing the pdf rendering information" do
         pdf_rendering_hash = {"@id"=>"/concern/paged_resources/#{work.id}/pdf", "label"=>"Download as PDF", "format"=>"application/pdf"}
-
         expect(subject).to be_an Array
         expect(subject).to include(pdf_rendering_hash)
       end

--- a/spec/presenters/hyrax/paged_resource_presenter_spec.rb
+++ b/spec/presenters/hyrax/paged_resource_presenter_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Hyrax::PagedResourcePresenter do
             allow(current_user).to receive(:admin?).and_return(false)
           end
 
-          it 'returns a hash containing the pdf rendering information' do
+          it 'returns a hash without the pdf rendering information' do
             pdf_rendering_hash = {"@id"=>"/concern/paged_resources/#{work.id}/pdf", "label"=>"Download as PDF", "format"=>"application/pdf"}
             expect(subject).to be_an Array
             expect(subject).not_to include(pdf_rendering_hash)
@@ -65,7 +65,30 @@ RSpec.describe Hyrax::PagedResourcePresenter do
       end
 
       context 'when allow_pdf_download config is false' do
+        before do
+          ESSI.config[:essi][:allow_pdf_download] = false
+        end
+        context 'when user is an admin' do
+          before do
+            allow(current_user).to receive(:admin?).and_return(true)
+          end
+          it 'returns a hash without the pdf rendering information' do
+            pdf_rendering_hash = {"@id"=>"/concern/paged_resources/#{work.id}/pdf", "label"=>"Download as PDF", "format"=>"application/pdf"}
+            expect(subject).to be_an Array
+            expect(subject).not_to include(pdf_rendering_hash)
+          end
+        end
+        context 'when user is not an admin' do
+          before do
+            allow(current_user).to receive(:admin?).and_return(false)
+          end
 
+          it 'returns a hash without the pdf rendering information' do
+            pdf_rendering_hash = {"@id"=>"/concern/paged_resources/#{work.id}/pdf", "label"=>"Download as PDF", "format"=>"application/pdf"}
+            expect(subject).to be_an Array
+            expect(subject).not_to include(pdf_rendering_hash)
+          end
+        end
       end
     end
   end

--- a/spec/presenters/hyrax/paged_resource_presenter_spec.rb
+++ b/spec/presenters/hyrax/paged_resource_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::PagedResourcePresenter do
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:request) { double(host: 'example.org', base_url: 'http://example.org') }
   let(:user_key) { 'a_user_key' }
-  let(:current_user) { FactoryBot.build(:admin) }
+  let(:current_user) { create :admin }
 
   let(:attributes) do
     { "id" => '888888',
@@ -33,13 +33,39 @@ RSpec.describe Hyrax::PagedResourcePresenter do
       before do
         Hydra::Works::AddFileToFileSet.call(work.file_sets.first,
                                             File.open(fixture_path + '/world.png'), :original_file)
-        allow(current_user).to receive(:admin?).and_return(true)
       end
 
-      it "returns a hash containing the pdf rendering information" do
-        pdf_rendering_hash = {"@id"=>"/concern/paged_resources/#{work.id}/pdf", "label"=>"Download as PDF", "format"=>"application/pdf"}
-        expect(subject).to be_an Array
-        expect(subject).to include(pdf_rendering_hash)
+      context 'when allow_pdf_download config is true' do
+        before do
+          ESSI.config[:essi][:allow_pdf_download] = true
+        end
+        context 'when user is an admin' do
+          before do
+            allow(current_user).to receive(:admin?).and_return(true)
+          end
+
+          it 'returns a hash containing the pdf rendering information' do
+            pdf_rendering_hash = {"@id"=>"/concern/paged_resources/#{work.id}/pdf", "label"=>"Download as PDF", "format"=>"application/pdf"}
+            expect(subject).to be_an Array
+            expect(subject).to include(pdf_rendering_hash)
+          end
+        end
+
+        context 'when user is not an admin' do
+          before do
+            allow(current_user).to receive(:admin?).and_return(false)
+          end
+
+          it 'returns a hash containing the pdf rendering information' do
+            pdf_rendering_hash = {"@id"=>"/concern/paged_resources/#{work.id}/pdf", "label"=>"Download as PDF", "format"=>"application/pdf"}
+            expect(subject).to be_an Array
+            expect(subject).not_to include(pdf_rendering_hash)
+          end
+        end
+      end
+
+      context 'when allow_pdf_download config is false' do
+
       end
     end
   end


### PR DESCRIPTION
Add a setting to the ESSI config to turn on/off pdf downloads
Make sure current user is admin before showing pdf download button

Pull Request https://github.com/IU-Libraries-Joint-Development/essi/pull/184 must be merged before this PR

Both conditions met:
![image](https://user-images.githubusercontent.com/18175797/85324759-3d450080-b47f-11ea-8289-e5375423cf3c.png)

One or both conditions not met:
![image](https://user-images.githubusercontent.com/18175797/85324782-48982c00-b47f-11ea-9297-2a202faf3b98.png)
