### PR TITLE
[ESSI-1288] In AllinsonFlex, ensure empty properties return a Hash

### DIFF
--- a/lib/extensions/allinson_flex/dynamic_schema/load_empty_properties.rb
+++ b/lib/extensions/allinson_flex/dynamic_schema/load_empty_properties.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Extensions
+  module AllinsonFlex
+    module DynamicSchema
+      module LoadEmptyProperties
+        def schema
+          return_value = self[:schema]
+          return_value['properties'] ||= {}
+          return_value
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -74,3 +74,6 @@ InheritPermissionsJob.prepend Extensions::Hyrax::Jobs::ShortCircuitOnNil
 
 # Hyrax user lookup
 Hyrax::UsersController.prepend Extensions::Hyrax::UsersController::FindUser
+
+# AllinsonFlex changes
+AllinsonFlex::DynamicSchema.prepend Extensions::AllinsonFlex::DynamicSchema::LoadEmptyProperties


### PR DESCRIPTION
When a work class was configured to use AllinsonFlex with no properties configured, the resultant `DynamicSchema` object had a `nil` value, instead of an empty Hash, in the `properties` field of the `schema` attribute (serialized JSON).  Granted, this is an odd situation you probably wouldn't _want_ to create -- but other parts of the stack assume a valid Hash value is present there, and break.  This includes the issue prompting the ESSI-1288 story, the form to create new work not rendering.  This monkeypatches that issue.

We may not actually want to merge this PR, as we can also simply avoid the situation until such time as it is fixed in AllinsonFlex.