### PR TITLE
[ESSI-1540] Bugfix and refactoring for allowing PDF download

### DIFF
--- a/app/controllers/concerns/essi/pdf_download.rb
+++ b/app/controllers/concerns/essi/pdf_download.rb
@@ -1,7 +1,7 @@
 module ESSI
-  module PDFBehavior
+  module PDFDownload
     def pdf
-      if presenter.allow_pdf_download == "true" || current_ability.current_user.admin?
+      if presenter.allow_pdf_download?
         pdf = ESSI::GeneratePdfService.new(presenter.solr_document).generate
 
         send_file pdf[:file_path],

--- a/app/controllers/hyrax/archival_materials_controller.rb
+++ b/app/controllers/hyrax/archival_materials_controller.rb
@@ -11,7 +11,7 @@ module Hyrax
     include Hyrax::BreadcrumbsForWorks
     include ESSI::BreadcrumbsForWorks
     include ESSI::OCRSearch
-    include ESSI::PDFBehavior
+    include ESSI::PDFDownload
     include ESSI::StructureBehavior
     include AllinsonFlex::DynamicControllerBehavior
     self.curation_concern_type = ::ArchivalMaterial

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -11,7 +11,7 @@ module Hyrax
     include Hyrax::BreadcrumbsForWorks
     include ESSI::BreadcrumbsForWorks
     include ESSI::OCRSearch
-    include ESSI::PDFBehavior
+    include ESSI::PDFDownload
     include ESSI::StructureBehavior
     include AllinsonFlex::DynamicControllerBehavior
     self.curation_concern_type = ::PagedResource

--- a/app/models/archival_material.rb
+++ b/app/models/archival_material.rb
@@ -9,7 +9,8 @@ class ArchivalMaterial < ActiveFedora::Base
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
   # include ESSI::OCRMetadata
-  include ESSI::PDFMetadata
+  include ESSI::PDFBehavior
+  #include ESSI::PDFMetadata
 
   self.indexer = ArchivalMaterialIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/concerns/essi/ocr_behavior.rb
+++ b/app/models/concerns/essi/ocr_behavior.rb
@@ -3,8 +3,7 @@ module ESSI
     extend ActiveSupport::Concern
 
     def ocr_searchable?
-      return true if self.ocr_state == 'searchable'
-      return false
+      self.ocr_state == 'searchable'
     end
 
     def to_solr(solr_doc = {})

--- a/app/models/concerns/essi/pdf_behavior.rb
+++ b/app/models/concerns/essi/pdf_behavior.rb
@@ -3,8 +3,7 @@ module ESSI
     extend ActiveSupport::Concern
 
     def pdf_downloadable?
-      return true if self.pdf_state == 'downloadable'
-      return false
+      self.pdf_state == 'downloadable'
     end
 
     def to_solr(solr_doc = {})

--- a/app/models/concerns/essi/pdf_behavior.rb
+++ b/app/models/concerns/essi/pdf_behavior.rb
@@ -1,0 +1,17 @@
+module ESSI
+  module PDFBehavior
+    extend ActiveSupport::Concern
+
+    def pdf_downloadable?
+      return true if self.pdf_state == 'downloadable'
+      return false
+    end
+
+    def to_solr(solr_doc = {})
+      super.tap do |doc|
+        doc[Solrizer.solr_name('pdf_downloadable',
+                               Solrizer::Descriptor.new(:boolean, :stored, :indexed))] = self.pdf_downloadable?
+      end
+    end
+  end
+end

--- a/app/models/concerns/essi/pdf_metadata.rb
+++ b/app/models/concerns/essi/pdf_metadata.rb
@@ -2,7 +2,7 @@ module ESSI
   module PDFMetadata
     extend ActiveSupport::Concern
     included do
-      property :allow_pdf_download, predicate: ::RDF::Vocab::DCAT.accessURL, multiple: false, boolean: true do |index|
+      property :pdf_state, predicate: ::RDF::URI.new('http://dlib.indiana.edu/vocabulary/PDFState'), multiple: false do |index|
         index.as :stored_searchable
       end
     end

--- a/app/models/paged_resource.rb
+++ b/app/models/paged_resource.rb
@@ -9,7 +9,8 @@ class PagedResource < ActiveFedora::Base
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
   # include ESSI::OCRMetadata
-  include ESSI::PDFMetadata
+  include ESSI::PDFBehavior
+  # include ESSI::PDFMetadata
 
   self.indexer = PagedResourceIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,7 +34,7 @@ class SolrDocument
   attribute :ocr_searchable, Solr::String, solr_name('ocr_searchable', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
   # @todo remove after upgrade to Hyrax 3.x
   attribute :original_file_id, Solr::String, solr_name('original_file_id', :stored_sortable)
-  attribute :allow_pdf_download, Solr::String, solr_name('allow_pdf_download', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
+  attribute :pdf_downloadable, Solr::String, solr_name('pdf_downloadable', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
   attribute :file_set_ids, Solr::Array, solr_name('file_set_ids', :symbol)
   attribute :extracted_text, Solr::String, 'ocr_text_tesi'
 

--- a/app/presenters/concerns/essi/presents_pdf.rb
+++ b/app/presenters/concerns/essi/presents_pdf.rb
@@ -1,5 +1,32 @@
 module ESSI
   module PresentsPDF
-    delegate :allow_pdf_download, to: :solr_document
+    delegate :pdf_downloadable, to: :solr_document
+
+    def allow_pdf_download?
+      pdf_downloadable || current_ability.current_user.admin?
+    end
+
+    # Overrides hyrax
+    def manifest_helper
+      @manifest_helper ||= ESSI::ManifestHelper.new(request.base_url)
+    end
+
+    # Overrides hyrax
+    # IIIF rendering linking property for inclusion in the manifest
+    #  Called by the `iiif_manifest` gem to add a 'rendering' (eg. a link a download for the resource)
+    #
+    # @return [Array] array of rendering hashes
+    def sequence_rendering
+      rendering_ids = solr_document[:file_set_ids_ssim]
+
+      renderings = []
+      if rendering_ids.present? && allow_pdf_download?
+        # We only want a single PDF link rendering for the work as a whole
+        # Use build_pdf_rendering to build the rendering block but don't iterate over all rendering_ids
+        renderings << manifest_helper.build_pdf_rendering(rendering_ids&.first)
+      end
+      renderings.flatten.uniq
+    end
+
   end
 end

--- a/app/presenters/hyrax/archival_material_presenter.rb
+++ b/app/presenters/hyrax/archival_material_presenter.rb
@@ -11,28 +11,6 @@ module Hyrax
     delegate :series, :viewing_direction, :viewing_hint,
              to: :solr_document
 
-    # Overrides hyrax
-    # IIIF rendering linking property for inclusion in the manifest
-    #  Called by the `iiif_manifest` gem to add a 'rendering' (eg. a link a download for the resource)
-    #
-    # @return [Array] array of rendering hashes
-    def sequence_rendering
-      rendering_ids = solr_document[:file_set_ids_ssim]
-
-      renderings = []
-      if rendering_ids.present?
-        rendering_ids.each do |file_set_id|
-          if solr_document[:allow_pdf_download_tesim] == ["true"] || current_ability.current_user.admin?
-            renderings << manifest_helper.build_pdf_rendering(file_set_id)
-          end
-        end
-      end
-      renderings.flatten.uniq
-    end
-
-    def manifest_helper
-      @manifest_helper ||= ESSI::ManifestHelper.new(request.base_url)
-    end
     include AllinsonFlex::DynamicPresenterBehavior
     self.model_class = ::ArchivalMaterial
     include ESSI::PresentsCampus

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -11,28 +11,6 @@ module Hyrax
     delegate :series, :viewing_direction, :viewing_hint,
              to: :solr_document
 
-    # Overrides hyrax
-    # IIIF rendering linking property for inclusion in the manifest
-    #  Called by the `iiif_manifest` gem to add a 'rendering' (eg. a link a download for the resource)
-    #
-    # @return [Array] array of rendering hashes
-    def sequence_rendering
-      rendering_ids = solr_document[:file_set_ids_ssim]
-
-      renderings = []
-      if rendering_ids.present?
-        # We only want a single PDF link rendering for the work as a whole
-        # Use build_pdf_rendering to build the rendering block but don't iterate over all rendering_ids
-        if solr_document[:allow_pdf_download_tesim] == ["true"] || current_ability.current_user.admin?
-          renderings << manifest_helper.build_pdf_rendering(rendering_ids&.first)
-        end
-      end
-      renderings.flatten.uniq
-    end
-
-    def manifest_helper
-      @manifest_helper ||= ESSI::ManifestHelper.new(request.base_url)
-    end
     include AllinsonFlex::DynamicPresenterBehavior
     self.model_class = ::PagedResource
     include ESSI::PresentsCampus

--- a/app/views/records/edit_fields/_pdf_state.html.erb
+++ b/app/views/records/edit_fields/_pdf_state.html.erb
@@ -1,6 +1,7 @@
 <% if current_user.admin? %>
   <%= f.input key, as: :radio_buttons,
+      collection: [[true, 'downloadable'], [false, 'disabled']],
       label: dynamic_label(key),
-      value: f.object.allow_pdf_download,
+      value: f.object.pdf_state,
       hint: dynamic_hint(key) %>
 <% end %>

--- a/config/metadata_profile/essi_short.yaml
+++ b/config/metadata_profile/essi_short.yaml
@@ -129,6 +129,16 @@ properties:
     property_uri: http://dlib.indiana.edu/vocabulary/OCRState
     cardinality:
       maximum: 1
+  pdf_state:
+    display_label:
+      default: "PDF Download"
+    available_on:
+      class:
+        - PagedResource
+        - ArchivalMaterial
+    property_uri: http://dlib.indiana.edu/vocabulary/PDFState
+    cardinality:
+      maximum: 1
   publication_place:
     display_label:
       default: "Publication Place"

--- a/spec/presenters/hyrax/archival_material_presenter_spec.rb
+++ b/spec/presenters/hyrax/archival_material_presenter_spec.rb
@@ -32,66 +32,7 @@ RSpec.describe Hyrax::ArchivalMaterialPresenter do
       }
     }
 
-    describe "#sequence_rendering" do
-      subject do
-        presenter.sequence_rendering
-      end
-
-      before do
-        Hydra::Works::AddFileToFileSet.call(work.file_sets.first,
-                                            File.open(fixture_path + '/world.png'), :original_file)
-      end
-
-      context 'when allow_pdf_download is true' do
-        context 'when user is an admin' do
-          before do
-            allow(current_user).to receive(:admin?).and_return(true)
-            work.allow_pdf_download = 'true'
-          end
-
-          it 'returns a hash containing the pdf rendering information' do
-            expect(subject).to be_an Array
-            expect(subject).to include(pdf_rendering_hash)
-          end
-        end
-
-        context 'when user is not an admin' do
-          before do
-            allow(current_user).to receive(:admin?).and_return(false)
-          end
-
-          it 'returns a hash without the pdf rendering information' do
-            expect(subject).to be_an Array
-            expect(subject).not_to include(pdf_rendering_hash)
-          end
-        end
-      end
-
-      context 'when allow_pdf_download config is false' do
-        before do
-          work.allow_pdf_download = 'false'
-        end
-        context 'when user is an admin' do
-          before do
-            allow(current_user).to receive(:admin?).and_return(true)
-          end
-          it 'returns a hash without the pdf rendering information' do
-            expect(subject).to be_an Array
-            expect(subject).to include(pdf_rendering_hash)
-          end
-        end
-        context 'when user is not an admin' do
-          before do
-            allow(current_user).to receive(:admin?).and_return(false)
-          end
-
-          it 'returns a hash without the pdf rendering information' do
-            expect(subject).to be_an Array
-            expect(subject).not_to include(pdf_rendering_hash)
-          end
-        end
-      end
-    end
+    include_examples "pdf sequence rendering"
   end
 
   include_examples "presents related_url"

--- a/spec/presenters/hyrax/paged_resource_presenter_spec.rb
+++ b/spec/presenters/hyrax/paged_resource_presenter_spec.rb
@@ -32,66 +32,7 @@ RSpec.describe Hyrax::PagedResourcePresenter do
       }
     }
 
-    describe "#sequence_rendering" do
-      subject do
-        presenter.sequence_rendering
-      end
-
-      before do
-        Hydra::Works::AddFileToFileSet.call(work.file_sets.first,
-                                            File.open(fixture_path + '/world.png'), :original_file)
-      end
-
-      context 'when allow_pdf_download is true' do
-        context 'when user is an admin' do
-          before do
-            allow(current_user).to receive(:admin?).and_return(true)
-            work.allow_pdf_download = 'true'
-          end
-
-          it 'returns a hash containing the pdf rendering information' do
-            expect(subject).to be_an Array
-            expect(subject).to include(pdf_rendering_hash)
-          end
-        end
-
-        context 'when user is not an admin' do
-          before do
-            allow(current_user).to receive(:admin?).and_return(false)
-          end
-
-          it 'returns a hash without the pdf rendering information' do
-            expect(subject).to be_an Array
-            expect(subject).not_to include(pdf_rendering_hash)
-          end
-        end
-      end
-
-      context 'when allow_pdf_download config is false' do
-        before do
-          work.allow_pdf_download = 'false'
-        end
-        context 'when user is an admin' do
-          before do
-            allow(current_user).to receive(:admin?).and_return(true)
-          end
-          it 'returns a hash without the pdf rendering information' do
-            expect(subject).to be_an Array
-            expect(subject).to include(pdf_rendering_hash)
-          end
-        end
-        context 'when user is not an admin' do
-          before do
-            allow(current_user).to receive(:admin?).and_return(false)
-          end
-
-          it 'returns a hash without the pdf rendering information' do
-            expect(subject).to be_an Array
-            expect(subject).not_to include(pdf_rendering_hash)
-          end
-        end
-      end
-    end
+    include_examples "pdf sequence rendering"
   end
 
   include_examples "presents related_url"

--- a/spec/support/shared_examples/pdf_sequence_rendering.rb
+++ b/spec/support/shared_examples/pdf_sequence_rendering.rb
@@ -1,0 +1,64 @@
+RSpec.shared_examples "pdf sequence rendering" do
+  describe "#sequence_rendering" do
+    subject do
+      presenter.sequence_rendering
+    end
+
+    before do
+      Hydra::Works::AddFileToFileSet.call(work.file_sets.first,
+                                          File.open(fixture_path + '/world.png'), :original_file)
+    end
+
+    context 'when pdf_state is downloadable' do
+      before do
+        work.pdf_state = 'downloadable'
+      end
+      context 'when user is an admin' do
+        before do
+          allow(current_user).to receive(:admin?).and_return(true)
+        end
+
+        it 'returns a hash containing the pdf rendering information' do
+          expect(subject).to be_an Array
+          expect(subject).to include(pdf_rendering_hash)
+        end
+      end
+
+      context 'when user is not an admin' do
+        before do
+          allow(current_user).to receive(:admin?).and_return(false)
+        end
+
+        it 'returns a hash containing the pdf rendering information' do
+          expect(subject).to be_an Array
+          expect(subject).to include(pdf_rendering_hash)
+        end
+      end
+    end
+
+    context 'when pdf_state is disabled' do
+      before do
+        work.pdf_state = 'disabled'
+      end
+      context 'when user is an admin' do
+        before do
+          allow(current_user).to receive(:admin?).and_return(true)
+        end
+        it 'returns a hash containing the pdf rendering information' do
+          expect(subject).to be_an Array
+          expect(subject).to include(pdf_rendering_hash)
+        end
+      end
+      context 'when user is not an admin' do
+        before do
+          allow(current_user).to receive(:admin?).and_return(false)
+        end
+
+        it 'returns a hash without the pdf rendering information' do
+          expect(subject).to be_an Array
+          expect(subject).not_to include(pdf_rendering_hash)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Various changes:
* Moves shared Presenter code into a module, and shared Presenter spec code into a shared_example
* Changes the paradigm for the pdf download Boolean to match the pattern we're using for ocr_state/ocr_searchable
  * replaces allow_pdf_download with pdf_state (ActiveFedora property) and pdf_downloadable (solr index)
    * pdf_state is present in the minimal default metadata profile, but the property is not hard-coded, rather expected to be configured via allinson_flex
  * adds a custom UI component to present pdf_state values ("downloadable", "disabled") as a true/false radio button
  
For this to work, there needs to be a pdf_state property configured in allinson_flex, as follows:
**key**: pdf_state
**display_label**: (probably "PDF Download" or something similar)
**available_on**: Paged Resource and ArchivalMaterial, minimally -- could apply to other work types, too, but we'll need to start including the PDF download modules for them to actually have pdf download work
**cardinality**: min 0, max 1
**indexing**: stored_searchable, and (probably) admin_only
**usage_guidelines**: might want something here about how admin status overrides a "false" here?
**property_uri**: suggest "http://dlib.indiana.edu/vocabulary/PDFState" to mimic what we have for ocr_state, but the code just cares about the property name (pdf_state)
