### PR TITLE
[ESSI-1221] Bulkrax METS ingest, processing local/remote images

### DIFF
--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -29,7 +29,7 @@ class METSDocument
   def thumbnail_path
     xp = "/mets:mets/mets:fileSec/mets:fileGrp[@USE='thumbnail']" \
     "/mets:file/mets:FLocat/@xlink:href"
-    @mets.xpath(xp).to_s.gsub(/file:\/\//, '')
+    @mets.xpath(xp).to_s
   end
 
   def viewing_direction
@@ -104,7 +104,7 @@ class METSDocument
     end
 
     def final_url(file)
-      url = file.xpath('mets:FLocat/@xlink:href').to_s.gsub(/file:\/\//, '')
+      url = file.xpath('mets:FLocat/@xlink:href').to_s
       #return unless url.present?
 
       fl = if url.present?

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -174,6 +174,7 @@ default: &default
         title: Example title
         url: https://example.com
     homepage_banner: images/homepage_banner.png
+    whitelisted_ingest_dirs: []
         
 development:
   <<: *default

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -178,6 +178,7 @@ default: &default
         title: Example title
         url: https://example.com
     homepage_banner: images/homepage_banner.png
+    whitelisted_ingest_dirs: []
 
 development:
   <<: *default

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -299,6 +299,10 @@ Hyrax.config do |config|
   #
   config.whitelisted_ingest_dirs ||= []
   config.whitelisted_ingest_dirs << Rails.root.join('spec', 'fixtures').to_s
+  [ESSI.config.dig(:essi, :whitelisted_ingest_dirs) || [], 
+   ENV['WHITELISTED_INGEST_DIRS'].to_s.split].select(&:any?).each do |additional_dirs|
+    config.whitelisted_ingest_dirs += additional_dirs
+  end
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -50,6 +50,8 @@ Bulkrax::Importer.prepend Extensions::Bulkrax::Importer::LastRun
 # actor customizations
 Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest, ESSI::Actors::PerformLaterActor
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesActor, ESSI::Actors::CreateWithRemoteFilesOrderedMembersStructureActor
+Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesOrderedMembersActor
+
 Hyrax::Actors::BaseActor.prepend Extensions::Hyrax::Actors::BaseActor::UndoAttributeArrayWrap
 
 # .jp2 conversion settings

--- a/spec/iu_metadata/mets_record_spec.rb
+++ b/spec/iu_metadata/mets_record_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe IuMetadata::METSRecord do
     pth = File.join(fixture_path, 'iu_metadata/pudl0001-4609321-s42.mets')
     described_class.new('file://' + pth, open(pth))
   }
+  let(:thumbnail_path) { "file:///users/escowles/downloads/tmp/00000001.tif" }
 
   record1_attributes =
     {
@@ -27,6 +28,30 @@ RSpec.describe IuMetadata::METSRecord do
           expect(record1.send(att)).to eq val
         end
       end
+    end
+  end
+
+  describe "#final_url" do
+    let(:thumbnail_xpath) { "/mets:mets/mets:fileSec/mets:fileGrp[@USE='thumbnail']/mets:file" }
+    let(:file) { record1.instance_variable_get(:@mets).xpath(thumbnail_xpath).first }
+    context "when a final redirect url is applicable" do
+      let(:final_url) { 'http//final.url' }
+      before { allow(IuMetadata::FinalRedirectUrl).to receive(:final_redirect_url).and_return(final_url) }
+      it "returns the final redirect url" do
+        expect(record1.send(:final_url, file)).to eq final_url
+      end
+    end
+    context "when no final redirect url is applicable" do
+      before { allow(IuMetadata::FinalRedirectUrl).to receive(:final_redirect_url).and_return(nil) }
+      it "returns the final redirect url, inclusive of any initial file://" do
+        expect(record1.send(:final_url, file)).to eq thumbnail_path
+      end
+    end
+  end
+
+  describe "#thumbnail_path" do
+    it "returns the xlink:href value, retaining any 'file://' at the beginning" do
+      expect(record1.thumbnail_path).to eq thumbnail_path
     end
   end
 end


### PR DESCRIPTION
1st commit gets Bulkrax METS ingest to fully process images:
* all remotely sourced (https://...), with structure
* all locally sourced (as direct file paths, like "/path/to/file"), but loses structure
* from a combination of remote and local sources, but loses structure
The structure loss with local files looks like it's due to us handling structure entirely in the `CreateWithRemoteFiles` version of the actor, and not at all in the `CreateWithFiles` version.  It should be pretty straightforward to add structure support to the other actor, but handling a mixed-source case would be trickier as the current structure-file map generation logic is dependent on all the files being handled in the same actor.

An important note here is that handling files as raw paths works, but going that route, [at some point Bulkrax](https://github.com/samvera-labs/bulkrax/blob/b2196899e2987cd34745b72cd4dcfc637051f906/app/models/concerns/bulkrax/file_factory.rb#L87-L97) ~~and/or Hyrax~~  handles them as UploadedFile objects -- and they are each copied to the `tmp/uploads/hyrax/uploaded_file/file` tree, which isn't optimally performant.

2nd commit uses the more performant version of the `CreateWithFiles` actor, which I'm pretty sure we want, even if we don't further modify it with structure support.

UPDATES 2021-04-01

3rd commit fixes issue failing to call `IngestLocalFileJob`

4th commit stops `METSDocument` removing `file://` portions of URIs, which allows them to pass down later in the stack and call `CreateWithRemoteFiles` instead of `CreateWithFiles`.  But some important notes on this:
* For this to work, the target paths need to be [whitelisted for ingest](https://github.com/IU-Libraries-Joint-Development/essi/blob/master/config/initializers/hyrax.rb#L286-L302) -- @randalldfloyd we might want a commit making this configurable in deployment using the same pattern we are for other initialization configurations? UPDATE: handled in 5th commit
* ~~Curiously, Hyrax seems to filter on whitelisted_ingest_dirs for ingesting `file://` paths via `CreateWithRemoteFiles` actors but _not_ for ingesting raw paths via `CreateWithFiles` actors; I'm not sure if this is intentional, or an inconsistency worth raising an issue about~~ Bulkrax isn't applying the whitelisted_ingest_dirs filter on local file ingest
* Note that while this does get us using the intended portion of the stack -- `ESSI::Actors::CreateWithRemoteFilesOrderedMembersStructureActor`, which then calls `IngestLocalFileJob` instead of `ImportUrlJob`, ultimately calling `FileSetActor` without a `from_url: true` argument and skipping the `VisibilityCopyJob` and `InheritPermissionsJob` calls that could occur there -- watching the logs, it looks like those 2 jobs _did_ get called much later, per image file, for some reason, but I haven't tracked that down yet.

Note that we may want to have a separate story about handling structure in the `CreateWithFiles` actors?

Note that I have gotten some intermittent failures of particular images to process, due to database locking, but that should just be due to my development environment locally choking on too many threads and I wouldn't expect to see this in production.

~~In draft status as it would be better to include any/all of the following:~~
1. ~~Test coverage for the changes~~ resolved
2. ~~Investigating or resolving why file:// values doesn't seem to work.  Those strings actually get stripped out in the `METSDocuments`/`METSRecord` part of the stack, but I tried injecting them back in before further bulkrax processing, and files didn't get created.  This should move processing from the `CreateWithFiles` version of actors to the `CreateWithRemoteFiles` version, which would be one way to resolve getting the structure map.  And it also stop making the redundant `UploadedFile` version of local files.  So it's worth at least investigating further, I just haven't done it yet.~~  Resolved!