### PR TITLE
[ESSI-1540] Remove authorization for #pdf, add for #file_manager

### DIFF
--- a/app/controllers/concerns/essi/pdf_download.rb
+++ b/app/controllers/concerns/essi/pdf_download.rb
@@ -1,5 +1,11 @@
 module ESSI
   module PDFDownload
+    def self.included(base)
+      base.class_eval do
+        skip_load_and_authorize_resource only: :pdf
+      end
+    end
+  
     def pdf
       if presenter.allow_pdf_download?
         pdf = ESSI::GeneratePdfService.new(presenter.solr_document).generate

--- a/app/controllers/concerns/essi/works_controller_behavior.rb
+++ b/app/controllers/concerns/essi/works_controller_behavior.rb
@@ -1,5 +1,13 @@
 module ESSI
   module WorksControllerBehavior
+    # @todo review after upgrade to Hyrax 3.x
+    def self.included(base) 
+      base.class_eval do
+        # hyrax claims the presenter handles authorization
+        # in practice, it generates a ruby error
+        load_and_authorize_resource only: :file_manager
+      end
+    end
 
     def additional_response_formats(wants)
       wants.uv do


### PR DESCRIPTION
Turns out [stock hyrax 2.9.6 does an object load and authorization for most actions](https://github.com/samvera/hyrax/blob/v2.9.6/app/controllers/concerns/hyrax/works_controller_behavior.rb#L27-L31), which we don't want for #pdf (for those PDFs that are available for public download).  And we probably do want it for #file_manager, since calling it without being logged in produces a ruby error.