### PR TITLE
ESSI-1474 Move sequential job queueing to module so bulkrax can use it

### DIFF
--- a/app/jobs/bulkrax/application_job.rb
+++ b/app/jobs/bulkrax/application_job.rb
@@ -1,5 +1,7 @@
 # Job classes based on ApplicationJob will wait to enqueue any nested jobs until
 # the current job has finished.
-class ApplicationJob < ActiveJob::Base
-  prepend SequentialJob
+module Bulkrax
+  class ApplicationJob < ActiveJob::Base
+    prepend SequentialJob
+  end
 end

--- a/app/jobs/concerns/sequential_job.rb
+++ b/app/jobs/concerns/sequential_job.rb
@@ -1,0 +1,39 @@
+module SequentialJob
+  # extend ActiveSupport::Concern
+
+  def self.prepended(mod)
+    mod.singleton_class.prepend(ClassMethods)
+
+    mod.class_eval do
+      before_perform do |job|
+        if Thread.current[:essi_nested_job_parent_id].nil?
+          Thread.current[:essi_nested_job_parent_id] = job.job_id
+          Rails.logger.debug { "Nested job queue not empty with no parent_id set!" unless Thread.current[:essi_nested_job_queue].blank? }
+          Thread.current[:essi_nested_job_queue] = []
+        end
+      end
+
+      after_perform do |job|
+        # actually enqueue jobs
+        while nested_job = Thread.current[:essi_nested_job_queue].shift do
+          Rails.logger.debug { "Enqueuing #{nested_job.inspect}. #{Thread.current[:essi_nested_job_queue].size} jobs left to queue." }
+          nested_job.enqueue
+        end
+        Thread.current[:essi_nested_job_parent_id] = nil
+      end
+    end
+  end
+
+  module ClassMethods
+    def perform_later(*args)
+      if Thread.current[:essi_nested_job_parent_id].nil?
+        Rails.logger.debug { "Thread var parent_id is nil. Calling super.perform_later with args #{args.inspect}" }
+        super(*args)
+      else
+        # nested_job_service.push(new(*args))
+        Rails.logger.debug { "Thread storing #{self.name} with args #{args.inspect} with #{Thread.current[:essi_nested_job_queue].size} jobs in the queue." }
+        Thread.current[:essi_nested_job_queue].push(new(*args))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Bulkrax jobs are based on a different (Bulkrax::)ApplicationJob class than essi's ApplicationJob. This cause them to not use the sequential job enqueuing system. This PR moves that system to a module and overrides Bulkrax::ApplicationJob which was previously empty anyways.