### PR TITLE
hot fix: non admin users should be able to download pdf if setting is true

### DIFF
--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -19,13 +19,15 @@ module Hyrax
 
     def pdf
       resource = PagedResource.find(params[:id])
-      return unless resource.allow_pdf_download == "true" || current_ability.current_user.admin?
-      pdf = ESSI::GeneratePdfService.new(resource).generate if resource
 
-      send_file pdf[:file_path],
-                filename: pdf[:file_name],
-                type: 'application/pdf',
-                disposition: 'inline'
+      if (resource && resource.allow_pdf_download == "true") || (resource && current_user.admin?)
+        pdf = ESSI::GeneratePdfService.new(resource).generate
+
+        send_file pdf[:file_path],
+          filename: pdf[:file_name],
+          type: 'application/pdf',
+          disposition: 'inline'
+      end
     end
   end
 end

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -20,7 +20,7 @@ module Hyrax
     def pdf
       resource = PagedResource.find(params[:id])
 
-      if (resource && resource.allow_pdf_download == "true") || (resource && current_user.admin?)
+      if (resource && resource.allow_pdf_download == "true") || (resource && current_ability.current_user.admin?)
         pdf = ESSI::GeneratePdfService.new(resource).generate
 
         send_file pdf[:file_path],

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -18,7 +18,7 @@ module Hyrax
     self.show_presenter = Hyrax::PagedResourcePresenter
 
     def pdf
-      resource = PagedResource.find(params[:id])
+      resource = PagedResource.find(params[:id]) if params[:id]
 
       if (resource && resource.allow_pdf_download == "true") || (resource && current_ability.current_user.admin?)
         pdf = ESSI::GeneratePdfService.new(resource).generate
@@ -27,6 +27,9 @@ module Hyrax
           filename: pdf[:file_name],
           type: 'application/pdf',
           disposition: 'inline'
+      else
+        redirect_to "/concern/paged_resources/#{resource.id}?locale=en",
+          alert: 'You do not have access to download this PDF.'
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,7 +5,7 @@ class Ability
   self.ability_logic += [:everyone_can_create_curation_concerns]
   # Define any customized permissions here.
   def custom_permissions
-    can %i[file_manager save_structure structure], PagedResource
+    can %i[file_manager save_structure structure pdf], PagedResource
     # Limits deleting objects to a the admin user
     #
     # if current_user.admin?
@@ -18,7 +18,7 @@ class Ability
     #   can [:create], ActiveFedora::Base
     # end
     if current_user.admin?
-        can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
+        can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy, :pdf], Role
     end
   end
 

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -22,7 +22,7 @@ module Hyrax
       renderings = []
       if rendering_ids.present?
         rendering_ids.each do |file_set_id|
-          if solr_document[:allow_pdf_download_tesim] == "true" || current_ability.current_user.admin?
+          if solr_document[:allow_pdf_download_tesim] == ["true"] || current_user.admin?
             renderings << manifest_helper.build_pdf_rendering(file_set_id)
           end
         end

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -22,7 +22,7 @@ module Hyrax
       renderings = []
       if rendering_ids.present?
         rendering_ids.each do |file_set_id|
-          if solr_document[:allow_pdf_download_tesim] == ["true"] || current_user.admin?
+          if solr_document[:allow_pdf_download_tesim] == ["true"] || current_ability.current_user.admin?
             renderings << manifest_helper.build_pdf_rendering(file_set_id)
           end
         end


### PR DESCRIPTION
Non admin users should be able to download pdf when flag is set to true. This ended up being a permissions issue and needed pdf added to the ability file. + Error handling.

<img width="1673" alt="Screen Shot 2020-07-09 at 9 10 39 AM" src="https://user-images.githubusercontent.com/10081604/87067746-52cd6080-c1c9-11ea-8f72-ba0080617d16.png">
