### PR TITLE
essi-1441 Disable FITS use of tesseract via apache tika

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
           curl -fSL -o /tmp/fits-1.5.0.zip https://github.com/harvard-lts/fits/releases/download/1.5.0/fits-1.5.0.zip
           sudo mv /tmp/fits-1.5.0.zip /opt/fits
           cd /opt/fits && sudo unzip fits-1.5.0.zip && sudo chmod +X fits.sh
+          sudo sed -i 's/\(<tool.*TikaTool.*>\)/<!--\1-->/' /opt/fits/xml/fits.xml
           echo 'export PATH=/opt/fits:$PATH' >> $BASH_ENV
 
     # Download and cache dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN yarn && \
     yarn config set silent
 RUN mkdir -p /opt/fits && \
     curl -fSL -o /opt/fits/fits-1.5.0.zip https://github.com/harvard-lts/fits/releases/download/1.5.0/fits-1.5.0.zip && \
-    cd /opt/fits && unzip fits-1.5.0.zip && chmod +X fits.sh
+    cd /opt/fits && unzip fits-1.5.0.zip && chmod +X fits.sh && sed -i 's/\(<tool.*TikaTool.*>\)/<!--\1-->/' /opt/fits/xml/fits.xml
 ENV PATH /opt/fits:$PATH
 
 ###


### PR DESCRIPTION
By default FITS uses Apache Tika as one of its tools, which in turn will run tesseract. As far as I can tell, no data from running tesseract in this way makes it into the repository. Other Samvera projects have disabled Tika in the same way as this PR, by commenting the relevant line out in the FITS configuration file. Our own tesseract OCR service should be unaffected.