### PR TITLE
[ESSI-1371] In bulkrax export, skip redundant record saves, and make optional

### DIFF
--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -83,6 +83,10 @@
   <%= form.input :parser_klass, 
     collection: Bulkrax.parsers.map {|p| [p[:name], p[:class_name], {'data-partial' => p[:partial]}] if p[:class_name].constantize.export_supported? }.compact, 
     label: t('bulkrax.exporter.labels.export_format') %>
+
+  <%= form.input :make_round_trippable,
+    collection: [['No', false], ['Yes', true]],
+    label: t('bulkrax.exporter.labels.make_round_trippable') %>
 </div>
 
 <%# Find definitions for the functions called in this script in

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -1,0 +1,120 @@
+<div class="panel-body">
+  <% if exporter.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(exporter.errors.count, "error") %> prohibited this exporter from being saved:</h2>
+
+      <ul>
+        <% exporter.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= form.input :name, label: t('bulkrax.exporter.labels.name') %>
+
+  <%= form.hidden_field :user_id, value: current_user.id %>
+
+  <%= form.input :export_type, 
+    collection:  form.object.export_type_list, 
+    label: t('bulkrax.exporter.labels.export_type'), 
+    required: true,
+    prompt: 'Please select an export type' %>
+
+  <%= form.input :export_from, 
+    collection: form.object.export_from_list, 
+    label: t('bulkrax.exporter.labels.export_from'), 
+    required: true,
+    prompt: 'Please select an export source' %>
+
+  <%= form.input :export_source_importer,
+    label: t('bulkrax.exporter.labels.importer'),
+    prompt: 'Select from the list',
+    label_html: { class: 'importer export-source-option hidden' },
+    input_html: { class: 'importer export-source-option hidden' },
+    collection:  form.object.importers_list %>
+
+  <%= form.input :export_source_collection,
+    prompt: 'Start typing ...',
+    label: t('bulkrax.exporter.labels.collection'),
+    placeholder: @collection&.title&.first,
+    label_html: { class: 'collection export-source-option hidden' },
+    input_html: {
+      class: 'collection export-source-option hidden',
+      data: {
+        'autocomplete-url' => '/authorities/search/collections',
+        'autocomplete' => 'collection'
+      }
+    }
+  %>
+
+  <%= form.input :export_source_worktype,
+    label: t('bulkrax.exporter.labels.worktype'),
+    prompt: 'Select from the list',
+    label_html: { class: 'worktype export-source-option hidden' },
+    input_html: { class: 'worktype export-source-option hidden' },
+    collection: Hyrax.config.curation_concerns.map {|cc| [cc.to_s, cc.to_s] } %>
+
+  <%= form.input :limit, 
+    as: :integer, 
+    hint: 'leave blank or 0 for all records',
+    label: t('bulkrax.exporter.labels.limit') %>
+
+  <%= form.input :date_filter,
+                 as: :boolean,
+                 label: t('bulkrax.exporter.labels.filter_by_date') %>
+  <div id="date_filter_picker" class="hidden">
+    <%= form.input :start_date,
+                   as: :date,
+                   label: t('bulkrax.exporter.labels.start_date') %>
+
+    <%= form.input :finish_date,
+                   as: :date,
+                   label: t('bulkrax.exporter.labels.finish_date') %>
+  </div>
+  <%= form.input :work_visibility,
+                 collection: form.object.work_visibility_list,
+                 label: t('bulkrax.exporter.labels.visibility') %>
+
+  <%= form.input :workflow_status,
+                 collection: form.object.workflow_status_list,
+                 label: t('bulkrax.exporter.labels.status') %>
+
+  <%= form.input :parser_klass, 
+    collection: Bulkrax.parsers.map {|p| [p[:name], p[:class_name], {'data-partial' => p[:partial]}] if p[:class_name].constantize.export_supported? }.compact, 
+    label: t('bulkrax.exporter.labels.export_format') %>
+</div>
+
+<%# Find definitions for the functions called in this script in
+    app/assets/javascripts/bulkrax/exporters.js %>
+<script>
+  $(function() {
+    // show the selected export_source option
+    var selectedVal = $('.exporter_export_from option:selected').val();
+    hideUnhide(selectedVal);
+
+    // Select2 dropdowns don't like taking a value param. Thus,
+    // if export_source_collection is present, we populate the input.
+    var selectedCollectionId = "<%= @collection&.id %>"
+    if (selectedCollectionId.length > 0) {
+      $('#exporter_export_source_collection').val(selectedCollectionId)
+    }
+
+    // get the selected export_from option and show the corresponding export_source
+    $('.exporter_export_from').change(function() {
+      var selectedVal = $('.exporter_export_from option:selected').val();
+      hideUnhide(selectedVal);
+    });
+
+    // get the date filter option and show the corresponding date selectors
+    $('.exporter_date_filter').change(function() {
+        if($('.exporter_date_filter').find(".boolean").is(":checked"))
+            $('#date_filter_picker').removeClass('hidden');
+        else
+            $('#date_filter_picker').addClass('hidden');
+    });
+
+    if($('.exporter_date_filter').find(".boolean").is(":checked"))
+        $('#date_filter_picker').removeClass('hidden');
+  });
+</script>

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -1,0 +1,5 @@
+en:
+  bulkrax:
+    exporter:
+      labels:
+        make_round_trippable: Make Round Trippable

--- a/db/migrate/20210820144015_add_make_round_trippable_to_bulkrax_exporters.rb
+++ b/db/migrate/20210820144015_add_make_round_trippable_to_bulkrax_exporters.rb
@@ -1,0 +1,5 @@
+class AddMakeRoundTrippableToBulkraxExporters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bulkrax_exporters, :make_round_trippable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210802164419) do
+ActiveRecord::Schema.define(version: 20210820144015) do
 
-  create_table "allinson_flex_contexts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "allinson_flex_contexts", force: :cascade do |t|
     t.string "name"
     t.string "admin_set_ids"
     t.string "m3_context_name"
@@ -24,28 +24,28 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["profile_id"], name: "index_allinson_flex_contexts_on_profile_id"
   end
 
-  create_table "allinson_flex_dynamic_schemas", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "allinson_flex_dynamic_schemas", force: :cascade do |t|
     t.string "allinson_flex_class"
     t.integer "context_id"
     t.integer "profile_id"
-    t.text "schema", limit: 16777215
+    t.text "schema", limit: 3000000
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["context_id"], name: "index_allinson_flex_dynamic_schemas_on_context_id"
     t.index ["profile_id"], name: "index_allinson_flex_dynamic_schemas_on_profile_id"
   end
 
-  create_table "allinson_flex_profile_available_properties", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "allinson_flex_profile_available_properties", force: :cascade do |t|
     t.integer "profile_property_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "available_on_type"
-    t.bigint "available_on_id"
+    t.integer "available_on_id"
     t.index ["available_on_type", "available_on_id"], name: "index_allinson_flex_profile_properties_available_on"
     t.index ["profile_property_id"], name: "index_available_properties_on_property_id"
   end
 
-  create_table "allinson_flex_profile_classes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "allinson_flex_profile_classes", force: :cascade do |t|
     t.string "name"
     t.string "display_label"
     t.string "schema_uri"
@@ -55,16 +55,16 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["profile_id"], name: "index_allinson_flex_profile_classes_on_profile_id"
   end
 
-  create_table "allinson_flex_profile_classes_contexts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint "profile_context_id"
-    t.bigint "profile_class_id"
+  create_table "allinson_flex_profile_classes_contexts", force: :cascade do |t|
+    t.integer "profile_context_id"
+    t.integer "profile_class_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["profile_class_id"], name: "index_profile_classes_contexts_on_profile_class_id"
     t.index ["profile_context_id"], name: "index_profile_classes_contexts_on_profile_context_id"
   end
 
-  create_table "allinson_flex_profile_contexts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "allinson_flex_profile_contexts", force: :cascade do |t|
     t.string "name"
     t.string "display_label"
     t.integer "profile_id"
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["profile_id"], name: "index_allinson_flex_profile_contexts_on_profile_id"
   end
 
-  create_table "allinson_flex_profile_properties", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "allinson_flex_profile_properties", force: :cascade do |t|
     t.string "name"
     t.string "property_uri"
     t.integer "cardinality_minimum", default: 0
@@ -85,32 +85,32 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["profile_id"], name: "index_profile_properties_on_profile_id"
   end
 
-  create_table "allinson_flex_profile_texts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "allinson_flex_profile_texts", force: :cascade do |t|
     t.string "name"
     t.string "value"
     t.integer "profile_property_id"
     t.string "textable_type"
-    t.bigint "textable_id"
+    t.integer "textable_id"
     t.index ["profile_property_id"], name: "index_profile_texts_on_profile_property_id"
     t.index ["textable_type", "textable_id"], name: "index_profile_texts_on_type_and_id"
   end
 
-  create_table "allinson_flex_profiles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "allinson_flex_profiles", force: :cascade do |t|
     t.string "name"
-    t.float "profile_version", limit: 24
+    t.float "profile_version"
     t.string "m3_version"
     t.string "responsibility"
     t.string "responsibility_statement"
     t.string "date_modified"
     t.string "profile_type"
-    t.text "profile", limit: 16777215
+    t.text "profile", limit: 3000000
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "locked_at"
     t.integer "locked_by_id"
   end
 
-  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -122,12 +122,11 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "bulkrax_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.string "importerexporter_type", default: "Bulkrax::Importer"
+  create_table "bulkrax_entries", force: :cascade do |t|
     t.string "identifier"
     t.string "collection_ids"
     t.string "type"
-    t.bigint "importerexporter_id"
+    t.integer "importerexporter_id"
     t.text "raw_metadata", limit: 16777215
     t.text "parsed_metadata", limit: 16777215
     t.datetime "created_at", null: false
@@ -135,11 +134,12 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.text "last_error", limit: 16777215
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
+    t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.index ["importerexporter_id"], name: "index_bulkrax_entries_on_importerexporter_id"
   end
 
-  create_table "bulkrax_exporter_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint "exporter_id"
+  create_table "bulkrax_exporter_runs", force: :cascade do |t|
+    t.integer "exporter_id"
     t.integer "total_work_entries", default: 0
     t.integer "enqueued_records", default: 0
     t.integer "processed_records", default: 0
@@ -148,9 +148,9 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["exporter_id"], name: "index_bulkrax_exporter_runs_on_exporter_id"
   end
 
-  create_table "bulkrax_exporters", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "bulkrax_exporters", force: :cascade do |t|
     t.string "name"
-    t.bigint "user_id"
+    t.integer "user_id"
     t.string "parser_klass"
     t.integer "limit"
     t.text "parser_fields", limit: 16777215
@@ -167,11 +167,12 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.date "finish_date"
     t.string "work_visibility"
     t.string "workflow_status"
+    t.boolean "make_round_trippable"
     t.index ["user_id"], name: "index_bulkrax_exporters_on_user_id"
   end
 
-  create_table "bulkrax_importer_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint "importer_id"
+  create_table "bulkrax_importer_runs", force: :cascade do |t|
+    t.integer "importer_id"
     t.integer "total_work_entries", default: 0
     t.integer "enqueued_records", default: 0
     t.integer "processed_records", default: 0
@@ -188,10 +189,10 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 
-  create_table "bulkrax_importers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "bulkrax_importers", force: :cascade do |t|
     t.string "name"
     t.string "admin_set_id"
-    t.bigint "user_id"
+    t.integer "user_id"
     t.string "frequency"
     t.string "parser_klass"
     t.integer "limit"
@@ -206,7 +207,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_bulkrax_importers_on_user_id"
   end
 
-  create_table "bulkrax_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "bulkrax_statuses", force: :cascade do |t|
     t.string "status_message"
     t.string "error_class"
     t.string "error_message"
@@ -219,7 +220,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "checksum_audit_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "checksum_audit_logs", force: :cascade do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -232,7 +233,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
   end
 
-  create_table "collection_branding_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "collection_branding_infos", force: :cascade do |t|
     t.string "collection_id"
     t.string "role"
     t.string "local_path"
@@ -246,8 +247,8 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.string "image_path"
   end
 
-  create_table "collection_type_participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint "hyrax_collection_type_id"
+  create_table "collection_type_participants", force: :cascade do |t|
+    t.integer "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -256,7 +257,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["hyrax_collection_type_id"], name: "hyrax_collection_type_id"
   end
 
-  create_table "content_blocks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "content_blocks", force: :cascade do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -264,14 +265,14 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "curation_concerns_operations", force: :cascade do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
     t.string "job_id"
     t.string "type"
     t.text "message"
-    t.bigint "user_id"
+    t.integer "user_id"
     t.integer "parent_id"
     t.integer "lft", null: false
     t.integer "rgt", null: false
@@ -285,7 +286,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "featured_works", force: :cascade do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -294,7 +295,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "file_download_stats", force: :cascade do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -305,7 +306,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "file_view_stats", force: :cascade do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -316,7 +317,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
   end
 
-  create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "hyrax_collection_types", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.string "machine_id"
@@ -333,16 +334,16 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 
-  create_table "hyrax_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "hyrax_features", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "job_io_wrappers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint "user_id"
-    t.bigint "uploaded_file_id"
+  create_table "job_io_wrappers", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "uploaded_file_id"
     t.string "file_set_id"
     t.string "mime_type"
     t.string "original_name"
@@ -354,7 +355,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -362,13 +363,13 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "mailboxer_conversations", force: :cascade do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "mailboxer_notifications", force: :cascade do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -391,7 +392,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "mailboxer_receipts", force: :cascade do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -408,19 +409,19 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "minter_states", force: :cascade do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.bigint "seq", default: 0
+    t.integer "seq", limit: 8, default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint "permission_template_id"
+  create_table "permission_template_accesses", force: :cascade do |t|
+    t.integer "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -430,7 +431,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["permission_template_id"], name: "index_permission_template_accesses_on_permission_template_id"
   end
 
-  create_table "permission_templates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "permission_templates", force: :cascade do |t|
     t.string "source_id"
     t.string "visibility"
     t.datetime "created_at", null: false
@@ -440,10 +441,10 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "proxy_deposit_requests", force: :cascade do |t|
     t.string "work_id", null: false
-    t.bigint "sending_user_id", null: false
-    t.bigint "receiving_user_id", null: false
+    t.integer "sending_user_id", null: false
+    t.integer "receiving_user_id", null: false
     t.datetime "fulfillment_date"
     t.string "status", default: "pending", null: false
     t.text "sender_comment"
@@ -454,24 +455,24 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint "grantor_id"
-    t.bigint "grantee_id"
+  create_table "proxy_deposit_rights", force: :cascade do |t|
+    t.integer "grantor_id"
+    t.integer "grantee_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["grantee_id"], name: "index_proxy_deposit_rights_on_grantee_id"
     t.index ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id"
   end
 
-  create_table "qa_local_authorities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "qa_local_authorities", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_qa_local_authorities_on_name", unique: true
   end
 
-  create_table "qa_local_authority_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint "local_authority_id"
+  create_table "qa_local_authority_entries", force: :cascade do |t|
+    t.integer "local_authority_id"
     t.string "label"
     t.string "uri"
     t.datetime "created_at", null: false
@@ -480,11 +481,11 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "roles", force: :cascade do |t|
     t.string "name"
   end
 
-  create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "roles_users", id: false, force: :cascade do |t|
     t.integer "role_id"
     t.integer "user_id"
     t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
@@ -493,7 +494,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "searches", force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -502,7 +503,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "single_use_links", force: :cascade do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -511,7 +512,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_agents", force: :cascade do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -519,7 +520,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_comments", force: :cascade do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -530,7 +531,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_entities", force: :cascade do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -541,7 +542,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_entity_specific_responsibilities", force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -553,7 +554,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_notifiable_contexts", force: :cascade do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -566,7 +567,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_notification_recipients", force: :cascade do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -578,7 +579,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_notifications", force: :cascade do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -587,7 +588,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_roles", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -595,7 +596,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_workflow_actions", force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -606,7 +607,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_workflow_methods", force: :cascade do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -615,7 +616,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_workflow_responsibilities", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -623,7 +624,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_workflow_roles", force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -631,7 +632,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_workflow_state_action_permissions", force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -639,7 +640,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_workflow_state_actions", force: :cascade do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -647,7 +648,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_workflow_states", force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -656,7 +657,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "sipity_workflows", force: :cascade do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -668,22 +669,22 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "tinymce_assets", force: :cascade do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "trophies", force: :cascade do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "uploaded_files", force: :cascade do |t|
     t.string "file"
-    t.bigint "user_id"
+    t.integer "user_id"
     t.string "file_set_uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -691,7 +692,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "user_stats", force: :cascade do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -702,7 +703,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["user_id"], name: "index_user_stats_on_user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -748,7 +749,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_committers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "version_committers", force: :cascade do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -757,7 +758,7 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "work_view_stats", force: :cascade do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"
@@ -768,14 +769,4 @@ ActiveRecord::Schema.define(version: 20210802164419) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
-  add_foreign_key "bulkrax_exporter_runs", "bulkrax_exporters", column: "exporter_id"
-  add_foreign_key "bulkrax_importer_runs", "bulkrax_importers", column: "importer_id"
-  add_foreign_key "collection_type_participants", "hyrax_collection_types"
-  add_foreign_key "curation_concerns_operations", "users"
-  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
-  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
-  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
-  add_foreign_key "permission_template_accesses", "permission_templates"
-  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
-  add_foreign_key "uploaded_files", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20210820144015) do
 
-  create_table "allinson_flex_contexts", force: :cascade do |t|
+  create_table "allinson_flex_contexts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
     t.string "admin_set_ids"
     t.string "m3_context_name"
@@ -24,28 +24,28 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["profile_id"], name: "index_allinson_flex_contexts_on_profile_id"
   end
 
-  create_table "allinson_flex_dynamic_schemas", force: :cascade do |t|
+  create_table "allinson_flex_dynamic_schemas", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "allinson_flex_class"
     t.integer "context_id"
     t.integer "profile_id"
-    t.text "schema", limit: 3000000
+    t.text "schema", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["context_id"], name: "index_allinson_flex_dynamic_schemas_on_context_id"
     t.index ["profile_id"], name: "index_allinson_flex_dynamic_schemas_on_profile_id"
   end
 
-  create_table "allinson_flex_profile_available_properties", force: :cascade do |t|
+  create_table "allinson_flex_profile_available_properties", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "profile_property_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "available_on_type"
-    t.integer "available_on_id"
+    t.bigint "available_on_id"
     t.index ["available_on_type", "available_on_id"], name: "index_allinson_flex_profile_properties_available_on"
     t.index ["profile_property_id"], name: "index_available_properties_on_property_id"
   end
 
-  create_table "allinson_flex_profile_classes", force: :cascade do |t|
+  create_table "allinson_flex_profile_classes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
     t.string "display_label"
     t.string "schema_uri"
@@ -55,16 +55,16 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["profile_id"], name: "index_allinson_flex_profile_classes_on_profile_id"
   end
 
-  create_table "allinson_flex_profile_classes_contexts", force: :cascade do |t|
-    t.integer "profile_context_id"
-    t.integer "profile_class_id"
+  create_table "allinson_flex_profile_classes_contexts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.bigint "profile_context_id"
+    t.bigint "profile_class_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["profile_class_id"], name: "index_profile_classes_contexts_on_profile_class_id"
     t.index ["profile_context_id"], name: "index_profile_classes_contexts_on_profile_context_id"
   end
 
-  create_table "allinson_flex_profile_contexts", force: :cascade do |t|
+  create_table "allinson_flex_profile_contexts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
     t.string "display_label"
     t.integer "profile_id"
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["profile_id"], name: "index_allinson_flex_profile_contexts_on_profile_id"
   end
 
-  create_table "allinson_flex_profile_properties", force: :cascade do |t|
+  create_table "allinson_flex_profile_properties", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
     t.string "property_uri"
     t.integer "cardinality_minimum", default: 0
@@ -85,32 +85,32 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["profile_id"], name: "index_profile_properties_on_profile_id"
   end
 
-  create_table "allinson_flex_profile_texts", force: :cascade do |t|
+  create_table "allinson_flex_profile_texts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
     t.string "value"
     t.integer "profile_property_id"
     t.string "textable_type"
-    t.integer "textable_id"
+    t.bigint "textable_id"
     t.index ["profile_property_id"], name: "index_profile_texts_on_profile_property_id"
     t.index ["textable_type", "textable_id"], name: "index_profile_texts_on_type_and_id"
   end
 
-  create_table "allinson_flex_profiles", force: :cascade do |t|
+  create_table "allinson_flex_profiles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
-    t.float "profile_version"
+    t.float "profile_version", limit: 24
     t.string "m3_version"
     t.string "responsibility"
     t.string "responsibility_statement"
     t.string "date_modified"
     t.string "profile_type"
-    t.text "profile", limit: 3000000
+    t.text "profile", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "locked_at"
     t.integer "locked_by_id"
   end
 
-  create_table "bookmarks", force: :cascade do |t|
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -122,11 +122,12 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "bulkrax_entries", force: :cascade do |t|
+  create_table "bulkrax_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.string "identifier"
     t.string "collection_ids"
     t.string "type"
-    t.integer "importerexporter_id"
+    t.bigint "importerexporter_id"
     t.text "raw_metadata", limit: 16777215
     t.text "parsed_metadata", limit: 16777215
     t.datetime "created_at", null: false
@@ -134,12 +135,11 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.text "last_error", limit: 16777215
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
-    t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.index ["importerexporter_id"], name: "index_bulkrax_entries_on_importerexporter_id"
   end
 
-  create_table "bulkrax_exporter_runs", force: :cascade do |t|
-    t.integer "exporter_id"
+  create_table "bulkrax_exporter_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.bigint "exporter_id"
     t.integer "total_work_entries", default: 0
     t.integer "enqueued_records", default: 0
     t.integer "processed_records", default: 0
@@ -148,9 +148,9 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["exporter_id"], name: "index_bulkrax_exporter_runs_on_exporter_id"
   end
 
-  create_table "bulkrax_exporters", force: :cascade do |t|
+  create_table "bulkrax_exporters", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "parser_klass"
     t.integer "limit"
     t.text "parser_fields", limit: 16777215
@@ -171,8 +171,8 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_bulkrax_exporters_on_user_id"
   end
 
-  create_table "bulkrax_importer_runs", force: :cascade do |t|
-    t.integer "importer_id"
+  create_table "bulkrax_importer_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.bigint "importer_id"
     t.integer "total_work_entries", default: 0
     t.integer "enqueued_records", default: 0
     t.integer "processed_records", default: 0
@@ -189,10 +189,10 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 
-  create_table "bulkrax_importers", force: :cascade do |t|
+  create_table "bulkrax_importers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
     t.string "admin_set_id"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "frequency"
     t.string "parser_klass"
     t.integer "limit"
@@ -207,7 +207,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_bulkrax_importers_on_user_id"
   end
 
-  create_table "bulkrax_statuses", force: :cascade do |t|
+  create_table "bulkrax_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "status_message"
     t.string "error_class"
     t.string "error_message"
@@ -220,7 +220,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "checksum_audit_logs", force: :cascade do |t|
+  create_table "checksum_audit_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -233,7 +233,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
   end
 
-  create_table "collection_branding_infos", force: :cascade do |t|
+  create_table "collection_branding_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "collection_id"
     t.string "role"
     t.string "local_path"
@@ -247,8 +247,8 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.string "image_path"
   end
 
-  create_table "collection_type_participants", force: :cascade do |t|
-    t.integer "hyrax_collection_type_id"
+  create_table "collection_type_participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.bigint "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -257,7 +257,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["hyrax_collection_type_id"], name: "hyrax_collection_type_id"
   end
 
-  create_table "content_blocks", force: :cascade do |t|
+  create_table "content_blocks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -265,14 +265,14 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade do |t|
+  create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
     t.string "job_id"
     t.string "type"
     t.text "message"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.integer "parent_id"
     t.integer "lft", null: false
     t.integer "rgt", null: false
@@ -286,7 +286,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade do |t|
+  create_table "featured_works", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -295,7 +295,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade do |t|
+  create_table "file_download_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -306,7 +306,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade do |t|
+  create_table "file_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -317,7 +317,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
   end
 
-  create_table "hyrax_collection_types", force: :cascade do |t|
+  create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "title"
     t.text "description"
     t.string "machine_id"
@@ -334,16 +334,16 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 
-  create_table "hyrax_features", force: :cascade do |t|
+  create_table "hyrax_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "job_io_wrappers", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "uploaded_file_id"
+  create_table "job_io_wrappers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.bigint "user_id"
+    t.bigint "uploaded_file_id"
     t.string "file_set_id"
     t.string "mime_type"
     t.string "original_name"
@@ -355,7 +355,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -363,13 +363,13 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", force: :cascade do |t|
+  create_table "mailboxer_conversations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", force: :cascade do |t|
+  create_table "mailboxer_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -392,7 +392,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", force: :cascade do |t|
+  create_table "mailboxer_receipts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -409,19 +409,19 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", force: :cascade do |t|
+  create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.integer "seq", limit: 8, default: 0
+    t.bigint "seq", default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade do |t|
-    t.integer "permission_template_id"
+  create_table "permission_template_accesses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.bigint "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -431,7 +431,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["permission_template_id"], name: "index_permission_template_accesses_on_permission_template_id"
   end
 
-  create_table "permission_templates", force: :cascade do |t|
+  create_table "permission_templates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "source_id"
     t.string "visibility"
     t.datetime "created_at", null: false
@@ -441,10 +441,10 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade do |t|
+  create_table "proxy_deposit_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "work_id", null: false
-    t.integer "sending_user_id", null: false
-    t.integer "receiving_user_id", null: false
+    t.bigint "sending_user_id", null: false
+    t.bigint "receiving_user_id", null: false
     t.datetime "fulfillment_date"
     t.string "status", default: "pending", null: false
     t.text "sender_comment"
@@ -455,24 +455,24 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade do |t|
-    t.integer "grantor_id"
-    t.integer "grantee_id"
+  create_table "proxy_deposit_rights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.bigint "grantor_id"
+    t.bigint "grantee_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["grantee_id"], name: "index_proxy_deposit_rights_on_grantee_id"
     t.index ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id"
   end
 
-  create_table "qa_local_authorities", force: :cascade do |t|
+  create_table "qa_local_authorities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_qa_local_authorities_on_name", unique: true
   end
 
-  create_table "qa_local_authority_entries", force: :cascade do |t|
-    t.integer "local_authority_id"
+  create_table "qa_local_authority_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.bigint "local_authority_id"
     t.string "label"
     t.string "uri"
     t.datetime "created_at", null: false
@@ -481,11 +481,11 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "roles", force: :cascade do |t|
+  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name"
   end
 
-  create_table "roles_users", id: false, force: :cascade do |t|
+  create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "role_id"
     t.integer "user_id"
     t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
@@ -494,7 +494,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -503,7 +503,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade do |t|
+  create_table "single_use_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -512,7 +512,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade do |t|
+  create_table "sipity_agents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -520,7 +520,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade do |t|
+  create_table "sipity_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -531,7 +531,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade do |t|
+  create_table "sipity_entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -542,7 +542,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade do |t|
+  create_table "sipity_entity_specific_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -554,7 +554,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade do |t|
+  create_table "sipity_notifiable_contexts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -567,7 +567,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade do |t|
+  create_table "sipity_notification_recipients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -579,7 +579,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade do |t|
+  create_table "sipity_notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -588,7 +588,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade do |t|
+  create_table "sipity_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -596,7 +596,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade do |t|
+  create_table "sipity_workflow_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -607,7 +607,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade do |t|
+  create_table "sipity_workflow_methods", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -616,7 +616,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade do |t|
+  create_table "sipity_workflow_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -624,7 +624,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade do |t|
+  create_table "sipity_workflow_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -632,7 +632,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade do |t|
+  create_table "sipity_workflow_state_action_permissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -640,7 +640,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade do |t|
+  create_table "sipity_workflow_state_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -648,7 +648,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade do |t|
+  create_table "sipity_workflow_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -657,7 +657,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade do |t|
+  create_table "sipity_workflows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -669,22 +669,22 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade do |t|
+  create_table "tinymce_assets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade do |t|
+  create_table "trophies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade do |t|
+  create_table "uploaded_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "file"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "file_set_uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -692,7 +692,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade do |t|
+  create_table "user_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -703,7 +703,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["user_id"], name: "index_user_stats_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -749,7 +749,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_committers", force: :cascade do |t|
+  create_table "version_committers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -758,7 +758,7 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade do |t|
+  create_table "work_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"
@@ -769,4 +769,14 @@ ActiveRecord::Schema.define(version: 20210820144015) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "bulkrax_exporter_runs", "bulkrax_exporters", column: "exporter_id"
+  add_foreign_key "bulkrax_importer_runs", "bulkrax_importers", column: "importer_id"
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
+  add_foreign_key "uploaded_files", "users"
 end

--- a/lib/extensions/bulkrax/entry/optional_round_trippable_save.rb
+++ b/lib/extensions/bulkrax/entry/optional_round_trippable_save.rb
@@ -1,4 +1,4 @@
-# modified from bulkrax: skip redundant save
+# modified from bulkrax: skip redundant save, and make record update optional
 module Extensions
   module Bulkrax
     module Entry
@@ -7,6 +7,7 @@ module Extensions
         # we need a unique value in Bulkrax.system_identifier_field
         # add the existing hyrax_record id to Bulkrax.system_identifier_field
         def make_round_trippable
+          return unless importerexporter.make_round_trippable
           values = hyrax_record.send(::Bulkrax.system_identifier_field.to_s).to_a
           return if values.include? hyrax_record.id
           values << hyrax_record.id

--- a/lib/extensions/bulkrax/entry/optional_round_trippable_save.rb
+++ b/lib/extensions/bulkrax/entry/optional_round_trippable_save.rb
@@ -1,4 +1,4 @@
-# unmodified from bulkrax
+# modified from bulkrax: skip redundant save
 module Extensions
   module Bulkrax
     module Entry
@@ -8,6 +8,7 @@ module Extensions
         # add the existing hyrax_record id to Bulkrax.system_identifier_field
         def make_round_trippable
           values = hyrax_record.send(::Bulkrax.system_identifier_field.to_s).to_a
+          return if values.include? hyrax_record.id
           values << hyrax_record.id
           hyrax_record.send("#{::Bulkrax.system_identifier_field}=", values)
           hyrax_record.save

--- a/lib/extensions/bulkrax/entry/optional_round_trippable_save.rb
+++ b/lib/extensions/bulkrax/entry/optional_round_trippable_save.rb
@@ -1,0 +1,18 @@
+# unmodified from bulkrax
+module Extensions
+  module Bulkrax
+    module Entry
+      module OptionalRoundTrippableSave
+        # In order for the existing exported hyrax_record, to be updated by a re-import
+        # we need a unique value in Bulkrax.system_identifier_field
+        # add the existing hyrax_record id to Bulkrax.system_identifier_field
+        def make_round_trippable
+          values = hyrax_record.send(::Bulkrax.system_identifier_field.to_s).to_a
+          values << hyrax_record.id
+          hyrax_record.send("#{::Bulkrax.system_identifier_field}=", values)
+          hyrax_record.save
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/bulkrax/exporters_controller/support_make_round_trippable.rb
+++ b/lib/extensions/bulkrax/exporters_controller/support_make_round_trippable.rb
@@ -1,0 +1,21 @@
+module Extensions
+  module Bulkrax
+    module ExportersController
+      module SupportMakeRoundTrippable
+        # Only allow a trusted parameters through.
+        def exporter_params
+          params[:exporter][:export_source] = params[:exporter]["export_source_#{params[:exporter][:export_from]}".to_sym]
+          if params[:exporter][:date_filter] == "1"
+            params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type,
+                                           :parser_klass, :limit, :start_date, :finish_date, :work_visibility,
+                                           :workflow_status, field_mapping: {})
+          else
+            params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type,
+                                           :parser_klass, :limit, :work_visibility, :workflow_status,
+                                           field_mapping: {}).merge(start_date: nil, finish_date: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/bulkrax/exporters_controller/support_make_round_trippable.rb
+++ b/lib/extensions/bulkrax/exporters_controller/support_make_round_trippable.rb
@@ -2,16 +2,18 @@ module Extensions
   module Bulkrax
     module ExportersController
       module SupportMakeRoundTrippable
-        # Only allow a trusted parameters through.
+        # modified to support :make_round_trippable
         def exporter_params
           params[:exporter][:export_source] = params[:exporter]["export_source_#{params[:exporter][:export_from]}".to_sym]
           if params[:exporter][:date_filter] == "1"
             params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type,
                                            :parser_klass, :limit, :start_date, :finish_date, :work_visibility,
+                                           :make_round_trippable,
                                            :workflow_status, field_mapping: {})
           else
             params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type,
                                            :parser_klass, :limit, :work_visibility, :workflow_status,
+                                           :make_round_trippable,
                                            field_mapping: {}).merge(start_date: nil, finish_date: nil)
           end
         end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -61,6 +61,7 @@ Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::AllinsonFlexFields
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::SingularizeRightsStatement
 Bulkrax::CsvEntry.prepend Extensions::Bulkrax::Entry::DynamicSchemaField
 Bulkrax::MetsXmlEntry.prepend Extensions::Bulkrax::Entry::DynamicSchemaField
+Bulkrax::CsvEntry.prepend Extensions::Bulkrax::Entry::OptionalRoundTrippableSave
 Bulkrax::Exporter.prepend Extensions::Bulkrax::Exporter::LastRun
 Bulkrax::Importer.prepend Extensions::Bulkrax::Importer::LastRun
 Bulkrax::Exporter.prepend Extensions::Bulkrax::Exporter::Mapping

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -66,6 +66,7 @@ Bulkrax::Exporter.prepend Extensions::Bulkrax::Exporter::LastRun
 Bulkrax::Importer.prepend Extensions::Bulkrax::Importer::LastRun
 Bulkrax::Exporter.prepend Extensions::Bulkrax::Exporter::Mapping
 Bulkrax::Importer.prepend Extensions::Bulkrax::Importer::Mapping
+Bulkrax::ExportersController.prepend Extensions::Bulkrax::ExportersController::SupportMakeRoundTrippable
 
 # actor customizations
 Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest, ESSI::Actors::PerformLaterActor


### PR DESCRIPTION
Bulkrax export saves each record it exports, setting the `source` field to include the object's `id` value, to support round-tripping.  This slows down the export process results in server response timeout.

The first two commits add a check to only perform the save when the `source` does not yet contain the desired value.  This would improve the performance on subsequent exports of the same records, skipping unnecessary `save` calls.

The later commits add a new flag to the exporter object, form, and controller to allow opting out of the save calls, if the ability to round-trip is not needed.