### PR TITLE
[ESSI-1370] bulkrax export display

### DIFF
--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -97,7 +97,11 @@
             <tr>
               <td><%= link_to e.identifier, bulkrax.exporter_entry_path(@exporter.id, e.id) %></td>
               <% if e.parsed_metadata.present? && e.parsed_metadata.dig('collections').present? %>
-                <td><%= e.parsed_metadata.dig('collections').map {|c| c['id'] }.join('; ') %></td>
+                <% if e.parsed_metadata.dig('collections').respond_to?(:map) %>
+                  <td><%= e.parsed_metadata.dig('collections').map {|c| c['id'] }.join('; ') %></td>
+                <% else %>
+                  <td><%= e.parsed_metadata.dig('collections') %></td>
+                <% end %>
               <% elsif e.raw_metadata.present? %>
                 <td><%= Array.wrap(e.raw_metadata.dig('collection')).join(';') %></td>
               <% else %>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -1,0 +1,135 @@
+<p id='notice'><%= notice %></p>
+
+<div class='col-xs-12 main-header'>
+  <h1><span class='fa fa-cloud-download' aria-hidden='true'></span> Exporter: <%= @exporter.name %></h1>
+</div>
+
+<div class='panel panel-default'>
+  <div class='panel-body'>
+
+    <% if File.exist?(@exporter.exporter_export_zip_path) %>
+      <p class='bulkrax-p-align'>
+        <strong>Download:</strong>
+        <%= link_to raw('<span class="glyphicon glyphicon-download"></span>'), exporter_download_path(@exporter) %>
+      </p>
+    <% end %>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.name') %>:</strong>
+      <%= @exporter.name %>
+    </p>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.user') %>:</strong>
+      <%= @exporter.user %>
+    </p>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.export_type') %>:</strong>
+      <%= @exporter.export_type %>
+    </p>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.export_from') %>:</strong>
+      <%= @exporter.export_from %>
+    </p>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.export_source') %>:</strong>
+      <% case @exporter.export_from %>
+      <% when 'collection' %>
+        <% collection = Collection.find(@exporter.export_source) %>
+        <%= link_to collection&.title&.first, hyrax.dashboard_collection_path(collection.id) %>
+      <% when 'importer' %>
+        <% importer = Bulkrax::Importer.find(@exporter.export_source) %>
+        <%= link_to importer.name, bulkrax.importer_path(importer.id) %>
+      <% when 'worktype' %>
+        <%= @exporter.export_source %>
+      <% end %>
+    </p>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.parser_klass') %>:</strong>
+      <%= @exporter.parser_klass %>
+    </p>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.limit') %>:</strong>
+      <%= @exporter.limit %>
+    </p>
+
+  <%= render partial: 'bulkrax/shared/bulkrax_field_mapping', locals: {item: @exporter} %>
+
+    <%# Currently, no parser-specific fields exist on Exporter,
+        thus there's no real reason to always show this field %>
+    <% if @exporter.parser_fields.present? %>
+      <p class='bulkrax-p-align'>
+        <strong><%= t('bulkrax.exporter.labels.parser_fields') %>:</strong><br>
+        <% @exporter.parser_fields.each do |k, v| %>
+          <%= k %>: <%= v %><br>
+        <% end %>
+      </p>
+    <% end %>
+
+    <p class='bulkrax-p-align'><strong><%= t('bulkrax.exporter.labels.field_mapping') %>:</strong></p>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.total_work_entries') %>:</strong>
+      <%= @exporter.exporter_runs.last&.total_work_entries %>
+    </p>
+    <br>
+    <div class="bulkrax-nav-tab-table-left-align">
+      <h2>Entries</h2>
+      <table class='table table-striped'>
+        <thead>
+          <tr>
+            <th>Identifier</th>
+            <th>Collection</th>
+            <th>Entry ID</th>
+            <th>Status</th>
+            <th>Errors</th>
+            <th>Status Set At</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @work_entries.each do |e| %>
+            <tr>
+              <td><%= link_to e.identifier, bulkrax.exporter_entry_path(@exporter.id, e.id) %></td>
+              <% if e.parsed_metadata.present? && e.parsed_metadata.dig('collections').present? %>
+                <td><%= e.parsed_metadata.dig('collections').map {|c| c['id'] }.join('; ') %></td>
+              <% elsif e.raw_metadata.present? %>
+                <td><%= Array.wrap(e.raw_metadata.dig('collection')).join(';') %></td>
+              <% else %>
+              <td></td>
+              <% end %>
+              <td><%= e.id %></td>
+              <% if e.status == 'Complete' %>
+                <td><span class='glyphicon glyphicon-ok' style='color: green;'></span> <%= e.status %></td>
+                <% else %>
+                <td><span class='glyphicon glyphicon-remove' style='color: red;'></span> <%= e.status %></td>
+              <% end %>
+              <% if e.last_error.present? %>
+                <td><%= link_to e.last_error.dig('error_class'), bulkrax.exporter_entry_path(@exporter.id, e.id) %></td>
+              <% else %>
+                <td></td>
+              <% end %>
+              <td><%= e.status_at %></td>
+              <td><%= link_to raw("<span class='glyphicon glyphicon-info-sign'></span>"), bulkrax.exporter_entry_path(@exporter.id, e.id) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= page_entries_info(@work_entries) %><br>
+      <%= paginate(@work_entries, param_name: :work_entries_page) %>
+      <br>
+      <% if File.exist?(@exporter.exporter_export_zip_path) %>
+        <%= link_to 'Download', exporter_download_path(@exporter) %>
+        |
+      <% end %>
+      <%= link_to 'Edit', edit_exporter_path(@exporter) %>
+      |
+      <%= link_to 'Back', exporters_path %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
It looks like in our change from bulkrax 1.0.0 to 1.0.2 a few months ago, there was a change to how 'collections' is parsed and stored that broke a view.  This attempts to work around the issue by differentially displaying the value.

Display is broken for both exporters currently up on the dev server.  Locally, I am finding display of some exporters works, others are broken, but this change resolves them all.  To test this locally, you may need to create an exporter if you currently have none.