### PR TITLE
[ESSI-1465] profile import error messages

### DIFF
--- a/lib/extensions/allinson_flex/include_allinson_flex_constructor.rb
+++ b/lib/extensions/allinson_flex/include_allinson_flex_constructor.rb
@@ -5,6 +5,39 @@ module Extensions
     module IncludeAllinsonFlexConstructor
       def self.included(base)
         base.class_eval do
+          # unmodified from allinson_flex
+          def self.find_or_create_from(profile_id:, data:, logger: default_logger)
+            profile = ::AllinsonFlex::Profile.find(profile_id) unless profile_id.nil?
+      
+            # when loading from path, we need to create the profile
+            # when loading from form data, we already have the profile
+            if profile.blank?
+              profile = ::AllinsonFlex::Profile.new(
+                profile: data,
+                profile_version: data.dig('profile', 'version'),
+                m3_version: data.dig('m3_version')
+              )
+            end
+            profile.responsibility = data.dig('profile', 'responsibility')
+            profile.responsibility_statement = data.dig('profile', 'responsibility_statement')
+            profile.date_modified = data.dig('profile', 'date_modified')
+            profile.profile_type = data.dig('profile', 'type')
+      
+            construct_profile_contexts(profile: profile)
+            profile.save!
+            logger.info(%(LoadedAllinsonFlex::Profile ID=#{profile.id}))
+            create_dynamic_schemas(profile: profile)
+            profile
+          end
+
+          # unmodified from allinson_flex
+          def self.create_dynamic_schemas(profile:, logger: default_logger)
+            profile = construct_default_dynamic_schemas(profile: profile)
+            profile = construct_dynamic_schemas(profile: profile)
+            profile.save!
+            logger.info(%(Created AllinsonFlex::Context and AllinsonFlex::DynamicSchema objects for ID=#{profile.id}))
+          end
+
           # modified from allinson_flex: property texts built in separate method
           def self.construct_profile_properties(profile:, profile_context:, profile_class:, logger: default_logger)
             properties_hash = profile.profile.dig('properties')

--- a/lib/extensions/allinson_flex/include_allinson_flex_constructor.rb
+++ b/lib/extensions/allinson_flex/include_allinson_flex_constructor.rb
@@ -5,7 +5,7 @@ module Extensions
     module IncludeAllinsonFlexConstructor
       def self.included(base)
         base.class_eval do
-          # unmodified from allinson_flex
+          # modified from allinson_flex: log construction errors
           def self.find_or_create_from(profile_id:, data:, logger: default_logger)
             profile = ::AllinsonFlex::Profile.find(profile_id) unless profile_id.nil?
       
@@ -24,18 +24,29 @@ module Extensions
             profile.profile_type = data.dig('profile', 'type')
       
             construct_profile_contexts(profile: profile)
+            log_profile_construction_errors(profile: profile, logger: logger)
             profile.save!
             logger.info(%(LoadedAllinsonFlex::Profile ID=#{profile.id}))
-            create_dynamic_schemas(profile: profile)
+            create_dynamic_schemas(profile: profile, logger: logger)
             profile
           end
 
-          # unmodified from allinson_flex
+          # modified from allinson_flex: log construction errors
           def self.create_dynamic_schemas(profile:, logger: default_logger)
             profile = construct_default_dynamic_schemas(profile: profile)
             profile = construct_dynamic_schemas(profile: profile)
+            log_profile_construction_errors(profile: profile, logger: logger)
             profile.save!
             logger.info(%(Created AllinsonFlex::Context and AllinsonFlex::DynamicSchema objects for ID=#{profile.id}))
+          end
+
+          # essi method for logging errors
+          def self.log_profile_construction_errors(profile:, logger: default_logger)
+            unless profile.valid?
+              profile.errors.full_messages.each_with_index do |message, index|
+                logger.error "Profile error #{index+1} of #{profile.errors.full_messages.count}: #{message}"
+              end
+            end
           end
 
           # modified from allinson_flex: property texts built in separate method

--- a/lib/extensions/allinson_flex/include_profile_property.rb
+++ b/lib/extensions/allinson_flex/include_profile_property.rb
@@ -17,6 +17,11 @@ module Extensions
       def self.included(base)
         base.class_eval do
           const_set(:INDEXING, INDEXING)
+
+          # modified from allinson_flex: adds error messaging here at parent level
+          validates_associated :texts, message: ->(object, data) do
+            "for #{object.name} are invalid"
+          end
         end
       end
     end

--- a/lib/extensions/allinson_flex/include_profile_text.rb
+++ b/lib/extensions/allinson_flex/include_profile_text.rb
@@ -4,8 +4,11 @@ module Extensions
     module IncludeProfileText
       def self.included(base)
         base.class_eval do
-          # unmodified from allinson_flex
-          validates :name, :value, presence: true
+          # modified from allinson_flex: more specific messaging
+          validates :name, :value, presence: { message: ->(object, data) do
+            "required: name (#{object.name}) or value (#{object.value}) is missing"
+            end
+          }
         end
       end
     end

--- a/lib/extensions/allinson_flex/include_profile_text.rb
+++ b/lib/extensions/allinson_flex/include_profile_text.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Extensions
+  module AllinsonFlex
+    module IncludeProfileText
+      def self.included(base)
+        base.class_eval do
+          # unmodified from allinson_flex
+          validates :name, :value, presence: true
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/allinson_flex/prepend_importer.rb
+++ b/lib/extensions/allinson_flex/prepend_importer.rb
@@ -3,13 +3,21 @@
 module Extensions
   module AllinsonFlex
     module PrependImporter
+      # unmodified from allinson_flex
+      def construct
+        ::AllinsonFlex::AllinsonFlexConstructor.find_or_create_from(
+          profile_id: profile_id,
+          data: ::ActiveSupport::HashWithIndifferentAccess.new(data)
+        )
+      end
+
       # modified from allinson_flex to use a separate log
       def validate!
         validator.validate(data: data, schema: schema, logger: validation_logger)
       end
 
       def validation_logger
-        @validation_logger ||= Logger.new(ESSI.config.dig(:essi, :metadata, :profile_log))
+        @validation_logger ||= ::Logger.new(ESSI.config.dig(:essi, :metadata, :profile_log))
       end
     end
   end

--- a/lib/extensions/allinson_flex/prepend_importer.rb
+++ b/lib/extensions/allinson_flex/prepend_importer.rb
@@ -3,11 +3,12 @@
 module Extensions
   module AllinsonFlex
     module PrependImporter
-      # unmodified from allinson_flex
+      # modified from allinson_flex to use a separate log
       def construct
         ::AllinsonFlex::AllinsonFlexConstructor.find_or_create_from(
           profile_id: profile_id,
-          data: ::ActiveSupport::HashWithIndifferentAccess.new(data)
+          data: ::ActiveSupport::HashWithIndifferentAccess.new(data),
+          logger: validation_logger
         )
       end
 

--- a/lib/extensions/allinson_flex_extensions.rb
+++ b/lib/extensions/allinson_flex_extensions.rb
@@ -26,3 +26,6 @@ AllinsonFlex::Profile.prepend Extensions::AllinsonFlex::PrependProfile
 
 # profile properties
 AllinsonFlex::ProfileProperty.include Extensions::AllinsonFlex::IncludeProfileProperty
+
+# profile texts
+AllinsonFlex::ProfileText.include Extensions::AllinsonFlex::IncludeProfileText


### PR DESCRIPTION
Provides profile import error messages in the user interface (at `/profiles/log`), and more specific error messages for `ProfileText` errors.

Suggested testing procedure:
* download the [testing profile attached the JIRA story](https://bugs.dlib.indiana.edu/secure/attachment/102524/metadata_profile_with_error.yml)
* running the `main` branch, try importing; should fail, but without any useful logging at `/profiles/log`
* running this branch, try importing; should fail, but now provide useful logging at `/profiles/log`