### PR TITLE
[ESSI-1470] Update PurlController to handle all worktypes

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -25,12 +25,12 @@ class PurlController < ApplicationController
 
   private
     FILESET_LOOKUPS = { FileSet => nil }.freeze
-    WORK_LOOKUPS = {
-      BibRecord => /^[a-zA-Z\/]{0,}\w{3}\d{4}$/,
-      Image => /^[a-zA-Z\/]{0,}\w{3,}\d{4,}$/,
-      PagedResource => /^[a-zA-Z\/]{0,}\w{3}\d{4}$/,
-      Scientific => /^[a-zA-Z\/]{0,}\w{3}\d{4}$/,
-    }.freeze
+    DEFAULT_WORK_PATTERN = /^[a-zA-Z\/]{0,}\w{3}\d{4}$/.freeze
+    DEFAULT_WORK_LOOKUPS = Hyrax.config.registered_curation_concern_types.sort.map do |klass|
+      [klass.constantize, DEFAULT_WORK_PATTERN.dup]
+    end.to_h.freeze
+    CUSTOM_WORK_LOOKUPS = {}.freeze
+    WORK_LOOKUPS = DEFAULT_WORK_LOOKUPS.dup.merge(CUSTOM_WORK_LOOKUPS.dup).freeze
    
     # sets @solr_hit (if found), @url (always)
     def set_object(lookup_rules, split_id: false)

--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -47,8 +47,9 @@ class PurlController < ApplicationController
 
     # TODO: reconsider how not all work types support source_metadata_identifier?
     def find_object(id, klass, match_pattern)
+      klass.new # load allinson_flex properties
       terms = { source_metadata_identifier: id } if klass.properties['source_metadata_identifier']
-      terms = { identifier_tesim: id } if id.match('/') && klass.properties['identifier']
+      terms = { purl: id } if id.match('/') && klass.properties['purl']
       return unless terms
       if match_pattern.nil? || id.match(match_pattern)
         klass.search_with_conditions(terms, rows: 1).first

--- a/config/context.yml
+++ b/config/context.yml
@@ -55,8 +55,11 @@
     "@id": dcterms:created
   extent:
     "@id": dcterms:extent
+  # below for purl/identifier swap
   identifier:
     "@id": dcterms:identifier
+  purl:
+    "@id": dc:identifier
   date_published:
     "@id": dcterms:issued
   modified:

--- a/config/metadata_profile/essi_short.yaml
+++ b/config/metadata_profile/essi_short.yaml
@@ -164,6 +164,18 @@ properties:
     property_uri: http://iiif.io/api/presentation/2#viewingDirection
     cardinality:
       maximum: 1
+  purl:
+    display_label:
+      default: "Purl"
+    available_on:
+      class:
+        - Image
+        - BibRecord
+        - PagedResource
+        - ArchivalMaterial
+    property_uri: http://purl.org/dc/elements/1.1/identifier
+    cardinality:
+      minimum: 0
   source_identifier:
     display_label:
       default: "Source Identifier"

--- a/lib/iu_metadata/marc_record.rb
+++ b/lib/iu_metadata/marc_record.rb
@@ -12,7 +12,7 @@ module IuMetadata
     class MarcParsingError < StandardError; end
 
     ATTRIBUTES = %i[
-      identifier
+      purl
       title
       sort_title
       responsibility_note
@@ -128,7 +128,7 @@ module IuMetadata
       parts
     end
 
-    def identifier
+    def purl
       formatted_subfields_as_array(['856'], codes: ['u']).first
     end
 

--- a/spec/controllers/purl_controller_spec.rb
+++ b/spec/controllers/purl_controller_spec.rb
@@ -6,7 +6,7 @@ describe PurlController do
   let(:paged_resource) {
     FactoryBot.create(:paged_resource,
                        user: user,
-                       identifier: ['http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405'],
+                       purl: ['http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405'],
                        source_metadata_identifier: 'BHR9405')
   }
   let(:paged_resource_path) { Rails.application.routes.url_helpers.hyrax_paged_resource_path(paged_resource) }


### PR DESCRIPTION
PurlController changes:
* Add support for ArchivalMaterial
* changes purl lookup field from "identifier" to "purl"

Remote metadata lookup changes:
* changes identifier lookup to purl lookup

Note that testing, and working in deployment, requires configuring a "purl" field in allinson_flex with this URI:
http://purl.org/dc/elements/1.1/identifier