### PR TITLE
Optimize profile property text loading to avoid N+1 db queries

### DIFF
--- a/app/controllers/concerns/essi/dynamic_catalog_behavior.rb
+++ b/app/controllers/concerns/essi/dynamic_catalog_behavior.rb
@@ -5,7 +5,7 @@ module ESSI
 
     class_methods do
       def load_allinson_flex
-        profile = AllinsonFlex::Profile.current_version
+        profile = AllinsonFlex::Profile.includes(properties: :texts).order("created_at desc").first
         unless profile.blank?
           profile.properties.each do |prop|
             # blacklight wants 1 label for all classes with this property


### PR DESCRIPTION
Eager loads profile properties and their texts to avoid querying the db thousands of times.