### PR TITLE
[ESSI-1316] Turn off production mail errors; add config for contact_email, SMTP

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,11 +26,18 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: "localhost:3000" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address => ESSI.config.dig(:rails, :mailer, :address) || ENV['SMTP_ADDRESS'],
+    :port => ESSI.config.dig(:rails, :mailer, :port) || ENV['SMTP_PORT'],
+    :user_name => ESSI.config.dig(:rails, :mailer, :user_name) || ENV["SMTP_USERNAME"],
+    :password => ESSI.config.dig(:rails, :mailer, :password) || ENV["SMTP_PASSWORD"],
+    :authentication => ESSI.config.dig(:rails, :mailer, :authentication) || ENV["SMTP_AUTHENTICATION"],
+    :enable_starttls_auto => true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,13 +60,21 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter     = ESSI.config[:rails][:active_job][:queue_adapter].to_sym
   config.active_job.queue_name_prefix = "essi_#{Rails.env}"
-  config.action_mailer.perform_caching = false
 
+  config.action_mailer.perform_caching = false
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: ESSI.config[:rails][:mailer][:host] }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address => ESSI.config.dig(:rails, :mailer, :address) || ENV['SMTP_ADDRESS'],
+    :port => ESSI.config.dig(:rails, :mailer, :port) || ENV['SMTP_PORT'],
+    :user_name => ESSI.config.dig(:rails, :mailer, :user_name) || ENV["SMTP_USERNAME"],
+    :password => ESSI.config.dig(:rails, :mailer, :password) || ENV["SMTP_PASSWORD"],
+    :authentication => ESSI.config.dig(:rails, :mailer, :authentication) || ENV["SMTP_AUTHENTICATION"],
+    :enable_starttls_auto => true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -29,6 +29,11 @@ default: &default
   rails:
     mailer:
       host: localhost:3000
+      address: 'smtp.gmail.com'
+      port: 587
+      user_name: 'example@gmail.com'
+      password: 'app_password'
+      authentication: 'plain'
     serve_static_files: true
     secret_key_base: 628b30efcdf28acbbd30a80e53e2b743d44f74bf393462badc49e0f5909ed109812ff12905e3a98bf4f81d3618fac5c061ad4e1ca5c91f9c1dce8226ca3cff25
     cache:
@@ -175,6 +180,7 @@ default: &default
         url: https://example.com
     homepage_banner: images/homepage_banner.png
     whitelisted_ingest_dirs: []
+    contact_email: example@test.test
         
 development:
   <<: *default

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -26,6 +26,11 @@ default: &default
   rails:
     mailer:
       host: localhost:3000
+      address: 'smtp.gmail.com'
+      port: 587
+      user_name: 'example@gmail.com'
+      password: 'app_password'
+      authentication: 'plain'
     serve_static_files: true
     secret_key_base: 628b30efcdf28acbbd30a80e53e2b743d44f74bf393462badc49e0f5909ed109812ff12905e3a98bf4f81d3618fac5c061ad4e1ca5c91f9c1dce8226ca3cff25
     cache:
@@ -179,7 +184,8 @@ default: &default
         url: https://example.com
     homepage_banner: images/homepage_banner.png
     whitelisted_ingest_dirs: []
-
+    contact_email: example@test.test
+        
 development:
   <<: *default
 

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -32,7 +32,7 @@ Hyrax.config do |config|
   # config.rendering_predicate = ::RDF::DC.hasFormat
 
   # Email recipient of messages sent via the contact form
-  # config.contact_email = "repo-admin@example.org"
+  config.contact_email = ESSI.config.dig(:essi, :contact_email) || "repo-admin@example.org"
 
   # Text prefacing the subject entered in the contact form
   # config.subject_prefix = "Contact form:"


### PR DESCRIPTION
* Explicitly disables mailer errors in production
* Adds configuration for SMTP settings
* Adds configuration for `contact_email`, the email address sent to by the Contact form