### PR TITLE
[ESSI-1157] Add work type selection to Bulkrax import form for METS

### DIFF
--- a/app/models/bulkrax/mets_xml_entry.rb
+++ b/app/models/bulkrax/mets_xml_entry.rb
@@ -55,7 +55,7 @@ module Bulkrax
       self.parsed_metadata = {}
       self.parsed_metadata['admin_set_id'] = self.importerexporter.admin_set_id
       self.parsed_metadata[Bulkrax.system_identifier_field] = [source_identifier]
-      self.parsed_metadata['work_type'] = ['PagedResource']
+      self.parsed_metadata['work_type'] = [parser.parser_fields['work_type'] || 'PagedResource']
 
       record.attributes.each do |k,v|
         add_metadata(k, v) unless v.blank?

--- a/app/views/bulkrax/importers/_mets_xml_fields.html.erb
+++ b/app/views/bulkrax/importers/_mets_xml_fields.html.erb
@@ -22,6 +22,12 @@
 		], 
     selected: importer.parser_fields['import_type'],
     input_html: { class: 'form-control' }
+  %>
+
+  <%= fi.input :work_type, 
+    collection: Hyrax::SelectTypeListPresenter.new(current_user).options_for_select,
+    selected: importer.parser_fields['work_type'] || Bulkrax.default_work_type,
+    input_html: { class: 'form-control' }
     %>
   
   <h4>Visiblity</h4>

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -74,3 +74,6 @@ InheritPermissionsJob.prepend Extensions::Hyrax::Jobs::ShortCircuitOnNil
 
 # Hyrax user lookup
 Hyrax::UsersController.prepend Extensions::Hyrax::UsersController::FindUser
+
+# Hyrax Work Type selection
+Hyrax::SelectTypeListPresenter.prepend Extensions::Hyrax::SelectTypeListPresenter::OptionsForSelect

--- a/lib/extensions/hyrax/select_type_list_presenter/options_for_select.rb
+++ b/lib/extensions/hyrax/select_type_list_presenter/options_for_select.rb
@@ -1,0 +1,14 @@
+# options for select
+module Extensions
+  module Hyrax
+    module SelectTypeListPresenter
+      module OptionsForSelect
+        def options_for_select
+          options = []
+          self.each { |r| options << [r.name, r.concern.to_s] }
+          options.sort
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/select_type_list_presenter.rb
+++ b/spec/presenters/hyrax/select_type_list_presenter.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::SelectTypeListPresenter do
+  let(:user) { FactoryBot.build(:admin) }
+  subject { described_class.new(user) }
+
+  describe '#options_for_select' do
+    it 'returns a sorted array of work type names, classes (as Strings)' do
+      expect(subject.options_for_select.to_h.values).to eq Hyrax.config.registered_curation_concern_types.sort
+    end
+  end
+end


### PR DESCRIPTION
For METS format, changes Bulkrax format to pull work type from user form, rather than from METS metadata.

Another solution might be to handle this as rights_statement is done -- pulling the value from the metadata, but defaulting to the form value when blank, with a checkbox option to enforce overriding with the form value -- but this is minimal change necessary.