### PR TITLE
[ESSI-1480] Expose :source in Collection edit page

### DIFF
--- a/lib/extensions/hyrax/forms/collection_form/customized_terms.rb
+++ b/lib/extensions/hyrax/forms/collection_form/customized_terms.rb
@@ -5,19 +5,22 @@ module Extensions
         module CustomizedTerms
           def self.included(base)
             base.class_eval do
+              # modified from hyrax to include :campus, :source
               self.terms = [:resource_type, :title, :creator, :contributor, :description,
                             :keyword, :license, :publisher, :date_created, :subject, :language,
                             :representative_id, :thumbnail_id, :identifier, :based_near,
-                            :campus, :related_url, :visibility, :collection_type_gid]
+                            :campus, :related_url, :visibility, :collection_type_gid, :source]
         
               self.required_fields = [:title]
         
               # Terms that appear above the accordion
+              # Modified from hyrax to include :source
               def primary_terms
-                [:title, :description]
+                [:title, :description, :source]
               end
         
               # Terms that appear within the accordion
+              # Modified from hyrax to include :campus
               def secondary_terms
                 [:creator,
                  :contributor,


### PR DESCRIPTION
Minor change to expose the `source` field in the UI, for a Collection.  This is the default field used for Bulkrax import/export record-matching -- but even if we configure using a different field, or don't use Bulkrax for import/export, it's probably better to expose this field than hide it.  Note this change exposes the field on the edit page, but not on the show page -- the same view partial is used for both admin and public views, and we probably don't want to clutter the public view with this field.