### PR TITLE
[ESSI-1361] Allow choosing Collection thumbnail from any Fileset (beyond first 10)

### DIFF
--- a/app/indexers/archival_material_indexer.rb
+++ b/app/indexers/archival_material_indexer.rb
@@ -4,6 +4,7 @@ class ArchivalMaterialIndexer < Hyrax::WorkIndexer
   include ESSI::IndexesArchivalMaterialMetadata # Replaces IndexesBasicMetadata
   include ESSI::ArchivalMaterialIndexerBehavior
   include ESSI::IIIFThumbnailBehavior
+  include ESSI::IndexesFilesets
   include ESSI::IndexesNumPages
 
   # Uncomment this block if you want to add custom indexing behavior:

--- a/app/indexers/bib_record_indexer.rb
+++ b/app/indexers/bib_record_indexer.rb
@@ -4,6 +4,7 @@ class BibRecordIndexer < Hyrax::WorkIndexer
   include ESSI::IndexesBibRecordMetadata # Replaces IndexesBasicMetadata
   include ESSI::BibRecordIndexerBehavior
   include ESSI::IIIFThumbnailBehavior
+  include ESSI::IndexesFilesets
   include ESSI::IndexesNumPages
 
   # Uncomment this block if you want to add custom indexing behavior:

--- a/app/indexers/concerns/essi/indexes_filesets.rb
+++ b/app/indexers/concerns/essi/indexes_filesets.rb
@@ -1,0 +1,9 @@
+module ESSI
+  module IndexesFilesets
+    def generate_solr_document
+      super.tap do |solr_doc|
+        solr_doc['file_sets_ssim'] = object.file_sets.map(&:to_s)
+      end
+    end
+  end
+end

--- a/app/indexers/image_indexer.rb
+++ b/app/indexers/image_indexer.rb
@@ -4,6 +4,7 @@ class ImageIndexer < Hyrax::WorkIndexer
   include ESSI::IndexesImageMetadata # Replaces IndexesBasicMetadata
   include ESSI::ImageIndexerBehavior
   include ESSI::IIIFThumbnailBehavior
+  include ESSI::IndexesFilesets
   include ESSI::IndexesNumPages
 
   # Uncomment this block if you want to add custom indexing behavior:

--- a/app/indexers/paged_resource_indexer.rb
+++ b/app/indexers/paged_resource_indexer.rb
@@ -4,6 +4,7 @@ class PagedResourceIndexer < Hyrax::WorkIndexer
   include ESSI::IndexesPagedResourceMetadata # Replaces IndexesBasicMetadata
   include ESSI::PagedResourceIndexerBehavior
   include ESSI::IIIFThumbnailBehavior
+  include ESSI::IndexesFilesets
   include ESSI::IndexesNumPages
 
   # Uncomment this block if you want to add custom indexing behavior:

--- a/app/indexers/scientific_indexer.rb
+++ b/app/indexers/scientific_indexer.rb
@@ -4,6 +4,7 @@ class ScientificIndexer < Hyrax::WorkIndexer
   include ESSI::IndexesScientificMetadata # Replaces IndexesBasicMetadata
   include ESSI::ScientificIndexerBehavior
   include ESSI::IIIFThumbnailBehavior
+  include ESSI::IndexesFilesets
   include ESSI::IndexesNumPages
 
   # Uncomment this block if you want to add custom indexing behavior:

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -97,3 +97,8 @@ Hyrax::SelectTypeListPresenter.prepend Extensions::Hyrax::SelectTypeListPresente
 
 # return false for render_bookmarks_control? in CollectionsController
 Hyrax::CollectionsController.prepend Extensions::Hyrax::CollectionsController::RenderBookmarksControl
+
+# ESSI-1361: select from all files for Collection thumbnail
+Hyrax::Forms::CollectionForm.prepend Extensions::Hyrax::Forms::CollectionForm::AllFilesWithAccess
+Hyrax::CollectionMemberSearchBuilder.prepend Extensions::Hyrax::CollectionMemberSearchBuilder::Rows
+Hyrax::Collections::CollectionMemberService.prepend Extensions::Hyrax::Collections::CollectionMemberService::AvailableMemberFilesetTitleIds

--- a/lib/extensions/hyrax/collection_member_search_builder/rows.rb
+++ b/lib/extensions/hyrax/collection_member_search_builder/rows.rb
@@ -1,0 +1,28 @@
+# unmodified Hyrax/Blacklight methods, prepping changes for ESSI-1361, collection thumbnail selection
+module Extensions
+  module Hyrax
+    module CollectionMemberSearchBuilder
+      module Rows
+        def rows=(value)
+          params_will_change!
+          @rows = [value, blacklight_config.max_per_page].map(&:to_i).min
+        end
+    
+        # @param [#to_i] value
+        def rows(value = nil)
+          if value
+            self.rows = value
+            return self
+          end
+          @rows ||= begin
+            # user-provided parameters should override any default row
+            r = [:rows, :per_page].map {|k| blacklight_params[k] }.reject(&:blank?).first
+            r ||= blacklight_config.default_per_page
+            # ensure we don't excede the max page size
+            r.nil? ? nil : [r, blacklight_config.max_per_page].map(&:to_i).min
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/collection_member_search_builder/rows.rb
+++ b/lib/extensions/hyrax/collection_member_search_builder/rows.rb
@@ -1,11 +1,11 @@
-# unmodified Hyrax/Blacklight methods, prepping changes for ESSI-1361, collection thumbnail selection
+# modified Hyrax/Blacklight methods, to allow arbitrary number of rows, for ESSI-1361, collection thumbnail selection
 module Extensions
   module Hyrax
     module CollectionMemberSearchBuilder
       module Rows
         def rows=(value)
           params_will_change!
-          @rows = [value, blacklight_config.max_per_page].map(&:to_i).min
+          @rows = [value, 1].map(&:to_i).max
         end
     
         # @param [#to_i] value
@@ -18,8 +18,7 @@ module Extensions
             # user-provided parameters should override any default row
             r = [:rows, :per_page].map {|k| blacklight_params[k] }.reject(&:blank?).first
             r ||= blacklight_config.default_per_page
-            # ensure we don't excede the max page size
-            r.nil? ? nil : [r, blacklight_config.max_per_page].map(&:to_i).min
+            r.nil? ? nil : [r, 1].map(&:to_i).max
           end
         end
       end

--- a/lib/extensions/hyrax/collections/collection_member_service/available_member_fileset_title_ids.rb
+++ b/lib/extensions/hyrax/collections/collection_member_service/available_member_fileset_title_ids.rb
@@ -1,9 +1,31 @@
-# incoming modifications for ESSI-1361, collection thumbnail selection
+# new methods for ESSI-1361, collection thumbnail selection
 module Extensions
   module Hyrax
     module Collections
       module CollectionMemberService
         module AvailableMemberFilesetTitleIds
+
+          def available_member_fileset_title_ids
+            query_solr_with_and_merge(query_builder: fileset_title_ids_search_builder,
+                                      with_params: params,
+                                      merge_params: { fl: ['file_sets_ssim', 'file_set_ids_ssim'] })
+          end
+
+          private
+
+          # @api private
+          #
+          def query_solr_with_and_merge(query_builder:, with_params: {}, merge_params: {})
+            repository.search(query_builder.with(with_params).merge(merge_params).query)
+          end
+
+          # @api private
+          #
+          # set up a member search builder for returning fileset titles and ids only
+          # @return [CollectionMemberSearchBuilder] new or existing
+          def fileset_title_ids_search_builder
+            @fileset_title_ids_search_builder ||= ::Hyrax::CollectionMemberSearchBuilder.new(scope: scope, collection: collection, search_includes_models: :works)
+          end
         end
       end
     end

--- a/lib/extensions/hyrax/collections/collection_member_service/available_member_fileset_title_ids.rb
+++ b/lib/extensions/hyrax/collections/collection_member_service/available_member_fileset_title_ids.rb
@@ -1,0 +1,11 @@
+# incoming modifications for ESSI-1361, collection thumbnail selection
+module Extensions
+  module Hyrax
+    module Collections
+      module CollectionMemberService
+        module AvailableMemberFilesetTitleIds
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/forms/collection_form/all_files_with_access.rb
+++ b/lib/extensions/hyrax/forms/collection_form/all_files_with_access.rb
@@ -8,7 +8,13 @@ module Extensions
           private
 
           def all_files_with_access
-            member_presenters(member_work_ids).flat_map(&:file_set_presenters).map { |x| [x.to_s, x.id] }
+            member_file_set_title_ids.sort { |x,y| x[0].upcase <=> y[0].upcase }
+          end
+
+          # @return [Array] grandchild FileSet title, id pairs
+          def member_file_set_title_ids
+            docs = collection_member_service.available_member_fileset_title_ids.response.fetch('docs').select(&:present?)
+            docs.flat_map { |e| (e['file_sets_ssim'] || e['file_set_ids_ssim'] || []).zip(e['file_set_ids_ssim'] || []) }.select(&:any?)
           end
 
           # modified from hyrax to support custom solr params, specifically more rows

--- a/lib/extensions/hyrax/forms/collection_form/all_files_with_access.rb
+++ b/lib/extensions/hyrax/forms/collection_form/all_files_with_access.rb
@@ -11,8 +11,11 @@ module Extensions
             member_presenters(member_work_ids).flat_map(&:file_set_presenters).map { |x| [x.to_s, x.id] }
           end
 
-          def collection_member_service
-            @collection_member_service ||= membership_service_class.new(scope: scope, collection: collection, params: blacklight_config.default_solr_params)
+          # modified from hyrax to support custom solr params, specifically more rows
+          # @param solr_params [Hash] the solr parameters to merge into defaults
+          # @return [Hyrax::Collections::CollectionMemberService]
+          def collection_member_service(solr_params: { rows: 10_000 })
+            @collection_member_service ||= membership_service_class.new(scope: scope, collection: collection, params: blacklight_config.default_solr_params.deep_dup.merge(solr_params))
           end
         end
       end

--- a/lib/extensions/hyrax/forms/collection_form/all_files_with_access.rb
+++ b/lib/extensions/hyrax/forms/collection_form/all_files_with_access.rb
@@ -1,0 +1,21 @@
+# unmodified hyrax methods prepping monkeypatch for ESSI-1361
+module Extensions
+  module Hyrax
+    module Forms
+      module CollectionForm
+        module AllFilesWithAccess
+
+          private
+
+          def all_files_with_access
+            member_presenters(member_work_ids).flat_map(&:file_set_presenters).map { |x| [x.to_s, x.id] }
+          end
+
+          def collection_member_service
+            @collection_member_service ||= membership_service_class.new(scope: scope, collection: collection, params: blacklight_config.default_solr_params)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Inherited issues:
  * default limit of 10 rows in a solr query result (unless otherwise specified)
  * `SearchBuilder` and subclasses limit of 100 rows in a solr query result (even if a greater amount specified)
  * poorly-scaling performance of `#all_files_with_access` generating a tree of presenters and solr queries

Changes:
 * adds support for `CollectionMemberSearchBuilder` returning any configured number of rows
 * refactors #all_files_with_access to run a single solr query
 * adds indexing of `FileSet` titles to a work, along with ids
   *  This is more consistent with how collections associated to a work are indexed on the work for both titles and ids, and facilitates the `#all_files_with_access` refactoring