### PR TITLE
ESSI-1230 Hiding all action buttons for works when site usage is access only

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,3 +1,4 @@
+<% unless access_only? %>
 <div class="row">
   <div class="show-actions">
     <div class="col-sm-4 text-left">
@@ -18,7 +19,7 @@
       <% end %>
     </div>
     <div class="col-sm-8 text-right">
-    <% unless presenter.editor? && access_only? %>
+    <% if presenter.editor? %>
         <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
         <% if presenter.member_presenters.any? %>
             <% begin %>
@@ -52,6 +53,7 @@
     </div>
   </div>
 </div>
+<% end %>
 
 <!-- COinS hook for Zotero -->
   <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>


### PR DESCRIPTION
Corrects a bug in logic that hides edit action buttons  if `site_usage == access_only` and additionally hides the remaining left side buttons for adding to collection and adding as featured item.