### PR TITLE
Add authorize calls to #structure, #save_structure

### DIFF
--- a/app/controllers/concerns/essi/structure_behavior.rb
+++ b/app/controllers/concerns/essi/structure_behavior.rb
@@ -1,12 +1,14 @@
 module ESSI
   module StructureBehavior
     def structure
+      authorize! :edit, @curation_concern
       parent_presenter
       @members = presenter.member_presenters
       @logical_order = presenter.logical_order_object
     end
 
     def save_structure
+      authorize! :edit, @curation_concern
       structure = { "label": params["label"], "nodes": params["nodes"] }
       if curation_concern.lock?
         head 423

--- a/spec/controllers/hyrax/archival_materials_controller_spec.rb
+++ b/spec/controllers/hyrax/archival_materials_controller_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Hyrax::ArchivalMaterialsController do
   include_examples('paged_structure persister',
                    :archival_material,
-                   Hyrax::ArchivalMaterialPresenter)
+                   Hyrax::ArchivalMaterialPresenter,
+                   described_class)
   include_examples('update metadata remotely', :archival_material)
 end

--- a/spec/controllers/hyrax/paged_resources_controller_spec.rb
+++ b/spec/controllers/hyrax/paged_resources_controller_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Hyrax::PagedResourcesController do
   include_examples('paged_structure persister',
                    :paged_resource,
-                   Hyrax::PagedResourcePresenter)
+                   Hyrax::PagedResourcePresenter,
+                   described_class)
   include_examples('update metadata remotely', :paged_resource)
 end

--- a/spec/support/shared_examples/paged_structured_controller.rb
+++ b/spec/support/shared_examples/paged_structured_controller.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples "paged_structure persister" \
-do |resource_symbol, presenter_factory|
+do |resource_symbol, presenter_factory, resource_controller|
 
   describe "when logged in" do
 
@@ -22,6 +22,7 @@ do |resource_symbol, presenter_factory|
 
       before do
         allow(resource.class).to receive(:find).and_return(resource)
+        allow_any_instance_of(resource_controller).to receive(:authorize!).and_return(true)
         resource.ordered_members << file_set
         solr.add file_set.to_solr.merge(ordered_by_ssim: [resource.id])
         solr.add resource.to_solr


### PR DESCRIPTION
Currently, trying to load a structure page when not logged in just produces a ruby error.  This does a proper login redirect.
