### PR TITLE
ESSI-1190 Airbrake gem installed with config stub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ gem 'i18n-js'
 gem 'bagit'
 gem 'validatable'
 gem 'prawn'
+gem 'airbrake'
 
 # Bulk Import / Export
 #TODO: N8 specific - use local for dev; use github for test/staging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,10 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    airbrake (11.0.1)
+      airbrake-ruby (~> 5.1)
+    airbrake-ruby (5.1.1)
+      rbtree3 (~> 0.5)
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
     arel (8.0.0)
@@ -635,8 +639,6 @@ GEM
       rails (~> 5.0)
       rdf
     rack (2.2.3)
-    rack-protection (2.0.5)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.7)
@@ -673,6 +675,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rbtree3 (0.6.0)
     rdf (3.1.4)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
@@ -926,6 +929,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake
   bagit
   better_errors
   binding_of_caller

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -42,6 +42,9 @@ default: &default
     iiif_server_url: /iiif/2/
   iucat_libraries:
     url: http://iucat-feature-tadas.uits.iu.edu/api/library
+  airbrake:
+    project_id:
+    project_key:
   ldap:
     enabled: false
     host: ads.iu.edu

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -54,6 +54,9 @@ default: &default
       :response_type: :public_url
     file_system:
       :home: <%= Rails.root.join("staged_files") %>
+  airbrake:
+    project_id:
+    project_key:
   ldap:
     enabled: false
     host: ads.iu.edu

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Airbrake is an online tool that provides robust exception tracking in your Rails
+# applications. In doing so, it allows you to easily review errors, tie an error
+# to an individual piece of code, and trace the cause back to recent
+# changes. Airbrake enables for easy categorization, searching, and prioritization
+# of exceptions so that when errors occur, your team can quickly determine the
+# root cause.
+#
+# Configuration details:
+# https://github.com/airbrake/airbrake-ruby#configuration
+Airbrake.configure do |c|
+  # You must set both project_id & project_key. To find your project_id and
+  # project_key navigate to your project's General Settings and copy the values
+  # from the right sidebar.
+  # https://github.com/airbrake/airbrake-ruby#project_id--project_key
+  c.project_id = ESSI.config.dig :airbrake, :project_id
+  c.project_key = ESSI.config.dig :airbrake, :project_key
+
+  # Configures the root directory of your project. Expects a String or a
+  # Pathname, which represents the path to your project. Providing this option
+  # helps us to filter out repetitive data from backtrace frames and link to
+  # GitHub files from our dashboard.
+  # https://github.com/airbrake/airbrake-ruby#root_directory
+  c.root_directory = Rails.root
+
+  # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
+  # use the Rails' logger.
+  # https://github.com/airbrake/airbrake-ruby#logger
+  c.logger = Airbrake::Rails.logger
+
+  # Configures the environment the application is running in. Helps the Airbrake
+  # dashboard to distinguish between exceptions occurring in different
+  # environments.
+  # NOTE: This option must be set in order to make the 'ignore_environments'
+  # option work.
+  # https://github.com/airbrake/airbrake-ruby#environment
+  #
+  # Airbrake might not report errors in Essi dev mode without class caching or eager loading enabled.
+  c.environment = Rails.env
+
+  # Setting this option allows Airbrake to filter exceptions occurring in
+  # unwanted environments such as :test.
+  # NOTE: This option *does not* work if you don't set the 'environment' option.
+  # https://github.com/airbrake/airbrake-ruby#ignore_environments
+  c.ignore_environments = %w[test]
+
+  # A list of parameters that should be filtered out of what is sent to
+  # Airbrake. By default, all "password" attributes will have their contents
+  # replaced.
+  # https://github.com/airbrake/airbrake-ruby#blocklist_keys
+  c.blocklist_keys = [/password/i, /authorization/i]
+
+  # Alternatively, you can integrate with Rails' filter_parameters.
+  # Read more: https://goo.gl/gqQ1xS
+  # c.blocklist_keys = Rails.application.config.filter_parameters
+end
+
+# A filter that collects request body information. Enable it if you are sure you
+# don't send sensitive information to Airbrake in your body (such as passwords).
+# https://github.com/airbrake/airbrake#requestbodyfilter
+Airbrake.add_filter(Airbrake::Rack::RequestBodyFilter.new)
+
+# Attaches thread & fiber local variables along with general thread information.
+Airbrake.add_filter(Airbrake::Filters::ThreadFilter.new)
+
+# Attaches loaded dependencies to the notice object
+# (under context/versions/dependencies).
+Airbrake.add_filter(Airbrake::Filters::DependencyFilter.new)
+
+# If you want to convert your log messages to Airbrake errors, we offer an
+# integration with the Logger class from stdlib.
+# https://github.com/airbrake/airbrake#logger
+# Rails.logger = Airbrake::AirbrakeLogger.new(Rails.logger)


### PR DESCRIPTION
Installs the airbrake gem and adds empty project_id and project_key config stubs.

Rails errors that occur in development mode (with cache_classes and/or eager_load disabled) seem to not be reported as errors to the Airbrake dashboard. Errors in sidekiq are reported.

It is expected that errors in production mode will be reported.