### PR TITLE
Adding okcomputer and custom service checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ gem 'prawn'
 gem 'airbrake'
 gem 'allinson_flex', github: 'samvera-labs/allinson_flex'
 # gem 'allinson_flex', path: 'vendor/engines/allinson_flex'
+gem 'okcomputer'
 
 # Bulk Import / Export
 #TODO: N8 specific - use local for dev; use github for test/staging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -664,6 +664,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    okcomputer (1.18.4)
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -1048,6 +1049,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   marc (~> 1.0.0)
   mysql2
+  okcomputer
   omniauth
   omniauth-iu-cas
   prawn

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,51 @@
+# If config value for mount_at set, then OkComputer will mount a route at that location,
+# otherwise it is effectively disabled
+OkComputer.mount_at = ESSI.config.dig(:okcomputer, :mount_at) || false
+
+if ESSI.config.dig(:okcomputer, :user)
+  OkComputer.require_authentication(ESSI.config.dig(:okcomputer, :user),
+                                    ESSI.config.dig(:okcomputer, :password))
+end
+
+# For built-in checks, see
+# https://github.com/sportngin/okcomputer/tree/master/lib/ok_computer/built_in_checks
+
+# Following checks execute after full initialization so that backend
+# configuration values are available
+Rails.application.configure do
+  config.after_initialize do
+    checks = OkComputer::CheckCollection.new("Standard Checks")
+    OkComputer::Registry.register "default", checks
+
+    checks.register "rails", OkComputer::DefaultCheck.new
+    checks.register "database", OkComputer::ActiveRecordCheck.new
+
+    redis_url = ESSI.config[:redis][:rails][:url]
+    checks.register "redis", OkComputer::RedisCheck.new(url: redis_url)
+
+    checks.register "sidekiq", EssiDevOps::SidekiqProcessCheck.new
+
+    checks.register "ruby", OkComputer::RubyVersionCheck.new
+
+    checks.register "cache", OkComputer::GenericCacheCheck.new
+
+    iiif_url = ESSI.config[:cantaloupe][:iiif_server_url]
+    checks.register "iiif", OkComputer::HttpCheck.new(iiif_url)
+
+    solr_url = ESSI.config[:solr][:url]
+    checks.register "solr", OkComputer::SolrCheck.new(solr_url)
+
+    fcrepo_url = ESSI.config[:fedora][:url]
+    fcrepo_user = ESSI.config[:fedora][:user]
+    fcrepo_password = ESSI.config[:fedora][:password]
+    auth_options = [fcrepo_user, fcrepo_password]
+    checks.register "fcrepo", EssiDevOps::FcrepoCheck.new(fcrepo_url, 10,
+                                                        auth_options)
+
+    # TODO: Remove this when CheckCollection instances not setting
+    # registrant_name is fixed.
+    checks.collection.each do |check_name, check_obj|
+      check_obj.registrant_name = check_name
+    end
+  end
+end

--- a/lib/essi_dev_ops/fcrepo_check.rb
+++ b/lib/essi_dev_ops/fcrepo_check.rb
@@ -1,0 +1,44 @@
+module EssiDevOps
+  # Performs a Fedora health check by reading the REST API over HTTP.
+  # A successful response is considered passing.
+  # To implement your own pass/fail criteria, inherit from this
+  # class, override #check, and call #perform_request to get the
+  # response body.
+  include OkComputer
+  class FcrepoCheck < HttpCheck
+    attr_accessor :auth_options
+
+    # Public: Initialize a new HTTP check.
+    #
+    # url - The URL to check, may also contain user:pass@ for basic auth but
+    #   auth_options will override request_timeout - How long to wait to
+    #   connect before timing out. Defaults to 5 seconds.
+    # auth_options - an ordered array containing username then password for
+    #   :http_basic_authentication.
+    def initialize(url, request_timeout = 5, auth_options = [])
+      super(url, request_timeout)
+      self.auth_options = auth_options
+    end
+
+    # Public: Return the status of the HTTP check
+    def check
+      mark_message "HTTP on Fedora REST interface successful" if ping?
+    rescue StandardError => e
+      mark_message "Error: '#{e}'"
+      mark_failure
+    end
+
+    def basic_auth_options
+      if auth_options.any?
+        auth_options
+      else
+        super
+      end
+    end
+
+    def ping?
+      response = perform_request
+      !(response =~ %r{info:fedora/fedora-system}).nil?
+    end
+  end
+end

--- a/lib/essi_dev_ops/sidekiq_process_check.rb
+++ b/lib/essi_dev_ops/sidekiq_process_check.rb
@@ -1,0 +1,22 @@
+module EssiDevOps
+  # Performs a Sidekiq process health check. Uses the same method as the
+  # Sidekiq dashboard to discover processes.
+  include OkComputer
+  class SidekiqProcessCheck < Check
+    # Public: Return the status of the Sidekiq processes
+    def check
+      if running? # rubocop:disable Style/GuardClause
+        mark_message "Sidekiq is up"
+      else
+        raise ConnectionFailed, "No Sidekiq processes found"
+      end
+    rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
+      mark_failure
+      mark_message e
+    end
+
+    def running?
+      Sidekiq::ProcessSet.new.any?
+    end
+  end
+end


### PR DESCRIPTION
Adds the okcomputer gem and custom repository service checks.  **Note:** For this to be available in the application, there must be a configuration section in the main YAML config file.  It is being omitted from the committed config files so that a route for okcomputer is not defined by default in any given deployment. Configuration should look something like:
```
okcomputer:
    mount_at: '/status'
    user: user
    password: password
```