### PR TITLE
Use a non-node ci image since we install node 12 ourselves

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     docker:
     # legacy needed for phantomjs
-    - image: circleci/ruby:2.6-bullseye-node-browsers-legacy
+    - image: circleci/ruby:2.6-bullseye-browsers-legacy
     - image: circleci/redis:6
     - image: ghcr.io/samvera/fcrepo4:4.7.5
       environment:


### PR DESCRIPTION
The circleci base images updated to node 16 which seems to be incompatible. This gets us back to node 12, although we do need to plan to upgrade soon due to EOL.