### PR TITLE
[ESSI-1562] Fix catalog "masonry" and "gallery" views with query parameter, add to "list" view

### DIFF
--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,3 +1,9 @@
 <div class="search-results-title-row">
-  <h3 class="search-result-title"><%= link_to document.title_or_label, document %></h3>
+  <h3 class="search-result-title">
+  <% if params['q'].present? %>
+    <%= link_to document.title_or_label, [document, { query: params['q'] }] %></h3>
+  <% else %>
+    <%= link_to document.title_or_label, document %></h3>
+  <% end %>
+  </h3>
 </div>

--- a/config/initializers/blacklight_helpers.rb
+++ b/config/initializers/blacklight_helpers.rb
@@ -1,4 +1,5 @@
 Blacklight::UrlHelperBehavior.module_eval do
+  # modified from blacklight wih the new #add_highlight_url
   # link_to_document(doc, 'VIEW', :counter => 3)
   # Use the catalog_path RESTful route to create a link to the show page for a specific item.
   # catalog_path accepts a hash. The solr query params are stored in the session,
@@ -18,12 +19,14 @@ Blacklight::UrlHelperBehavior.module_eval do
     link_to label, url, document_link_params(doc, opts)
   end
 
-  # Adds search term to be highlighed on item
-  # to catalog search URL
+  # Adds search term to be highlighed on item to catalog search URL
   #
-  # @param [Object] SOLR document
-  # @return [String] url string
+  # @param [Object] SolrDocument
+  # @return <Array(ActionDispatch::Routing::RoutesProxy, SolrDocument)> if no highlight parameter added
+  # @return <Array(ActionDispatch::Routing::RoutesProxy, SolrDocument, Hash)> if highlight parameter added
   def add_highlight_url(doc)
-    params['q'].present? ? [doc, query: CGI.escape(params['q'])] : url_for_document(doc)
+    modified_url = url_for_document(doc)
+    modified_url += [{ query: params['q'] }] if params['q'].present?
+    modified_url
   end
 end


### PR DESCRIPTION
An earlier PR added functionality to pass along a search term through catalog results, to the individual work display, to be applied in UV for search term highlighting:
https://github.com/IU-Libraries-Joint-Development/essi/pull/90

It looks like there's been some gem drift in the meantime that broke our monkeypatch.  The PR fixes the monkeypatch, which should resolve the ruby errors that can currently be generated in "gallery" and "masonry" view for catalog results that include Collections.

The second commit adds the text query pass-through feature to the catalog results "list" view, where it was missing.