### PR TITLE
Load profiler gems in prod, restrict to admins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,8 +70,6 @@ group :development do
 
   gem 'debase'
   gem 'ruby-debug-ide'
-  gem 'rack-mini-profiler'
-  gem 'stackprof'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -109,6 +107,10 @@ gem 'bulkrax', '~> 1.0.0'
 gem 'willow_sword', github: 'notch8/willow_sword'
 gem 'webpacker'
 gem 'react-rails'
+
+# Profiling
+gem 'rack-mini-profiler'
+gem 'stackprof'
 
 # hold back hydra-head due to implicit Blacklight 7 requirement in newer versions
 gem 'hydra-head', '10.6.1'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,10 @@ class ApplicationController < ActionController::Base
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
   protect_from_forgery with: :exception
+
+  before_action do
+    if current_user && current_user.admin?
+      Rack::MiniProfiler.authorize_request
+    end
+  end
 end


### PR DESCRIPTION
Activates the rack-mini-profiler gem in production and restricts access to admins. rack-mini-profiler disables some cache related headers, so there may be an impact on performance.