### PR TITLE
Cache user ldap roles to speed up user.admin?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,8 +45,11 @@ class User < ApplicationRecord
 
   # Roles to add depending on user's LDAP groups and ESSI configuration
   def ldap_roles
-    mappings = ESSI.config.dig(:ldap, :group_roles) || {}
-    mappings.select { |role, groups| member_of_ldap_group?(groups) }.keys
+    Rails.cache.fetch("ldap_roles-v1-#{cache_key_with_version}",
+                      expires_in: 1.hour, race_condition_ttl: 1.hour) do
+      mappings = ESSI.config.dig(:ldap, :group_roles) || {}
+      mappings.select { |role, groups| member_of_ldap_group?(groups) }.keys
+    end
   end
 
   # Modified method from hydra-role-management Hydra::RoleManagement::UserRoles

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,9 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
+  # Disable cache storage during tests
+  config.cache_store = :null_store
+
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Disable cache storage during tests
-  config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe User, type: :model do
   shared_examples "ldap_role behavior" do |method|
     describe "performs group lookup", :clean do
       before do
+        Rails.cache.clear
         groups1 = ['groupA', 'groupB']
         groups2 = ['groupB', 'groupC']
         allow(user).to receive(:member_of_ldap_group?).with(groups1).and_return(true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe User, type: :model do
     before do
       groups1 = ['groupA', 'groupB']
       groups2 = ['groupB', 'groupC']
+      user = FactoryBot.create :user
       allow(user).to receive(:member_of_ldap_group?).with(groups1).and_return(true)
       allow(user).to receive(:member_of_ldap_group?).with(groups2).and_return(false)
       allow(ESSI.config).to receive(:dig).with(:ldap, :group_roles).and_return({ roles[0].name => groups1, roles[1].name => groups2  })


### PR DESCRIPTION
Calling `admin?` on a user currently regenerates the user's ldap membership list. Some metadata fields now check admin status causing repeated lookups to render a single page. This change caches that result. The cache entry will be invalidated by a change to the user record, which should happen when logging in.