### PR TITLE
[ESSI-1336] Bulkrax import: use a specified dynamic schema (when provided)

### DIFF
--- a/app/actors/allinson_flex/dynamic_schema_actor.rb
+++ b/app/actors/allinson_flex/dynamic_schema_actor.rb
@@ -1,0 +1,21 @@
+module AllinsonFlex
+  class DynamicSchemaActor < Hyrax::Actors::AbstractActor
+    def create(env)
+      add_dynamic_schema(env)
+      next_actor.create(env)
+    end
+
+    def update(env)
+      add_dynamic_schema(env)
+      next_actor.update(env)
+    end
+
+    # @param [Hyrax::Actors::Environment] env
+    def add_dynamic_schema(env)
+      schema = env.curation_concern.dynamic_schema_service(as_id: env.attributes[:admin_set_id], update: true ).dynamic_schema
+      env.curation_concern.dynamic_schema = schema
+      env.attributes[:dynamic_schema_id] = schema.id
+      env.attributes[:profile_version] = schema.profile_version.to_f
+    end
+  end
+end

--- a/app/actors/allinson_flex/dynamic_schema_actor.rb
+++ b/app/actors/allinson_flex/dynamic_schema_actor.rb
@@ -1,18 +1,21 @@
 module AllinsonFlex
   class DynamicSchemaActor < Hyrax::Actors::AbstractActor
+    # modified from allinson_flex to not force update
     def create(env)
-      add_dynamic_schema(env)
+      add_dynamic_schema(env, update: false)
       next_actor.create(env)
     end
 
+    # modified from allinson_flex with explicit update argument
     def update(env)
-      add_dynamic_schema(env)
+      add_dynamic_schema(env, update: true)
       next_actor.update(env)
     end
 
     # @param [Hyrax::Actors::Environment] env
-    def add_dynamic_schema(env)
-      schema = env.curation_concern.dynamic_schema_service(as_id: env.attributes[:admin_set_id], update: true ).dynamic_schema
+    # modified from allinson_flex with explicit update argument
+    def add_dynamic_schema(env, update: true)
+      schema = env.curation_concern.dynamic_schema_service(as_id: env.attributes[:admin_set_id], update: update ).dynamic_schema
       env.curation_concern.dynamic_schema = schema
       env.attributes[:dynamic_schema_id] = schema.id
       env.attributes[:profile_version] = schema.profile_version.to_f

--- a/app/helpers/bulkrax/importers_helper.rb
+++ b/app/helpers/bulkrax/importers_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  module ImportersHelper
+    # borrowd from batch-importer https://github.com/samvera-labs/hyrax-batch_ingest/blob/master/app/controllers/hyrax/batch_ingest/batches_controller.rb
+    def available_admin_sets
+      # Restrict available_admin_sets to only those current user can desposit to.
+      @available_admin_sets ||= Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set').map do |admin_set_id|
+        [AdminSet.find(admin_set_id).title.first, admin_set_id]
+      end
+    end
+  end
+end

--- a/app/helpers/bulkrax/importers_helper.rb
+++ b/app/helpers/bulkrax/importers_helper.rb
@@ -11,7 +11,7 @@ module Bulkrax
     end
 
     def available_profiles
-      @available_profiles ||= AllinsonFlex::Profile.all.order(:id).map { |p| [p.profile_version.to_s, p.id] }
+      @available_profiles ||= AllinsonFlex::Profile.all.order(id: :desc).map { |p| [p.profile_version.to_s, p.id] }
     end
   end
 end

--- a/app/helpers/bulkrax/importers_helper.rb
+++ b/app/helpers/bulkrax/importers_helper.rb
@@ -9,5 +9,9 @@ module Bulkrax
         [AdminSet.find(admin_set_id).title.first, admin_set_id]
       end
     end
+
+    def available_profiles
+      @available_profiles ||= AllinsonFlex::Profile.all.order(:id).map { |p| [p.profile_version.to_s, p.id] }
+    end
   end
 end

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -1,6 +1,9 @@
 <div class='csv_fields'>
 
-  <%= fi.input :profile_id, collection: available_profiles, selected: available_profiles.last.last %>
+  <%= fi.input :profile_id,
+    collection: available_profiles,
+    selected: importer.parser_fields['profile_id'] || available_profiles.first.last
+  %>
 
   <%= fi.input :visibility,
     collection: [

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -1,5 +1,7 @@
 <div class='csv_fields'>
 
+  <%= fi.input :profile_id, collection: available_profiles, selected: available_profiles.last.last %>
+
   <%= fi.input :visibility,
     collection: [
       ['Public', 'open'],

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -1,0 +1,39 @@
+<div class='csv_fields'>
+
+  <%= fi.input :visibility,
+    collection: [
+      ['Public', 'open'],
+      ['Private', 'restricted']
+    ],
+    selected: importer.parser_fields['visibility'] || 'open',
+    input_html: { class: 'form-control' }
+  %>
+
+  <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
+  <%= fi.input :rights_statement,
+        collection: rights_statements.select_active_options,
+        selected: importer.parser_fields['rights_statement'],
+        include_blank: true,
+        item_helper: rights_statements.method(:include_current_value),
+        input_html: { class: 'form-control' },
+        required: false
+        %>
+  <%= fi.input :override_rights_statement, as: :boolean, hint: 'If checked, always use the selected rights statment. If unchecked, use rights or rights_statement from the record and only use the provided value if dc:rights is blank.', input_html: { checked: (importer.parser_fields['override_rights_statement'] == "1") } %>
+
+  <h4>Add CSV File to Import:</h4>
+  <%# accept a single file upload; data files and bags will need to be added another way %>
+
+  <%= fi.input :file_style, collection: ['Upload a File', 'Specify a Path on the Server'], as: :radio_buttons, label: false %>
+  <div id='file_upload'>
+    <%= fi.input 'file', as: :file, input_html: { accept: 'text/csv,application/zip' } %><br />
+  </div>
+  <div id='file_path'>
+    <%= fi.input :import_file_path, as: :string, input_html: { value: importer.parser_fields['import_file_path'] } %>
+  </div>
+  <% if Hyrax.config.browse_everything? %>
+	  <h4>Add Files to Import:</h4>
+	  <p>Choose files to upload. The filenames must be unique, and the filenames must be referenced in a column called 'file' in the accompanying CSV file.</p>
+    <%= render 'browse_everything', form: form %>
+  <% end %>
+  <br />
+</div>

--- a/app/views/bulkrax/importers/_mets_xml_fields.html.erb
+++ b/app/views/bulkrax/importers/_mets_xml_fields.html.erb
@@ -1,5 +1,7 @@
 <div class='mets_xml_fields'>
 
+  <%= fi.input :profile_id, collection: available_profiles, selected: available_profiles.last.last %>
+
   <%# @todo improve on this implementation. 
     As it stands, it's a hostage to namespaces, 
     eg. dc:title 

--- a/app/views/bulkrax/importers/_mets_xml_fields.html.erb
+++ b/app/views/bulkrax/importers/_mets_xml_fields.html.erb
@@ -1,6 +1,9 @@
 <div class='mets_xml_fields'>
 
-  <%= fi.input :profile_id, collection: available_profiles, selected: available_profiles.last.last %>
+  <%= fi.input :profile_id, 
+    collection: available_profiles, 
+    selected: importer.parser_fields['profile_id'] || available_profiles.first.last
+  %>
 
   <%# @todo improve on this implementation. 
     As it stands, it's a hostage to namespaces, 

--- a/lib/extensions/bulkrax/entry/dynamic_schema_field.rb
+++ b/lib/extensions/bulkrax/entry/dynamic_schema_field.rb
@@ -12,8 +12,12 @@ module Extensions
         def add_dynamic_schema
           return if self.parsed_metadata['dynamic_schema_id'].present?
           context_id = find_metadata_context_for(admin_set_id: self.parsed_metadata['admin_set_id'],
-                                                 profile_id: parser.parser_fields&.[]('profile_id'))
+                                                 profile_id: profile_id)
           self.parsed_metadata['dynamic_schema_id'] ||= ::AllinsonFlex::DynamicSchema.find_by(context_id: context_id, allinson_flex_class: factory_class.to_s)&.id
+        end
+
+        def profile_id
+          [self.parsed_metadata['profile_version'], self.parsed_metadata['profile_id'], parser.parser_fields&.[]('profile_id')].map(&:to_i).select(&:positive?).first
         end
 
         def find_metadata_context_for(admin_set_id:, profile_id:)

--- a/lib/extensions/bulkrax/entry/dynamic_schema_field.rb
+++ b/lib/extensions/bulkrax/entry/dynamic_schema_field.rb
@@ -10,7 +10,7 @@ module Extensions
         end
 
         def add_dynamic_schema
-          return if self.parsed_metadata['dynamic_schema_id']
+          return if self.parsed_metadata['dynamic_schema_id'].present?
           context_id = find_metadata_context_for(admin_set_id: self.parsed_metadata['admin_set_id'],
                                                  profile_id: parser.parser_fields&.[]('profile_id'))
           self.parsed_metadata['dynamic_schema_id'] ||= ::AllinsonFlex::DynamicSchema.find_by(context_id: context_id, allinson_flex_class: factory_class.to_s)&.id

--- a/lib/extensions/bulkrax/entry/dynamic_schema_field.rb
+++ b/lib/extensions/bulkrax/entry/dynamic_schema_field.rb
@@ -1,0 +1,26 @@
+# written as an Entry module, but needs to be applied to a specific subclass (e.i. CsvEntry)
+module Extensions
+  module Bulkrax
+    module Entry
+      module DynamicSchemaField
+        def build_metadata
+          super
+          add_dynamic_schema
+          self.parsed_metadata
+        end
+
+        def add_dynamic_schema
+          return if self.parsed_metadata['dynamic_schema_id']
+          context_id = find_metadata_context_for(admin_set_id: self.parsed_metadata['admin_set_id'],
+                                                 profile_id: parser.parser_fields&.[]('profile_id'))
+          self.parsed_metadata['dynamic_schema_id'] ||= ::AllinsonFlex::DynamicSchema.find_by(context_id: context_id, allinson_flex_class: factory_class.to_s)&.id
+        end
+
+        def find_metadata_context_for(admin_set_id:, profile_id:)
+          ::AllinsonFlex::Context.order("created_at asc").where(profile_id: profile_id).where.not(admin_set_ids: [nil, []]).select { |c| c.admin_set_ids.include?(admin_set_id) }.last ||
+            ::AllinsonFlex::Context.where(name: 'default').order('created_at').last
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/bulkrax/object_factory/create_with_dynamic_schema.rb
+++ b/lib/extensions/bulkrax/object_factory/create_with_dynamic_schema.rb
@@ -2,10 +2,10 @@ module Extensions
   module Bulkrax
     module ObjectFactory
       module CreateWithDynamicSchema
-        # unmodified
+        # modified to apply a supplied dynamic_schema_id to initial object build
         def create
           attrs = create_attributes
-          @object = klass.new
+          @object = klass.new(dynamic_schema_id: attrs[:dynamic_schema_id])
           object.reindex_extent = ::Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
           run_callbacks :save do
             run_callbacks :create do

--- a/lib/extensions/bulkrax/object_factory/create_with_dynamic_schema.rb
+++ b/lib/extensions/bulkrax/object_factory/create_with_dynamic_schema.rb
@@ -1,0 +1,20 @@
+module Extensions
+  module Bulkrax
+    module ObjectFactory
+      module CreateWithDynamicSchema
+        # unmodified
+        def create
+          attrs = create_attributes
+          @object = klass.new
+          object.reindex_extent = ::Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+          run_callbacks :save do
+            run_callbacks :create do
+              klass == ::Collection ? create_collection(attrs) : work_actor.create(environment(attrs))
+            end
+          end
+          log_created(object)
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/bulkrax/object_factory/structure.rb
+++ b/lib/extensions/bulkrax/object_factory/structure.rb
@@ -2,22 +2,20 @@ module Extensions
   module Bulkrax
     module ObjectFactory
       module Structure
-
-          def work_actor
-            # Override to force skipping duplicate perform later
-            actor = super
-            while(actor.class == ESSI::Actors::PerformLaterActor) do
-              actor = actor.next_actor
-            end
-            actor
+        def work_actor
+          # Override to force skipping duplicate perform later
+          actor = super
+          while(actor.class == ::ESSI::Actors::PerformLaterActor) do
+            actor = actor.next_actor
           end
+          actor
+        end
 
-          # Regardless of what the Parser gives us, these are the properties we are prepared to accept.
-          def permitted_attributes
-            # Override - add admin_set_id, structure to accepted fields
-            super + %i[admin_set_id structure]
-          end
-
+        # Regardless of what the Parser gives us, these are the properties we are prepared to accept.
+        def permitted_attributes
+          # Override - add admin_set_id, structure to accepted fields
+          super + %i[admin_set_id structure]
+        end
       end
     end
   end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -45,6 +45,8 @@ Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::Structure
 Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::CreateWithDynamicSchema
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::AllinsonFlexFields
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::SingularizeRightsStatement
+Bulkrax::CsvEntry.prepend Extensions::Bulkrax::Entry::DynamicSchemaField
+Bulkrax::MetsXmlEntry.prepend Extensions::Bulkrax::Entry::DynamicSchemaField
 Bulkrax::Exporter.prepend Extensions::Bulkrax::Exporter::LastRun
 Bulkrax::Importer.prepend Extensions::Bulkrax::Importer::LastRun
 

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -42,6 +42,7 @@ Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::SourceMetad
 
 # bulkrax overrides
 Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::Structure
+Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::CreateWithDynamicSchema
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::AllinsonFlexFields
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::SingularizeRightsStatement
 Bulkrax::Exporter.prepend Extensions::Bulkrax::Exporter::LastRun


### PR DESCRIPTION
For Bulkrax import via METS and CSV formats, add a form selection for "Profile Version".  The imported works should use the chosen Profile version, rather than assuming the most current version.  For CSV, the importer form selection can be overridden for one or more specific rows by providing `profile_id`/`profile_version` -- you can also provide the `dynamic_schema_id` directly but that value has much less discoverability. 