### PR TITLE
At work creation, keep existing ocr_state value if present

### DIFF
--- a/app/actors/concerns/essi/apply_ocr.rb
+++ b/app/actors/concerns/essi/apply_ocr.rb
@@ -11,6 +11,7 @@ module ESSI
 
       def apply_ocr_option_data_to_curation_concern(env)
         return unless ESSI.config.dig(:essi, :index_ocr_files)
+        return if env.curation_concern.ocr_state.present?
         env.curation_concern.ocr_state = "searchable"
       end
   end


### PR DESCRIPTION
Currently the config flag for `index_ocr_files` hard-sets ocr_state to "searchable", even if it's already been set to another value (though the manual creation form, or Bulkrax import parsing of CSV/METS/etc.)  This changes it to a soft set, only if blank.