### PR TITLE
ESSI-1414: Provide option to disable Sidekiq status check

### DIFF
--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -23,6 +23,8 @@ default: &default
     cas_logout_url: /idp/profile/cas/logout
     cas_callback_url: /users/auth/cas/callback
   sidekiq:
+    # This only signals whether Sidekiq runs locally and to check with OKComputer; doesn't alter Sidekiq config or behavior
+    processes_locally: true
     queue_names:
       - default
       - ingest

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     redis_url = ESSI.config[:redis][:rails][:url]
     checks.register "redis", OkComputer::RedisCheck.new(url: redis_url)
 
-    checks.register "sidekiq", EssiDevOps::SidekiqProcessCheck.new
+    checks.register "sidekiq", EssiDevOps::SidekiqProcessCheck.new if ESSI.config.dig(:sidekiq, :processes_locally)
 
     checks.register "ruby", OkComputer::RubyVersionCheck.new
 


### PR DESCRIPTION
The OKComputer status endpoint currently registers a check for Sidekiq processes running locally.  There are appropriate cases where we don't run Sidekiq attached to the local Rails environment, like in the public access site, or when we want to distribute job processing to other servers.  To prevent the status check from returning as failed in these cases, this PR adds and checks for a boolean specifying whether jobs processing is local or not:

```
  sidekiq:
   # This signals whether Sidekiq is running locally and to check with OKComputer; doesn't alter Sidekiq config or behavior
    processes_locally: true
    queue_names:
    ...
```