### PR TITLE
ESSI-1179 more accessible behavior on the homepage/add role=tablist

### DIFF
--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -7,7 +7,7 @@
   </div>
 </div>
 <div class="home_featured_tabs">
-  <ul id="homeTabs" class="nav nav-buttons">
+  <ul id="homeTabs" class="nav nav-buttons" role="tablist">
     <li class="active"><a href="#featured_container" data-toggle="tab" role="tab" id="featureTab" class="button"><%= t('hyrax.homepage.featured_works.tab_label') %></a></li>
     <li><a href="#recently_uploaded" data-toggle="tab" role="tab" id="recentTab" class="button"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a></li>
   </ul>


### PR DESCRIPTION
According to the accessibility document, it is good to add role="tablist" in ul tag and role="tab" in li tag. I made the change according to that.

