### PR TITLE
Modify PerformLaterActor to move work to newest schema on #update

### DIFF
--- a/app/actors/essi/actors/perform_later_actor.rb
+++ b/app/actors/essi/actors/perform_later_actor.rb
@@ -14,6 +14,8 @@ module ESSI
       def update(env)
         # Short circuit to next actor if we are running from a job.
         if env.attributes.delete 'in_perform_later_actor_job'
+          env.curation_concern.class.new # force-load newest profile
+          env.curation_concern.update_dynamic_schema
           super
         else
           env.attributes['in_perform_later_actor_job'] = true

--- a/lib/extensions/allinson_flex/prepend_work_dynamic_schema.rb
+++ b/lib/extensions/allinson_flex/prepend_work_dynamic_schema.rb
@@ -9,6 +9,14 @@ module Extensions
         @dynamic_schema ||= ::AllinsonFlex::DynamicSchema.find_by(id: self.dynamic_schema_id) || self.dynamic_schema_service(update: true)&.dynamic_schema
       end
 
+      # new method to facilitate updating schema via edit action
+      # defaults to newest schema if no id is provided
+      def update_dynamic_schema(schema_id: nil)
+        @dynamic_schema = ::AllinsonFlex::DynamicSchema.find_by(id: schema_id) || self.dynamic_schema_service(update: true)&.dynamic_schema
+        self.dynamic_schema_id = @dynamic_schema&.id
+        self.profile_version = @dynamic_schema&.profile&.profile_version
+      end
+
       # @todo remove after issue is resolved within allinson_flex
       # method from allinson_flex, to resolve issue #63
       def initialize(attributes = nil, &_block)


### PR DESCRIPTION
Background context: we earlier applied bugfixes for some allinson_flex issues (61, 63), one of which was an object was _always_ loading the newest dynamic schema, even when it wasn't supposed to.  But it looks like in fixing that, we've needed to address actively loading the newest schema when we _are_ intending to upgrade to it.

Running main locally, I find I can break updating a work under these circumstances:
* Have an existing work, using the newest metadata profile version
* Create a new metadata profile version with a new property
* Edit the work, assigning a value to a new property, and save
I find that the work is not updated, and although the UI shows no complaints, the server logs show the actor/job stack errored out trying to handle the new attribute that's not in the older schema.  (Side note: the UI seemingly reports the update was successful as long as the actor/job stack was _called_; do we want a story about reporting whether that call is ultimately successful?)

Running this PR, I find the update succeeds.

Note that the new `#update_dynamic_schema` method is also useful for rolling back a work to an older version of the schema.