### PR TITLE
[ESSI-1539] tweak dynamic indexing

### DIFF
--- a/app/indexers/archival_material_indexer.rb
+++ b/app/indexers/archival_material_indexer.rb
@@ -14,6 +14,7 @@ class ArchivalMaterialIndexer < Hyrax::WorkIndexer
   #  end
   # end
   include AllinsonFlex::DynamicIndexerBehavior
+  include ESSI::DynamicIndexerBehavior
   self.model_class = ::ArchivalMaterial
 
 end

--- a/app/indexers/bib_record_indexer.rb
+++ b/app/indexers/bib_record_indexer.rb
@@ -14,6 +14,7 @@ class BibRecordIndexer < Hyrax::WorkIndexer
   #  end
   # end
   include AllinsonFlex::DynamicIndexerBehavior
+  include ESSI::DynamicIndexerBehavior
   self.model_class = ::BibRecord
 
 end

--- a/app/indexers/essi/dynamic_indexer_behavior.rb
+++ b/app/indexers/essi/dynamic_indexer_behavior.rb
@@ -1,0 +1,13 @@
+module ESSI
+  module DynamicIndexerBehavior
+    # Array-ify results of allinson_flex dynamic indexing
+    def generate_solr_document
+      solr_doc = super
+      solr_doc.each do |key, value|
+        if value.is_a? ActiveTriples::Relation
+          solr_doc[key] = value.to_a
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/image_indexer.rb
+++ b/app/indexers/image_indexer.rb
@@ -14,6 +14,7 @@ class ImageIndexer < Hyrax::WorkIndexer
   #  end
   # end
   include AllinsonFlex::DynamicIndexerBehavior
+  include ESSI::DynamicIndexerBehavior
   self.model_class = ::Image
 
 end

--- a/app/indexers/paged_resource_indexer.rb
+++ b/app/indexers/paged_resource_indexer.rb
@@ -14,6 +14,7 @@ class PagedResourceIndexer < Hyrax::WorkIndexer
   #  end
   # end
   include AllinsonFlex::DynamicIndexerBehavior
+  include ESSI::DynamicIndexerBehavior
   self.model_class = ::PagedResource
 
 end

--- a/app/indexers/scientific_indexer.rb
+++ b/app/indexers/scientific_indexer.rb
@@ -14,6 +14,7 @@ class ScientificIndexer < Hyrax::WorkIndexer
   #  end
   # end
   include AllinsonFlex::DynamicIndexerBehavior
+  include ESSI::DynamicIndexerBehavior
   self.model_class = ::Scientific
 
 end

--- a/spec/services/cover_page_generator.rb
+++ b/spec/services/cover_page_generator.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CoverPageGenerator do
-  # FIXME: change resource to a SolrDocument after resolving dynamic indexing of ActiveTriples to Arrays
-  let(:resource) { build(:paged_resource) }
+  let(:resource) { SolrDocument.new(build(:paged_resource).to_solr) }
   let(:service) { described_class.new(resource) }
   let(:pdf) { Prawn::Document.new }
   let(:rights_statements) { ["http://rightsstatements.org/vocab/NKC/1.0/",

--- a/spec/services/essi/generate_pdf_service_spec.rb
+++ b/spec/services/essi/generate_pdf_service_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ESSI::GeneratePdfService do
-  # FIXME: change resource to a SolrDocument after resolving dynamic indexing of ActiveTriples to Arrays
-  let(:resource) { build(:paged_resource) }
+  let(:resource) { SolrDocument.new(build(:paged_resource).to_solr) }
   let(:service) { described_class.new(resource) }
   let(:pdf) { service.generate }
 


### PR DESCRIPTION
The default indexing process returns an `Array` for multi-valued field values, in a `#to_solr` call:
https://github.com/samvera/active_fedora/blob/12.2-stable/lib/active_fedora/indexing_service.rb#L30-L65
https://github.com/samvera/active_fedora/blob/12.2-stable/lib/active_fedora/rdf/indexing_service.rb#L21-L83

However, the dynamic indexing from `allinson_flex` pulls values directly from the resource:
https://github.com/IU-Libraries-Joint-Development/allinson_flex/blob/f3ed44ff96d50bc7c42cf2b9693d9b081f9a2f0c/app/indexers/allinson_flex/dynamic_indexer_behavior.rb#L20
which results in a value type of
```rb
ActiveTriples::Relation
```
instead.

If this is saved to `Solr`, it is ultimately persisted as an `Array` -- and that's what we get back from a `Solr` search, and all is well.  But if you directly build a `SolrDocument` from calling `#to_solr` on a Work, you'll get test-breaking results like:
```rb
> solr_doc.title
=> [['Some Title']] # an Array wrapping an ActiveTriple::Relation, instead of a simple Array
```
This PR resolves that by adding an another dynamic indexing module, that fixes datatypes at the end of the `#generate_solr_document` stack.

Keeping in draft status for now, for a few reasons:
* we should merge #368 first
* we may be okay leaving dynamic indexing results as they are (closing this PR without merging)
* we may prefer to resolve with issue directly within allinson_flex, or through a different resolution within essi