### PR TITLE
[ESSI-1542] Fix CircleCI builds with ruby holdback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     docker:
     # legacy needed for phantomjs
-    - image: circleci/ruby:2.7-bullseye-browsers-legacy
+    - image: circleci/ruby:2.7.4-bullseye-browsers-legacy
     - image: circleci/redis:6
     - image: ghcr.io/samvera/fcrepo4:4.7.5
       environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # system dependency image
-FROM ruby:2.7-bullseye AS essi-sys-deps
+FROM ruby:2.7.4-bullseye AS essi-sys-deps
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000


### PR DESCRIPTION
Upgrading from ruby 2.7.4 to 2.7.5 should not, in principle, break the stack.  But, it does.

In the future, this might be resolved in updates to the affected gems, or with ruby 2.7.6.

But for the moment, holding back to 2.7.4 keeps the build working.