### PR TITLE
Return nil when original_file is not available

### DIFF
--- a/app/services/iiif_thumbnail_path_service.rb
+++ b/app/services/iiif_thumbnail_path_service.rb
@@ -3,6 +3,7 @@ class IIIFThumbnailPathService < Hyrax::WorkThumbnailPathService
     # @return the network path to the thumbnail
     # @param [FileSet] thumbnail the object that is the thumbnail
     def thumbnail_path(thumbnail)
+      return unless thumbnail.original_file
       Hyrax.config.iiif_image_url_builder.call(thumbnail.original_file.id, nil, '250,')
       # Hyrax::Engine.routes.url_helpers.download_path(thumbnail.id,
       #                                                file: 'thumbnail')


### PR DESCRIPTION
Prevents an exception being raised when indexing a Fileset that doesn't have an original_file associated with it (yet).