### PR TITLE
ESSI-1554 Load AllinsonFlex attributes only when needed

### DIFF
--- a/app/models/concerns/essi/dynamic_solr_document.rb
+++ b/app/models/concerns/essi/dynamic_solr_document.rb
@@ -17,13 +17,21 @@ module ESSI
         # profile directly.
         profile = AllinsonFlex::Profile.current_version
         unless profile.blank?
-          profile.properties.each do |prop|
-            attribute(
-              prop.name,
-              # if the property is singular, make it so
-              prop.cardinality_maximum == 1 ? Hyrax::SolrDocument::Metadata::Solr::String : Hyrax::SolrDocument::Metadata::Solr::Array,
-              solr_name(prop.name.to_s)
-            )
+          Rails.logger.debug { "Loading AllinsonFlex DynamicSolrDocument #{ profile.profile_version } with #{profile.properties.count} properties." }
+
+          # Loading attributes is done by defining a method for each property. This only needs to be done once or when the profile changes.
+          # Code that needs to run for every SolrDocument instance should go outside this block.
+          if @loaded_allinson_flex_version != profile.profile_version
+            Rails.logger.debug { "AllinsonFlex profile not yet loaded, or version mismatch. Setting attributes..." }
+            profile.properties.each do |prop|
+              attribute(
+                prop.name,
+                # if the property is singular, make it so
+                prop.cardinality_maximum == 1 ? Hyrax::SolrDocument::Metadata::Solr::String : Hyrax::SolrDocument::Metadata::Solr::Array,
+                solr_name(prop.name.to_s)
+              )
+            end
+            @loaded_allinson_flex_version = profile.profile_version
           end
         end
       end


### PR DESCRIPTION
The AllinsonFlex DynamicSolrDocument is loading the profile and (re)defining attributes every time a SolrDocument instance is initialized. On pages with multiple objects this incurs a large performance penalty. For example, the All Collections Dashboard test case would spend ~80% of its time in this method.

This loading only needs to happen once per request, but because the outcome is defining methods, the effect of loading should persist even after the request is finished.