### PR TITLE
[ESSI-1153] [ESSI-1256] Pass all bulkrax importer form fields to work

### DIFF
--- a/lib/extensions/bulkrax/object_factory/structure.rb
+++ b/lib/extensions/bulkrax/object_factory/structure.rb
@@ -14,9 +14,8 @@ module Extensions
 
           # Regardless of what the Parser gives us, these are the properties we are prepared to accept.
           def permitted_attributes
-            # Override - add structure to accepted fields
-            super
-            klass.properties.keys.map(&:to_sym) + %i[structure]
+            # Override - add admin_set_id, structure to accepted fields
+            super + %i[admin_set_id structure]
           end
 
       end

--- a/spec/models/bulkrax/object_factory_spec.rb
+++ b/spec/models/bulkrax/object_factory_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Bulkrax
+  RSpec.describe ObjectFactory, type: :model do
+    let(:attributes) { {} }
+    let(:unique_identifier) { 'unique_identifier' }
+    let(:replace_files) { false }
+    let(:user) { FactoryBot.build(:user) }
+    let(:klass) { Image }
+    subject(:object_factory) { described_class.new(attributes, unique_identifier, replace_files, user, klass) }
+
+    describe '#permitted_attributes' do
+      it 'includes all importer form fields' do
+        form_fields = [:admin_set_id, :rights_statement, :visibility]
+        expect(object_factory.permitted_attributes).to include(*form_fields)
+      end
+      it 'includes ESSI structure map' do
+        expect(object_factory.permitted_attributes).to include(:structure)
+      end
+    end
+
+    xit '#work_actor' do
+      # TODO: test override for ESSI::Actors::PerformLaterActor
+    end
+  end
+end


### PR DESCRIPTION
Changes to the customization of `Bulkrax::ObjectFactory#permitted_attributes`:
* Fixes `super` call to retain Bulkrax-added fields to the work class properties (including `visibility`)
* Adds `admin_set_id` to added fields -- this was missing in bulkrax, and raised as [bulkrax issue 271](https://github.com/samvera-labs/bulkrax/issues/271)
* Adds spec coverage