### PR TITLE
[ESSI-1221] Attempt to prevent Processors::OCR LoadError, NameError

### DIFF
--- a/app/services/ocr_runner.rb
+++ b/app/services/ocr_runner.rb
@@ -2,10 +2,10 @@ class OCRRunner < Hydra::Derivatives::Runner
 
   # Facilitate storing the output as :extracted_text
   def self.output_file_service
-    @output_file_service || PersistDirectlyContainedOutputFileService
+    @output_file_service || ::PersistDirectlyContainedOutputFileService
   end
 
   def self.processor_class
-    Processors::OCR
+    ::Processors::OCR
   end
 end

--- a/app/services/processors.rb
+++ b/app/services/processors.rb
@@ -1,0 +1,1 @@
+module Processors; end


### PR DESCRIPTION
There are 2 known errors to occur inconsistently and intermittently when a `CreateDerivativesJob` is spun off by a `Bulkrax::ImportJob`:

**NameError**
This results from an (inconsistent) attempt to load `OCRRunner::Processors` instead of `Processors`
The PR attempts to block the namespacing with an initial `::`

**LoadError**
Intermittently, you'll see an error something like:
`LoadError (Unable to autoload constant Processors::OCR, app/services/processors/ocr.rb to define it)`
which is a bit odd because that file is present, and does define it.
This change is more heavily experimental and unproven as a remedy, but it looks like this may be something going awry with autoloading or eager-loading, and explicitly making an (empty) `Processors` module _may_ help here.

These changes are all difficult to test since the problems they seek to solve are intermittent.  Testing may look like running a large enough number of Bulkrax imports without these errors recurring, to be satisfied -- but knowing what that number is might require first establishing the % incidence without these changes.