### PR TITLE
[ESSI-1321] In an AllinsonFlex profile, edit property visibility (with an admin_only check)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,7 +1,7 @@
 class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
-  include AllinsonFlex::DynamicCatalogBehavior
+  include ESSI::DynamicCatalogBehavior
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show
 

--- a/app/controllers/concerns/essi/dynamic_catalog_behavior.rb
+++ b/app/controllers/concerns/essi/dynamic_catalog_behavior.rb
@@ -1,0 +1,46 @@
+# unmodified copy from allinson_flex
+module ESSI
+  module DynamicCatalogBehavior
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def load_allinson_flex
+        profile = AllinsonFlex::Profile.current_version
+        unless profile.blank?
+          profile.properties.each do |prop|
+            # blacklight wants 1 label for all classes with this property
+            # therefor we need to use the default label
+            label = prop.texts.map { |t| t.value if t.name == 'display_label' && t.textable_type.nil? }.compact.first
+            if prop.indexing.include?("stored_searchable")
+              index_args = {
+                itemprop: prop.name,
+                label: label
+              }
+
+              if prop.indexing.include?("facetable")
+                index_args[:link_to_search] = solr_name(prop.name.to_s, :facetable)
+              end
+
+              name = solr_name(prop.name.to_s, :stored_searchable)
+              unless blacklight_config.index_fields[name].present?
+                blacklight_config.add_index_field(name, index_args)
+              end
+            end
+
+            if prop.indexing.include?("facetable")
+              name = solr_name(prop.name.to_s, :facetable)
+              unless blacklight_config.facet_fields[name].present?
+                blacklight_config.add_facet_field(name, label: label)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    def initialize
+      self.class.load_allinson_flex
+      super
+    end
+  end
+end

--- a/app/services/allinson_flex/dynamic_schema_service.rb
+++ b/app/services/allinson_flex/dynamic_schema_service.rb
@@ -113,7 +113,7 @@ module AllinsonFlex
     # @return [Array] hashes of property => label
     def view_properties
       property_keys.map do |prop|
-        { prop => { label: property_locale(prop, 'label') } }
+        { prop => { label: property_locale(prop, 'label'), admin_only: admin_only_for(prop) } }
       end.inject(:merge)
     end
 
@@ -156,6 +156,10 @@ module AllinsonFlex
 
       def properties
         @properties ||= dynamic_schema.schema.deep_symbolize_keys![:properties]
+      end
+
+      def admin_only_for(property)
+        property_hash_for(property)[:indexing]&.include?('admin_only')
       end
 
       def required_for(property)

--- a/app/services/allinson_flex/dynamic_schema_service.rb
+++ b/app/services/allinson_flex/dynamic_schema_service.rb
@@ -82,6 +82,7 @@ module AllinsonFlex
     end
 
     # @return [Hash] property => array of indexing
+    # modified for essi to exclude modifier values like admin_only
     def indexing_properties
       indexers = {}
       properties.each_pair do |prop_name, prop_value|
@@ -89,8 +90,8 @@ module AllinsonFlex
                                 ["#{prop_name}#{default_indexing}"]
                               else
                                 prop_value[:indexing].map do |indexing_key|
-                                  "#{prop_name}#{index_as(indexing_key)}"
-                                end
+                                  "#{prop_name}#{index_as(indexing_key)}" if index_as(indexing_key)
+                                end.compact.uniq
         end
       end
       indexers[:profile_version] = ['profile_version_ssi']
@@ -194,8 +195,11 @@ module AllinsonFlex
       #
       # default behaviour is to return the string/text variant
       # @todo comine with data type to determine indexing value
+      # essi modification: handle admin_only modifier value
       def index_as(indexing_key)
         case indexing_key
+        when 'admin_only'
+          nil
         when 'stored_searchable'
           '_tesim'
         when 'facetable'

--- a/app/views/hyrax/admin/admin_sets/_form_metadata.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_metadata.html.erb
@@ -1,3 +1,3 @@
 <%= f.input :title %>
 <%= f.input :description, as: :text %>
-<%= render 'records/edit_fields/campus', f: f %>
+<%= render 'records/edit_fields/campus', f: f, key: :campus %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,8 +1,7 @@
 <% presenter.dynamic_schema_service.view_properties.each_pair do | prop_key, prop_value | %>
   <%# @todo internationalisation %>
-  <% if prop_key.in? [:ocr_state, :source_metadata_identifier, :source_identifier, :viewing_direction, :viewing_hint] %>
-    <% next unless presenter.current_ability.current_user.admin? %>
-  <% elsif prop_key.in?(presenter.class.try(:custom_rendered_properties) || []) %>
+  <% next if prop_value[:admin_only] && !presenter.current_ability.current_user.admin? %>
+  <% if prop_key.in?(presenter.class.try(:custom_rendered_properties) || []) %>
     <%= presenter.try(prop_key, options: { label: prop_value[:label] }) %>
   <% else %>
     <%= presenter.attribute_to_html(prop_key, label: prop_value[:label] ,html_dl: true) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -48,6 +48,10 @@ en:
   hyrax:
     account_name: My Institution Account Id
     admin:
+      admin_sets:
+        form_metadata_context:
+          no_metadata_context: No metadata contexts available
+          page_description: Metadata context for the admin set
       collection_types:
         errors:
           no_settings_change_for_user_collections: Collection type settings cannot be altered for the Collection type

--- a/config/m3_json_schemas/856237c2c6c64385619a643c88138fc5a776f7a8/m3_json_schema.json
+++ b/config/m3_json_schemas/856237c2c6c64385619a643c88138fc5a776f7a8/m3_json_schema.json
@@ -274,6 +274,7 @@
             "items": {
               "type": "string",
               "enum": [
+                "admin_only",
                 "displayable",
                 "facetable",
                 "searchable",

--- a/lib/extensions/allinson_flex/include_profile_property.rb
+++ b/lib/extensions/allinson_flex/include_profile_property.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Extensions
+  module AllinsonFlex
+    module IncludeProfileProperty
+      # modified from allinson_flex: added _adminonly variant
+      # array of valid values for indexing
+      INDEXING = %w[admin_only
+                    displayable
+                    facetable
+                    searchable
+                    sortable
+                    stored_searchable
+                    stored_sortable
+                    symbol
+                    fulltext_searchable].freeze
+
+      def self.included(base)
+        base.class_eval do
+          const_set(:INDEXING, INDEXING)
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/allinson_flex_extensions.rb
+++ b/lib/extensions/allinson_flex_extensions.rb
@@ -23,3 +23,6 @@ AllinsonFlex::Importer.prepend Extensions::AllinsonFlex::PrependImporter
 
 # profiles
 AllinsonFlex::Profile.prepend Extensions::AllinsonFlex::PrependProfile
+
+# profile properties
+AllinsonFlex::ProfileProperty.include Extensions::AllinsonFlex::IncludeProfileProperty


### PR DESCRIPTION
In the "Indexing" section of an AllinsonFlex profile, adds a new "admin_only" option.  When applied in conjunction with other values, it adds an admin_only check:
* `facetable`: this indexes and displays a facet; adding "admin_only" now adds an admin_only user check to display the facet
* `stored_searchable`: this indexes the field and displays it in catalog results and the work show page; adding "admin_only" now adds an admin_only user check to display the field in the catalog results and work show page

Although the changes are now more appropriately under ESSI-1384 after tweaking the division of work between the stories, this also resolves a couple of issues on the Metadata Context tab editing an AdminSet:
* supplies missing translations for page_description and no_metadata_contexts_available
* fixes rendering of campus field (but ESSI-1457)

Also see reference notes on wiki page:
https://uisapp2.iu.edu/confluence-prd/x/mIKPJg