### PR TITLE
ESSI-1226 accessibility broken aria reference

### DIFF
--- a/app/views/shared/_ajax_modal.html.erb
+++ b/app/views/shared/_ajax_modal.html.erb
@@ -1,6 +1,0 @@
-<div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
The error is due to aria-labelledby tag in "_ajax_model.html.erb'. After look into the code and check the hyrax. The file does not necessarily override. The origin "ajax_modal.html.erb' is from /gems/ruby-2.6.3/gems//blacklight-6.24.0/app/views/shared/_ajax_modal.html.erb and does not have aria-labelledby tag there.  So I think the better solution would be removing the whole file. 