### PR TITLE
[ESSI-1161] Remove HTML elements for UV metadata

### DIFF
--- a/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
+++ b/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
@@ -3,6 +3,7 @@ module Extensions
   module Hyrax
     module WorkShowPresenter
       module ManifestMetadata
+        HTML_RENDERED_FIELDS = [:holding_location].freeze
         # Copied from Hyrax gem
         # IIIF metadata for inclusion in the manifest
         #  Called by the `iiif_manifest` gem to add metadata
@@ -12,16 +13,25 @@ module Extensions
           metadata = []
           ::Hyrax.config.iiif_metadata_fields.each do |field|
             next unless methods.include?(field.to_sym)
+            value = Array.wrap(send(field))
+            if field.to_sym.in? HTML_RENDERED_FIELDS
+              value.map! { |v| unrender_value(v) }
+            end
       
             data = send(field)
             next if data.blank?
       
             metadata << {
               'label' => I18n.t("simple_form.labels.defaults.#{field}", default: field.to_s.humanize),
-              'value' => Array.wrap(send(field))
+              'value' => value
             }
           end
           metadata
+        end
+
+        # retain br tags, sanitize all other HTML, remove label line
+        def unrender_value(value)
+          Array.wrap(ActionView::Base.full_sanitizer.sanitize(value.gsub(/<br\s*\/?>/, "\n")).split("\n")[1..-1]).join('<br>')
         end
       end
     end


### PR DESCRIPTION
A more elegant solution would be presenter method calls that are context-aware of displaying in the general UI vs. within universal viewer, but that would require deeper changes to the Hyrax pattern.  So, it ain't pretty, but it works.