### PR TITLE
ESSI-1197: Help and Contact page changes

### DIFF
--- a/app/models/hyrax/contact_form.rb
+++ b/app/models/hyrax/contact_form.rb
@@ -1,0 +1,35 @@
+module Hyrax
+  class ContactForm
+    include ActiveModel::Model
+    attr_accessor :contact_method, :category, :name, :email, :subject, :message
+    validates :email, :category, :name, :subject, :message, presence: true
+    validates :email, format: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i, allow_blank: true
+
+    # - can't use this without ActiveRecord::Base validates_inclusion_of :category, in: self.class.issue_types_for_locale
+
+    # They should not have filled out the `contact_method' field. That's there to prevent spam.
+    def spam?
+      contact_method.present?
+    end
+
+    # Declare the e-mail headers. It accepts anything the mail method
+    # in ActionMailer accepts.
+    def headers
+      {
+        subject: "#{Hyrax.config.subject_prefix} #{subject}",
+        to: Hyrax.config.contact_email,
+        from: email
+      }
+    end
+
+    def self.issue_types_for_locale
+      [
+        I18n.t('hyrax.contact_form.issue_types.depositing'),
+        I18n.t('hyrax.contact_form.issue_types.changing'),
+        I18n.t('hyrax.contact_form.issue_types.browsing'),
+        I18n.t('hyrax.contact_form.issue_types.reporting'),
+        I18n.t('hyrax.contact_form.issue_types.general')
+      ]
+    end
+  end
+end

--- a/app/models/hyrax/contact_form.rb
+++ b/app/models/hyrax/contact_form.rb
@@ -23,13 +23,7 @@ module Hyrax
     end
 
     def self.issue_types_for_locale
-      [
-        I18n.t('hyrax.contact_form.issue_types.depositing'),
-        I18n.t('hyrax.contact_form.issue_types.changing'),
-        I18n.t('hyrax.contact_form.issue_types.browsing'),
-        I18n.t('hyrax.contact_form.issue_types.reporting'),
-        I18n.t('hyrax.contact_form.issue_types.general')
-      ]
+      I18n.t('hyrax.contact_form.issue_types').values.select(&:present?)
     end
   end
 end

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -6,8 +6,6 @@
           <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil %></li>
         <li <%= 'class=active' if current_page?(hyrax.about_path) %>>
           <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
-        <li <%= 'class=active' if current_page?(hyrax.help_path) %>>
-          <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
         <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
           <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
       </ul><!-- /.nav -->

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,0 +1,50 @@
+<div class="alert alert-info">
+  <%= render 'directions' %>
+</div>
+
+<h1>
+    <%= t('hyrax.contact_form.header') %>
+</h1>
+
+<% if user_signed_in? %>
+  <% nm = current_user.name %>
+  <% em = current_user.email %>
+<% else %>
+  <% nm = '' %>
+  <% em = '' %>
+<% end %>
+
+<%= form_for @contact_form, url: hyrax.contact_form_index_path,
+                            html: { class: 'form-horizontal' } do |f| %>
+  <%= f.text_field :contact_method, class: 'hide' %>
+  <div class="form-group">
+    <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
+    <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
+    <% issue_types.unshift([t('hyrax.contact_form.select_type'), nil]) %>
+    <div class="col-sm-10">
+      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :message, t('hyrax.contact_form.message_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+  </div>
+
+  <%= f.submit value: t('hyrax.contact_form.button_label'), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,3 +1,5 @@
+<% provide :page_title, "Contact Us" %>
+
 <div class="alert alert-info">
   <%= render 'directions' %>
 </div>
@@ -20,9 +22,8 @@
   <div class="form-group">
     <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
     <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
-    <% issue_types.unshift([t('hyrax.contact_form.select_type'), nil]) %>
     <div class="col-sm-10">
-      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
+      <%= f.select 'category', options_for_select(issue_types), { include_blank: t('hyrax.contact_form.select_type') }, {class: 'form-control', required: true } %>
     </div>
   </div>
 

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -56,6 +56,8 @@ en:
         list_collections: List of items in this collection
     contact_form:
       notice: If you have questions or comments about Digital Collections, please fill out the form below.
+      select_type: Select an Issue Type...
+      title: Contact Us
     directory:
       suffix: "@example.org"
     footer:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -55,6 +55,15 @@ en:
       show:
         list_collections: List of items in this collection
     contact_form:
+      issue_types: # blank values force overriding stock Hyrax entries
+        browsing: ''
+        changing: ''
+        depositing: ''
+        reporting: ''
+        general: General feedback
+        request_access: Request for access
+        tech_support: Technical support
+        other: Other
       notice: If you have questions or comments about Digital Collections, please fill out the form below.
       select_type: Select an Issue Type...
       title: Contact Us

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -54,6 +54,8 @@ en:
     collections:
       show:
         list_collections: List of items in this collection
+    contact_form:
+      notice: If you have questions or comments about Digital Collections, please fill out the form below.
     directory:
       suffix: "@example.org"
     footer:


### PR DESCRIPTION
Removes Help tab, tweaks content of Contact page.

This required overriding stock Hyrax code, when I felt like it mostly should have been doable solely via config changes.  I opened up corresponding PRs in Hyrax to this effect: [#4720](https://github.com/samvera/hyrax/pull/4720), [#4721](https://github.com/samvera/hyrax/pull/4721)