### PR TITLE
Resolve deprecation warning for #field_value calls

### DIFF
--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -5,17 +5,18 @@
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
           <dt><%= render_index_field_label document, field: field_name %></dt>
-          <% if doc_presenter.field_value(field_name).match(/(<([^>]+)>)/i) %>
-            <dd><%= doc_presenter.field_value(field_name) %></dd>
+          <% field_value = doc_presenter.field_value(Blacklight::Configuration::Field.new(field: field_name)) %>          
+          <% if field_value.match(/(<([^>]+)>)/i) %>
+            <dd><%= field_value %></dd>
           <% else %>
-            <dd><%= truncate doc_presenter.field_value(field_name), length:160 %></dd>
+            <dd><%= truncate field_value, length:160 %></dd>
           <% end %>
       <% end %>
     <% end %>
     </dl>
   </div>
 </div>
-<% if(doc_presenter.field_value('has_model_ssim') == 'Collection') %>
+<% if(doc_presenter.field_value(Blacklight::Configuration::Field.new(field: 'has_model_ssim')) == 'Collection') %>
     <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
 <div class="col-md-4">
   <div class="collection-counts-wrapper">


### PR DESCRIPTION
Resolves:

DEPRECATION WARNING: You provided a String value to IndexPresenter#field_value Provide a Blacklight::Configuration::Field instead. This behavior is deprecated in Blacklight 7.