### PR TITLE
ESSI-1316 Making additional SMTP options configurable

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.raise_delivery_errors = ESSI.config.dig(:rails, :mailer, :raise_delivery_errors) || ENV['SMTP_ERRORS']
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: "localhost:3000" }
   config.action_mailer.delivery_method = :smtp
@@ -36,7 +36,8 @@ Rails.application.configure do
     :user_name => ESSI.config.dig(:rails, :mailer, :user_name) || ENV["SMTP_USERNAME"],
     :password => ESSI.config.dig(:rails, :mailer, :password) || ENV["SMTP_PASSWORD"],
     :authentication => ESSI.config.dig(:rails, :mailer, :authentication) || ENV["SMTP_AUTHENTICATION"],
-    :enable_starttls_auto => true
+    :enable_starttls_auto => ESSI.config.dig(:rails, :mailer, :enable_starttls_auto) || ENV['SMTP_STARTTLS'],
+    :openssl_verify_mode => ESSI.config.dig(:rails, :mailer, :openssl_verify_mode) || ENV["SMTP_SSL_VERIFY"]
   }
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = ESSI.config.dig(:rails, :mailer, :raise_delivery_errors) || ENV['SMTP_ERRORS']
   config.action_mailer.default_url_options = { host: ESSI.config[:rails][:mailer][:host] }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
@@ -73,7 +73,8 @@ Rails.application.configure do
     :user_name => ESSI.config.dig(:rails, :mailer, :user_name) || ENV["SMTP_USERNAME"],
     :password => ESSI.config.dig(:rails, :mailer, :password) || ENV["SMTP_PASSWORD"],
     :authentication => ESSI.config.dig(:rails, :mailer, :authentication) || ENV["SMTP_AUTHENTICATION"],
-    :enable_starttls_auto => true
+    :enable_starttls_auto => ESSI.config.dig(:rails, :mailer, :enable_starttls_auto) || ENV['SMTP_STARTTLS'],
+    :openssl_verify_mode => ESSI.config.dig(:rails, :mailer, :openssl_verify_mode) || ENV["SMTP_SSL_VERIFY"]
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -31,6 +31,9 @@ default: &default
       user_name: 'example@gmail.com'
       password: 'app_password'
       authentication: 'plain'
+      raise_delivery_errors: false
+      enable_starttls_auto: true
+      openssl_verify_mode: 'none'
     serve_static_files: true
     secret_key_base: 628b30efcdf28acbbd30a80e53e2b743d44f74bf393462badc49e0f5909ed109812ff12905e3a98bf4f81d3618fac5c061ad4e1ca5c91f9c1dce8226ca3cff25
     cache:


### PR DESCRIPTION
To get email to route out of container environments and to a SMTP server, different environments may need more control over the available Action Mailer options.