### PR TITLE
Cache data from holding location service

### DIFF
--- a/app/services/holding_location_service.rb
+++ b/app/services/holding_location_service.rb
@@ -7,10 +7,15 @@ module HoldingLocationService
   end
 
   def self.select_all_options
-    authority.all.map { |element| [element[:label], element[:code]] }
+    results = Rails.cache.fetch('HoldLoc-v1-_ALL_', expires_in: 1.hour, race_condition_ttl: 1.hour) do
+      authority.all
+    end
+    results.map { |element| [element[:label], element[:code]] }
   end
 
   def self.find(id)
-    authority.find(id)
+    Rails.cache.fetch("HoldLoc-v1-#{id}", expires_in: 1.hour, race_condition_ttl: 1.hour) do
+      authority.find(id)
+    end
   end
 end


### PR DESCRIPTION
The holding location web service is being queried for every work on a search results page, which adds a second or two to the response time when all 10 results have a holding location.

This caches the web service response for between 1-2 hours.