### PR TITLE
ESSI-1503 Increase ruby stack size limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /opt/fits && \
     curl -fSL -o /opt/fits/fits-1.5.0.zip https://github.com/harvard-lts/fits/releases/download/1.5.0/fits-1.5.0.zip && \
     cd /opt/fits && unzip fits-1.5.0.zip && chmod +X fits.sh && sed -i 's/\(<tool.*TikaTool.*>\)/<!--\1-->/' /opt/fits/xml/fits.xml
 ENV PATH /opt/fits:$PATH
+ENV RUBY_THREAD_MACHINE_STACK_SIZE 8388608
 
 ###
 # ruby dev image


### PR DESCRIPTION
Fixes `SystemStackError: stack level too deep` exceptions when saving structure in large works.

The cause of this is the recursive method `ActiveTriples::ExtendedBoundedDescription#each_statement` which recurses once for each part of a logical_order (our structure object in Fedora). Each recursion loop adds 27 method calls to the ruby stack which quickly exceeds the default stack size limit of 1048576. For example, a work with 241 pages required this setting to be set to at least 1645000 (+-5000) to succeed.

The new value was selected based on it being an alternate default value when using a memory sanitizer, so in theory it's not egregiously oversized. See https://github.com/ruby/ruby/blob/ruby_2_7/vm_core.h#L693

If further stack size limits are encountered, there are three other stack limits that can be adjusted as well.