### PR TITLE
[ESSI-1153] [ESSI-1265] Ensure Bulkrax loads Allinson flex properties

### DIFF
--- a/lib/extensions/bulkrax/entry/allinson_flex_fields.rb
+++ b/lib/extensions/bulkrax/entry/allinson_flex_fields.rb
@@ -1,0 +1,13 @@
+module Extensions
+  module Bulkrax
+    module Entry
+      module AllinsonFlexFields
+        def build_for_importer
+          # Ensure loading of all flexible metadata properties
+          factory_class&.new
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -41,10 +41,10 @@ Hyrax::Dashboard::CollectionsController.prepend Extensions::Hyrax::Dashboard::Co
 Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::SourceMetadataIdentifier
 
 # bulkrax overrides
-
 Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::Structure
+Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::AllinsonFlexFields
 
-
+# actor customizations
 Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest, ESSI::Actors::PerformLaterActor
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesActor, ESSI::Actors::CreateWithRemoteFilesOrderedMembersStructureActor
 


### PR DESCRIPTION
It seems the bulkrax importer isn't guaranteed to have loaded the Allinson flex properties for the work class being imported, but that generating at least one instance ensures it.