### PR TITLE
[ESSI-1013] [ESSI-1034] Drop, move configuration initializations

### DIFF
--- a/config/initializers/derivatives_source_file_service.rb
+++ b/config/initializers/derivatives_source_file_service.rb
@@ -1,2 +1,0 @@
-# All derivative creation uses Fedora-stored files (or not) per the application config setting
-Hydra::Derivatives.source_file_service = Hydra::Derivatives::RetrieveSourceFileService if ESSI.config.dig(:essi, :store_original_files)

--- a/config/initializers/extend_file_set_derivatives.rb
+++ b/config/initializers/extend_file_set_derivatives.rb
@@ -1,1 +1,0 @@
-Hyrax::DerivativeService.services.unshift ESSI::FileSetOCRDerivativesService

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -46,3 +46,6 @@ Hydra::Derivatives.kdu_compress_path = ESSI.config.dig(:essi, :kdu_compress_path
 Hydra::Derivatives.kdu_compress_recipes =
   Hydra::Derivatives.kdu_compress_recipes.with_indifferent_access
                     .merge(ESSI.config.dig(:essi, :jp2_recipes) || {})
+
+# ocr derivation
+Hyrax::DerivativeService.services.unshift ESSI::FileSetOCRDerivativesService


### PR DESCRIPTION
Curiously, when I run the current `master` locally via `docker-compose`, I'm finding inconsistent results on whether some settings modified in `config/initializers` files take effect _at all_, or only in console, accessed via:
`docker-compose exec essi bash`
`rails c`
versus the running instance, when entering the same evaluations through `byebug` after catching a debugger statement, in either of:
`docker attach essi_essi_1 # for debugger statements in views, other application code`
`docker attach essi_worker_1 # for debugger statements in Jobs`

I do not find the same differences when each piece of the stack is run locally, directly.

What got me looking at this was seeing that OCR derivation wasn't running, despite it being configured to do so.

Here are the 3 things I've noticed, the first two of which this PR addresses:
**(1) OCR derivation**
In the running instance, I get:
```rb
> Hyrax::DerivativeService.services
=> [Hyrax::FileSetDerivativesService]
```
whereas the console produces:
```rb
=> [ESSI::FileSetOCRDerivativesService, Hyrax::FileSetDerivativesService]
```
This PR removes the `config/initializers/extend_file_set_derivatives.rb ` file, and puts that line in `lib/extensions/extensions.rb`, where it seems to take effect consistently.

**(2) Derivatives Source File Service**
The line from `config/initializers/derivatives_source_file_service.rb`:
```rb
# All derivative creation uses Fedora-stored files (or not) per the application config setting	
Hydra::Derivatives.source_file_service = Hydra::Derivatives::RetrieveSourceFileService if ESSI.config.dig(:essi, :store_original_files)
```
 didn't seem to take effect in _any_ environment, as (even with the config check passing) I always got:
```rb
> Hydra::Derivatives.source_file_service
=> Hyrax::LocalFileService
```
but I just removed this rather than move it into `lib/extensions/extensions.rb`, as it actually breaks the stack when it takes effect, and I don't think this is actually the behavior we want in 1013, anyway.

**(3) RIIIF Image Resolver**
Similarly to (1), `config/initializers/riif.rb` seems to _only_ take effect in console.  Among other things, it sets:
```rb
Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
```
and in console, I do get:
```rb
> Riiif::Image.file_resolver.class
=> Riiif::HTTPFileResolver
```
but byebug in the running instance gets:
```rb
(byebug) Riiif::Image.file_resolver.class
Riiif::FileSystemFileResolver
```
This PR does _not_ currently address this difference.