### PR TITLE
ESSI-1313 Enable all_text_timv in solr schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,7 +340,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.14.2)
+    ffi (1.15.0)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -913,7 +913,7 @@ GEM
       activemodel (>= 5.0)
     sixarm_ruby_unaccent (1.2.0)
     slop (4.8.2)
-    solr_wrapper (3.1.1)
+    solr_wrapper (3.1.2)
       http
       retriable
       ruby-progressbar

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -21,7 +21,7 @@ class CatalogController < ApplicationController
 
     # configuration for Blacklight IIIF Content Search
     config.iiif_search = {
-      full_text_field: 'text_tesim',
+      full_text_field: 'ocr_text_tesi',
       object_relation_field: 'is_page_of_ssi',
       supported_params: %w[q page],
       autocomplete_handler: 'iiif_suggest',
@@ -45,7 +45,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim description_tesim creator_tesim keyword_tesim text_tesim word_boundary",
+      qf: "title_tesim description_tesim abstract_tesim creator_tesim keyword_tesim ocr_text_tesi word_boundary_tsi",
     }
 
     # solr field configuration for document/show views

--- a/app/indexers/essi/file_set_indexer.rb
+++ b/app/indexers/essi/file_set_indexer.rb
@@ -9,7 +9,7 @@ module ESSI
         solr_doc['is_page_of_ssi'] = object.parent.id if object.parent
         solr_doc['parent_path_tesi'] = Rails.application.routes.url_helpers.polymorphic_path(object.parent) if object.parent
 
-        solr_doc['text_tesim'] = object.extracted_text.content if object.extracted_text.present?
+        solr_doc['ocr_text_tesi'] = object.extracted_text.content if object.extracted_text.present?
         solr_doc['word_boundary_tsi'] = ::NewspaperWorks::TextExtraction::AltoReader.new(object.extracted_text.content).json if object.extracted_text.present?
         end
       end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -376,7 +376,7 @@
        text_tesim containing extracted text and Solrized by FileSetIndexer.
        Disabling for now.
   -->
-  <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
+   <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/>
 
    <!-- for suggestions -->
    <!-- <copyField source="*_tesim" dest="suggest"/>


### PR DESCRIPTION
Allows for flexible searching of *_tesim fields. Requires solr config change and reindexing.
OCR text fields are renamed to avoid being included in all_text.
Explicitly add abstract as a searched field for when it is used instead of description.
Fix word_boundary reference
Update solr_wrapper gem.