### PR TITLE
[ESSI-1338] Provide UI feedback for failed metadata profile import

### DIFF
--- a/lib/extensions/allinson_flex/prepend_profiles_controller.rb
+++ b/lib/extensions/allinson_flex/prepend_profiles_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Extensions
+  module AllinsonFlex
+    module PrependProfilesController
+      # unmodified from allinson_flex
+      def import
+        uploaded_io = params[:file]
+        if uploaded_io.blank?
+          redirect_to profiles_path, alert: 'Please select a file to upload'
+          return
+        end
+  
+        @allinson_flex_profile = ::AllinsonFlex::Importer.load_profile_from_path(path: uploaded_io.path)
+  
+        if @allinson_flex_profile.save
+          redirect_to profiles_path, notice: 'AllinsonFlexProfile was successfully created.'
+        else
+          redirect_to profiles_path, alert: @allinson_flex_profile.errors.messages.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/allinson_flex/prepend_profiles_controller.rb
+++ b/lib/extensions/allinson_flex/prepend_profiles_controller.rb
@@ -2,20 +2,38 @@
 module Extensions
   module AllinsonFlex
     module PrependProfilesController
-      # unmodified from allinson_flex
+      # modified from allinson_flex to supply error feedback
       def import
         uploaded_io = params[:file]
         if uploaded_io.blank?
           redirect_to profiles_path, alert: 'Please select a file to upload'
           return
         end
-  
-        @allinson_flex_profile = ::AllinsonFlex::Importer.load_profile_from_path(path: uploaded_io.path)
-  
-        if @allinson_flex_profile.save
+ 
+        begin 
+          @allinson_flex_profile = ::AllinsonFlex::Importer.load_profile_from_path(path: uploaded_io.path)
+        rescue ::AllinsonFlex::Importer::YamlSyntaxError => e
+          @validation_error = "Invalid YAML provided:<br/><br/>"
+          @validation_error += e.message
+        rescue ::AllinsonFlex::Validator::InvalidDataError
+          default_schema = ::JSONSchemer.schema(::Pathname.new(::AllinsonFlex.m3_schema_path))
+          data = ::YAML.load_file(uploaded_io.path)
+          @validation_error = "Profile data failed schema validation.  See logs for full details of all errors.  Initial errors are:<br/><br/>"
+          errors = default_schema.validate(data).to_a
+          errors.each do |error|
+            %w[type details data_pointer data schema_pointer schema].each do |key|
+              @validation_error += "#{key.titleize}: #{error[key]}<br/>" if error[key].present?
+            end
+            @validation_error += "<br/>"
+          end
+        end
+ 
+        if @validation_error.present?
+          redirect_to profiles_path, alert: @validation_error.to_s.truncate(800)
+        elsif @allinson_flex_profile.save
           redirect_to profiles_path, notice: 'AllinsonFlexProfile was successfully created.'
         else
-          redirect_to profiles_path, alert: @allinson_flex_profile.errors.messages.to_s
+          redirect_to profiles_path, alert: @allinson_flex_profile.errors.messages.to_s.truncate(800)
         end
       end
     end

--- a/lib/extensions/allinson_flex_extensions.rb
+++ b/lib/extensions/allinson_flex_extensions.rb
@@ -5,6 +5,7 @@ end
 
 #  controllers
 Hyrax::Admin::PermissionTemplatesController.prepend Extensions::AllinsonFlex::PrependPermissionTemplatesController
+AllinsonFlex::ProfilesController.prepend Extensions::AllinsonFlex::PrependProfilesController
 
 #  forms
 Hyrax::Forms::AdminSetForm.prepend Extensions::AllinsonFlex::PrependAdminSetForm

--- a/spec/controllers/allinson_flex/profiles_controller_spec.rb
+++ b/spec/controllers/allinson_flex/profiles_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe AllinsonFlex::ProfilesController, type: :controller do
+  routes { AllinsonFlex::Engine.routes }
+
+  context "when logged in as an admin user" do
+    let(:user) { FactoryBot.create(:admin) }
+
+    before do
+      sign_in user
+      allow_any_instance_of(user.class).to receive(:groups).and_return(['admin'])
+    end
+
+    describe 'POST #import', :clean do
+      context 'with no file' do
+        it 'redirects and alerts the file requirement' do
+          post :import, params: { file: '' }
+          expect(response).to be_redirect
+          expect(flash[:alert]).to eq('Please select a file to upload')
+        end
+      end
+      context 'with valid profile data' do
+        let(:file) { fixture_file_upload('allinson_flex/yaml_example.yaml') }
+        it 'redirects and notices the successful upload' do
+          post :import, params: { file: file }
+          expect(response).to be_redirect
+          expect(flash[:notice]).to match /AllinsonFlexProfile was successfully created/
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/allinson_flex/profiles_controller_spec.rb
+++ b/spec/controllers/allinson_flex/profiles_controller_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe AllinsonFlex::ProfilesController, type: :controller do
           expect(flash[:alert]).to eq('Please select a file to upload')
         end
       end
+      context 'with invalid YAML' do
+        let(:file) { fixture_file_upload('ocr.xml') }
+        it 'redirects and alerts the YAML failure' do
+          post :import, params: { file: file }
+          expect(response).to be_redirect
+          expect(flash[:alert]).to match /Invalid YAML/
+        end
+      end
+      context 'with invalid profile data' do
+        let(:file) { fixture_file_upload('paged_resource.yml') }
+        it 'redirects and alerts the data validation failure' do
+          post :import, params: { file: file }
+          expect(response).to be_redirect
+          expect(flash[:alert]).to match /data failed schema validation/
+        end
+      end
       context 'with valid profile data' do
         let(:file) { fixture_file_upload('allinson_flex/yaml_example.yaml') }
         it 'redirects and notices the successful upload' do

--- a/spec/factories/allinson_flex/profiles.rb
+++ b/spec/factories/allinson_flex/profiles.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :allinson_flex_profile, class: AllinsonFlex::Profile do
+    name { "Indiana University" }
+    sequence(:profile_version) { |n| n }
+    responsibility { 'http://iu.edu' }
+    date_modified { '2019-09-23' }
+    profile_classes { [FactoryBot.build(:allinson_flex_class)] }
+    profile_contexts { [FactoryBot.build(:profile_context)] }
+    properties { [FactoryBot.build(:allinson_flex_property)] }
+    profile { File.read('spec/fixtures/allinson_flex/yaml_example.yaml') }
+  end
+
+  factory :allinson_flex_class, class: AllinsonFlex::ProfileClass do
+    name            { "Image" }
+    display_label   { "Flexible Work" }
+    profile_contexts { [FactoryBot.build(:profile_context)] }
+    class_texts { [FactoryBot.build(:allinson_flex_text_for_class)] }
+  end
+
+  factory :profile_context, class: AllinsonFlex::ProfileContext do
+    name            { "flexible_context" }
+    display_label   { "Flexible Context" }
+    context_texts { [FactoryBot.build(:allinson_flex_text_for_context)] }
+  end
+
+  factory :allinson_flex_property, class: AllinsonFlex::ProfileProperty do
+    name            { "title" }
+    indexing        { ['stored_searchable'] }
+    available_on_classes { [FactoryBot.build(:allinson_flex_class)] }
+    available_on_contexts { [FactoryBot.build(:profile_context)] }
+    texts do
+      [
+        FactoryBot.build(:allinson_flex_text),
+        FactoryBot.build(:allinson_flex_text_for_class),
+        FactoryBot.build(:allinson_flex_text_for_context)
+      ]
+    end
+  end
+
+  factory :allinson_flex_text, class: AllinsonFlex::ProfileText do
+    name { "display_label" }
+    value { "Title" }
+  end
+
+  factory :allinson_flex_text_for_class, class: AllinsonFlex::ProfileText do
+    name            { "display_label" }
+    value           { "Title in Class" }
+  end
+
+  factory :allinson_flex_text_for_context, class: AllinsonFlex::ProfileText do
+    name            { "display_label" }
+    value { "Title in Context" }
+  end
+end

--- a/spec/fixtures/allinson_flex/yaml_example.yaml
+++ b/spec/fixtures/allinson_flex/yaml_example.yaml
@@ -1,0 +1,48 @@
+#-------------------
+# AllinsonFlex Metadata Model
+#-------------------
+
+# ESSI Sample Profile (see https://github.com/samvera-labs/houndstooth/tree/context)
+
+m3_version: "1.0.beta2"
+
+# Administrative information about the profile/model
+
+profile:
+  responsibility: https://indiana.edu/
+  responsibility_statement: Indiana University
+  date_modified: "2019-07-28"
+  type: concept
+  version: 0.1
+
+classes:
+  Image:
+    display_label: "Image Example"
+    contexts:
+      - "flexible_context"
+
+contexts:
+  flexible_context:
+    display_label: "Flexible Work Example"
+
+properties:
+  title:
+    display_label:
+      default: "Title"
+      Image: "Title for Work Type"
+      flexible_context: "Title in Context"
+    property_uri: http://purl.org/dc/terms/title
+    available_on:
+      class:
+        - Image
+        - BibRecord
+        - PagedResource
+        - Scientific
+      context:
+        - flexible_context
+    cardinality:
+      minimum: 1
+    index_documentation: "Title should be indexed as searchable and displayable."
+    indexing:
+      - "stored_searchable"
+      - "facetable"


### PR DESCRIPTION
Modified the #import action on the AllinsonFlex profiles controller to catch ruby error conditions for:
* invalid YAML
* valid YAML, but with invalid data (according to the flexible metadata schema)