### PR TITLE
Essi-1329 Speedup work edit forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ group :development do
 
   gem 'debase'
   gem 'ruby-debug-ide'
+  gem 'rack-mini-profiler'
+  gem 'stackprof'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -699,6 +699,8 @@ GEM
       rdf
     racc (1.5.2)
     rack (2.2.3)
+    rack-mini-profiler (2.3.2)
+      rack (>= 1.2.0)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -955,6 +957,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     ssrf_filter (1.0.7)
+    stackprof (0.2.17)
     switch_user (1.5.4)
     sxp (1.1.0)
       rdf (~> 3.1)
@@ -1058,6 +1061,7 @@ DEPENDENCIES
   omniauth-cas
   prawn
   puma
+  rack-mini-profiler
   rails (~> 5.1.6)
   rails-controller-testing
   react-rails
@@ -1073,6 +1077,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  stackprof
   switch_user
   turbolinks (~> 5)
   uglifier (>= 1.3.0)

--- a/app/helpers/file_manager_helper.rb
+++ b/app/helpers/file_manager_helper.rb
@@ -1,6 +1,6 @@
 module FileManagerHelper
   def ocr_check(presenter)
-    return '✅' if presenter.extracted_text
+    return '✅' if presenter.extracted_text?
     '❌'
   end
 end

--- a/app/helpers/file_manager_helper.rb
+++ b/app/helpers/file_manager_helper.rb
@@ -1,6 +1,6 @@
 module FileManagerHelper
-  def ocr_check(id)
-    return '✅' if FileSet.find(id).extracted_text
+  def ocr_check(presenter)
+    return '✅' if presenter.extracted_text
     '❌'
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -36,6 +36,7 @@ class SolrDocument
   attribute :original_file_id, Solr::String, solr_name('original_file_id', :stored_sortable)
   attribute :allow_pdf_download, Solr::String, solr_name('allow_pdf_download', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
   attribute :file_set_ids, Solr::Array, solr_name('file_set_ids', :symbol)
+  attribute :extracted_text, Solr::String, 'ocr_text_tesi'
 
   def series
     self[Solrizer.solr_name('series')]

--- a/app/views/hyrax/base/_file_manager_attributes.html.erb
+++ b/app/views/hyrax/base/_file_manager_attributes.html.erb
@@ -1,4 +1,4 @@
-OCR: <%= ocr_check(node.id) %>
+OCR: <%= ocr_check(node) %>
 
 <% hints = ['', 'non-paged', 'facing-pages'] %>
 <% hints_t = I18n.t('simple_form.options.file_set.viewing_hint').map{|key,val| [key.to_sym, val.to_s] }.to_h %>

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -39,6 +39,8 @@ Hyrax::WorkShowPresenter.include Extensions::Hyrax::WorkShowPresenter::Collectio
 Hyrax::Forms::WorkForm.include Extensions::Hyrax::Forms::WorkForm::PrimaryFields
 # support for worktype-specific #work_requires_files?
 Hyrax::Forms::WorkForm.include Extensions::Hyrax::Forms::WorkForm::WorkRequiresFiles
+# speedup work_members list generation by using solr
+Hyrax::Forms::WorkForm.prepend Extensions::Hyrax::Forms::WorkForm::WorkMembersSpeedy
 
 # IIIF Thumbnails for both types of Collections
 Hyrax::AdminSetIndexer.include ESSI::IIIFCollectionThumbnailBehavior

--- a/lib/extensions/hyrax/file_set_presenter/extracted_text.rb
+++ b/lib/extensions/hyrax/file_set_presenter/extracted_text.rb
@@ -3,8 +3,10 @@ module Extensions
   module Hyrax
     module FileSetPresenter
       module ExtractedText
+        delegate :extracted_text, to: :solr_document
+        
         def extracted_text?
-          ::FileSet.find(id).extracted_text.present?
+          extracted_text.present?
         end
       
         def extracted_text_link

--- a/lib/extensions/hyrax/forms/work_form/work_members_speedy.rb
+++ b/lib/extensions/hyrax/forms/work_form/work_members_speedy.rb
@@ -1,0 +1,14 @@
+module Extensions
+  module Hyrax
+    module Forms
+      module WorkForm
+        module WorkMembersSpeedy
+          # Use solr instead of fedora to lookup work members
+          def work_members
+            model.member_works
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Loading the edit form for works with many filesets can be very slow, to the point of the web proxy timing out. Rendering the edit form loads from fedora all members of the work, both filesets and works, and then filters to only works. This PR changes the loading behavior to use the membership data indexed in solr.

The work file manager shows icons for each file indicating if there is an associated OCR file. This required a fedora lookup for each file. This is being changed to use the ocr_text solr field.

This also adds some profiling gems to the development gem group. Now, when in development mode, we should see a profiler dialog in the upper left of the screen. A stack profile for a particular page can be accessed by adding `pp=flamegraph` to the page url parameters.