### PR TITLE
[ESSI-1358] Change "User Collection" to "Collection"

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,4 +1,9 @@
 Hyrax.config do |config|
+  # eager load Hyrax translations
+  [Pathname.new(Gem.loaded_specs['hyrax'].full_gem_path), Rails.root].each do |source_path|
+    I18n.load_path += Dir.glob(source_path.join('config', 'locales', '*'))
+  end
+
   # Injected via `rails g hyrax:work Image`
   config.register_curation_concern :image
   # Injected via `rails g hyrax:work BibRecord`

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -47,10 +47,21 @@ en:
           title_tesim: Title
   hyrax:
     account_name: My Institution Account Id
+    admin:
+      collection_types:
+        errors:
+          no_settings_change_for_user_collections: Collection type settings cannot be altered for the User Collection type
+        index:
+          more_toggle_content_html: "<p>Typical scenarios for collection types include:</p> <ul> <li><strong>User Collections</strong> that any registered user can create to organize items they deposit.</li> <li><strong>Exhibits</strong> that staff create and curate for public display, where items can be included in any number of exhibits.</li> <li><strong>Controlled Collections</strong> created and managed by staff and not intended for public display, such as collections associated with organizational units or departments.</li> <li><strong>Community Collections</strong> that are intended for public display, similar to how DSpace communities and collections are sometimes used.</li> </ul>"
     base:
       file_manager_actions:
         save: Save changes
         saving: Saving...
+    collection_type:
+      default_title: User Collection
+    collection_types:
+      create_service:
+        default_description: A User Collection can be created by any user to organize their works.
     collections:
       show:
         list_collections: List of items in this collection

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -50,18 +50,18 @@ en:
     admin:
       collection_types:
         errors:
-          no_settings_change_for_user_collections: Collection type settings cannot be altered for the User Collection type
+          no_settings_change_for_user_collections: Collection type settings cannot be altered for the Collection type
         index:
-          more_toggle_content_html: "<p>Typical scenarios for collection types include:</p> <ul> <li><strong>User Collections</strong> that any registered user can create to organize items they deposit.</li> <li><strong>Exhibits</strong> that staff create and curate for public display, where items can be included in any number of exhibits.</li> <li><strong>Controlled Collections</strong> created and managed by staff and not intended for public display, such as collections associated with organizational units or departments.</li> <li><strong>Community Collections</strong> that are intended for public display, similar to how DSpace communities and collections are sometimes used.</li> </ul>"
+          more_toggle_content_html: "<p>Typical scenarios for collection types include:</p> <ul> <li><strong>Collections</strong> that any registered user can create to organize items they deposit.</li> <li><strong>Exhibits</strong> that staff create and curate for public display, where items can be included in any number of exhibits.</li> <li><strong>Controlled Collections</strong> created and managed by staff and not intended for public display, such as collections associated with organizational units or departments.</li> <li><strong>Community Collections</strong> that are intended for public display, similar to how DSpace communities and collections are sometimes used.</li> </ul>"
     base:
       file_manager_actions:
         save: Save changes
         saving: Saving...
     collection_type:
-      default_title: User Collection
+      default_title: Collection
     collection_types:
       create_service:
-        default_description: A User Collection can be created by any user to organize their works.
+        default_description: A Collection can be created by any user to organize their works.
     collections:
       show:
         list_collections: List of items in this collection


### PR DESCRIPTION
The value to be changed needs to be tackled in 3 distinct manners:

1. Persistence in `Hyrax::CollectionType`, which can be fixed with a database record update along these lines:
```ruby
user_collection = Hyrax::CollectionType.find_by_machine_id('user_collection')
user_collection.update_attribute(:description, 'A Collection can be created by any user to organize their works.')
user_collection.update_attribute(:title, 'Collection')
```
(this PR does _not_ currently include that as a migration, but it could be added)
2. Certain `I18n` config values; there are separate commits explicitly inheriting these from hyrax, and then modifying them
3.  A hyrax issue is that:
    * certain `I18n` values are read and frozen during class initialization -- see [an example](https://github.com/samvera/hyrax/blob/main/app/models/hyrax/collection_type.rb#L26), and [another](https://github.com/samvera/hyrax/blob/main/app/controllers/hyrax/my/collections_controller.rb#L8-L20) -- _and_
    * this is done at a point in application startup when some, but not all, paths have been loaded into `I18n.load_path`

This 3rd issue leads to "translation missing" text persisting in the application.  The third commit kludges around this by explicitly loading `hyrax` and `essi` in the hyrax initializer.