### PR TITLE
Escaping obsoletions

### DIFF
--- a/lib/extensions/active_fedora/file/escaping_obsoletions.rb
+++ b/lib/extensions/active_fedora/file/escaping_obsoletions.rb
@@ -2,10 +2,10 @@ module Extensions
   module ActiveFedora
     module File
       module EscapingObsoletions
-        # unmodified from active_fedora
+        # modified from active_fedora: update obsolete URI methods to CGI
         def ldp_headers
           headers = { 'Content-Type'.freeze => mime_type, 'Content-Length'.freeze => content.size.to_s }
-          headers['Content-Disposition'.freeze] = "attachment; filename=\"#{::URI.encode(@original_name)}\"" if @original_name
+          headers['Content-Disposition'.freeze] = "attachment; filename=\"#{::CGI.escape(@original_name)}\"" if @original_name
           headers
         end
       end

--- a/lib/extensions/active_fedora/file/escaping_obsoletions.rb
+++ b/lib/extensions/active_fedora/file/escaping_obsoletions.rb
@@ -1,0 +1,15 @@
+module Extensions
+  module ActiveFedora
+    module File
+      module EscapingObsoletions
+        # unmodified from active_fedora
+        def ldp_headers
+          headers = { 'Content-Type'.freeze => mime_type, 'Content-Length'.freeze => content.size.to_s }
+          headers['Content-Disposition'.freeze] = "attachment; filename=\"#{::URI.encode(@original_name)}\"" if @original_name
+          headers
+        end
+      end
+    end
+  end
+end
+

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -128,3 +128,8 @@ Hyrax::Collections::PermissionsService.include Extensions::Hyrax::Collections::P
 
 # Collections search
 Qa::Authorities::Collections.prepend Extensions::Qa::Authorities::Collections::CollectionsSearch
+
+# update obsolete URI escaping methods
+Hydra::AccessControls::Permission.prepend Extensions::Hydra::AccessControls::Permission::EscapingObsoletions
+ActiveFedora::File.prepend Extensions::ActiveFedora::File::EscapingObsoletions
+

--- a/lib/extensions/hydra/access_controls/permission/escaping_obsoletions.rb
+++ b/lib/extensions/hydra/access_controls/permission/escaping_obsoletions.rb
@@ -1,0 +1,19 @@
+module Extensions
+  module Hydra
+    module AccessControls
+      module Permission
+        module EscapingObsoletions
+          # unmodified from hydra-access-controls
+          def agent_name
+            ::URI.decode(parsed_agent.last)
+          end
+
+          # unmodified from hydra-access-controls
+          def build_agent_resource(prefix, name)
+            [::Hydra::AccessControls::Agent.new(::RDF::URI.new("#{prefix}##{::URI.encode(name)}"))]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hydra/access_controls/permission/escaping_obsoletions.rb
+++ b/lib/extensions/hydra/access_controls/permission/escaping_obsoletions.rb
@@ -3,14 +3,14 @@ module Extensions
     module AccessControls
       module Permission
         module EscapingObsoletions
-          # unmodified from hydra-access-controls
+          # modified to use CGI method instead of obsolete URI method
           def agent_name
-            ::URI.decode(parsed_agent.last)
+            ::CGI.unescape(parsed_agent.last)
           end
 
-          # unmodified from hydra-access-controls
+          # modified to use CGI method instead of obsolete URI method
           def build_agent_resource(prefix, name)
-            [::Hydra::AccessControls::Agent.new(::RDF::URI.new("#{prefix}##{::URI.encode(name)}"))]
+            [::Hydra::AccessControls::Agent.new(::RDF::URI.new("#{prefix}##{::CGI.escape(name)}"))]
           end
         end
       end


### PR DESCRIPTION
A couple pieces of the hyrax stack are calling obsolete URI.encode, URI.decode methods that clutter add tons of clutter to test output and server logs.  This is a proposal for monkeypatching around them.