### PR TITLE
Essi-1323 Sequential job enqueueing

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -10,12 +10,12 @@ class ApplicationJob < ActiveJob::Base
   end
   
   after_perform do |job|
-    Thread.current[:essi_nested_job_parent_id] = nil # Does this fail when perform_now is used?
     # actually enqueue jobs
     while nested_job = Thread.current[:essi_nested_job_queue].shift do
       Rails.logger.debug { "Enqueuing #{nested_job.inspect}. #{Thread.current[:essi_nested_job_queue].size} jobs left to queue." }
       nested_job.enqueue
     end
+    Thread.current[:essi_nested_job_parent_id] = nil
   end
   
   # store jobs to be enqueued after current job is complete
@@ -25,7 +25,7 @@ class ApplicationJob < ActiveJob::Base
       super(*args)
     else
       # nested_job_service.push(new(*args))
-      Rails.logger.debug { "Thread storing #{self.class} with args #{args.inspect} with #{Thread.current[:essi_nested_job_queue].size} jobs in the queue." }
+      Rails.logger.debug { "Thread storing #{self.name} with args #{args.inspect} with #{Thread.current[:essi_nested_job_queue].size} jobs in the queue." }
       Thread.current[:essi_nested_job_queue].push(new(*args))
     end
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,33 @@
+# Job classes based on ApplicationJob will wait to enqueue any nested jobs until
+# the current job has finished.
 class ApplicationJob < ActiveJob::Base
+  before_perform do |job|
+    if Thread.current[:essi_nested_job_parent_id].nil?
+      Thread.current[:essi_nested_job_parent_id] = job.job_id
+      Rails.logger.debug { "Nested job queue not empty with no parent_id set!" unless Thread.current[:essi_nested_job_queue].blank? }
+      Thread.current[:essi_nested_job_queue] = []
+    end
+  end
+  
+  after_perform do |job|
+    Thread.current[:essi_nested_job_parent_id] = nil # Does this fail when perform_now is used?
+    # actually enqueue jobs
+    while nested_job = Thread.current[:essi_nested_job_queue].shift do
+      Rails.logger.debug { "Enqueuing #{nested_job.inspect}. #{Thread.current[:essi_nested_job_queue].size} jobs left to queue." }
+      nested_job.enqueue
+    end
+  end
+  
+  # store jobs to be enqueued after current job is complete
+  def self.perform_later(*args)
+    if Thread.current[:essi_nested_job_parent_id].nil?
+      Rails.logger.debug { "Thread var parent_id is nil. Calling super.perform_later with args #{args.inspect}" }
+      super(*args)
+    else
+      # nested_job_service.push(new(*args))
+      Rails.logger.debug { "Thread storing #{self.class} with args #{args.inspect} with #{Thread.current[:essi_nested_job_queue].size} jobs in the queue." }
+      Thread.current[:essi_nested_job_queue].push(new(*args))
+    end
+  end
+  
 end

--- a/app/jobs/bag_work_job.rb
+++ b/app/jobs/bag_work_job.rb
@@ -1,4 +1,4 @@
-class BagWorkJob < ActiveJob::Base
+class BagWorkJob < ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   def perform(identifier, dropbox_path = nil, bags_path = nil, bag_info = {})

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,4 +1,4 @@
-class CharacterizeJob < Hyrax::ApplicationJob
+class CharacterizeJob < ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   # Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository

--- a/app/jobs/ingest_yaml_job.rb
+++ b/app/jobs/ingest_yaml_job.rb
@@ -1,5 +1,5 @@
 # Refactor as custom actor
-class IngestYAMLJob < ActiveJob::Base
+class IngestYAMLJob < ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   # @param [File] yaml_file

--- a/app/jobs/perform_later_actor_job.rb
+++ b/app/jobs/perform_later_actor_job.rb
@@ -1,4 +1,4 @@
-class PerformLaterActorJob < ActiveJob::Base
+class PerformLaterActorJob < ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   def perform(action, curation_concern, ability_user, attributes_for_actor)

--- a/app/jobs/save_structure_job.rb
+++ b/app/jobs/save_structure_job.rb
@@ -1,4 +1,4 @@
-class SaveStructureJob < ActiveJob::Base
+class SaveStructureJob < ApplicationJob
   prepend ::LockableJob
   queue_as Hyrax.config.ingest_queue_name
 

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -93,20 +93,6 @@ default: &default
     default_email_domain: iu.edu
   authorized_ldap_groups:
     - ESSI-USERS
-  aws:
-    endpoint: http://minio:9000
-    bucket: essi-dropbox
-    access_key_id: essi-minio
-    secret_access_key: Essi12345
-    region: iu-local
-  browse_everything:
-    #TODO: N8 for local development 
-    #file_system:
-    #    :home: <%= Rails.root.join("staged_files") %>
-    s3:
-      :bucket: essi-dropbox
-      :region: iu-local
-      :response_type: :public_url
   essi:
     iiif_host: essi.docker  # riiif only
     notifier_email: example@test.test

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -19,7 +19,7 @@ class ApplicationTestJob < ApplicationJob
   end
 end
 
-describe 'ApplicationJobSpec' do
+describe ApplicationJob do
   before do
     ApplicationTestJob.class_job_log = Concurrent::Agent.new([])
     ApplicationTestJob.jobs_done = false

--- a/spec/jobs/application_job_spec_spec.rb
+++ b/spec/jobs/application_job_spec_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+class ApplicationTestJob < ApplicationJob
+  cattr_accessor :class_job_log, :jobs_done
+  
+  def perform(job_count)
+    id = job_count
+    
+    r = [0, 0.02, 0.05, 0.01, 0.1, 0.03][job_count]
+    sleep(r)
+    if job_count < 5
+      ApplicationTestJob.perform_later(job_count + 1)
+    else
+      self.jobs_done = true
+    end
+    sleep(r)
+    self.class_job_log.send { |a| a.push id }
+    self.class_job_log.await
+  end
+end
+
+describe 'ApplicationJobSpec' do
+  before do
+    ApplicationTestJob.class_job_log = Concurrent::Agent.new([])
+    ApplicationTestJob.jobs_done = false
+    ActiveJob::Base.enable_test_adapter ActiveJob::QueueAdapters::AsyncAdapter.new max_threads: 2 * Concurrent.processor_count
+  end
+  
+  after do
+    ActiveJob::Base.enable_test_adapter ActiveJob::QueueAdapters::TestAdapter.new
+  end
+  
+  context 'Job based on ApplicationJob' do
+    it 'run jobs in order by waiting to enqueue' do
+      expect(ApplicationTestJob.queue_adapter).to be_a ActiveJob::QueueAdapters::AsyncAdapter
+      ApplicationTestJob.perform_later(1)
+      while !ApplicationTestJob.jobs_done do
+        sleep 1
+      end
+      expect(ApplicationTestJob.class_job_log.value).to eq [1, 2, 3, 4, 5]
+    end
+  end
+end


### PR DESCRIPTION
Attempts to change the behavior of all jobs based on ApplicationJob to wait to enqueue new jobs until the current job has completed performing. This uses thread local variables to store the new jobs until an after hook completes the enqueueing.

Doing this helps avoid race conditions where the repository objects in memory in the primary import job thread do not match what has been written to active fedora by secondary jobs (e.g characterization, derivatives, etc).

Thanks to `Hyrax::ApplicationJob`, all jobs should now make use of this behavior including those contained within the hyrax gem.