### PR TITLE
ESSI-1102 masonry view make it not vertically stack everything with a…

### DIFF
--- a/app/assets/stylesheets/digital_collections/_layout.scss
+++ b/app/assets/stylesheets/digital_collections/_layout.scss
@@ -849,11 +849,6 @@ tr:nth-child(even):hover {
 	max-width: 100%;
 }
 
-.masonry {
-	display: flex;
-	width: 100%;
-	flex-flow: row wrap;
-}
 
 a {
 	color: #333;
@@ -863,16 +858,6 @@ a {
 	vertical-align: middle;
 	max-width: 100%;
 }
-
-.masonry {
-	display: flex;
-	width: 100%;
-	flex-flow: row wrap;
-}
-
-
-
-
 
 a {
 	color: #333;


### PR DESCRIPTION
We have three .masory in _layout.scss. Two are duplicated. 
"_layout.scss" is our local customized css. Remove two .marsory which have flex display property and keep an empty one will fix the problem. 