### PR TITLE
Update config for yaz proxy

### DIFF
--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -114,10 +114,11 @@ default: &default
       default_upload_dropbox: <%= Rails.root.join("staged_files/uploaded") %>
       default_bagit_dir: <%= Rails.root.join("staged_files/work_bags") %>
     manifest_builder:
-      see_also_hash:
-        id: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=%s&recordSchema=marcxml&version=1.1
+      see_also_hash: # TODO: enable or deprecate
+        id: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=%s&recordSchema=marcxml&version=1.1
         format: application/xml
     metadata:
+      remote_lookup: http://metadata.remote.service.url
       url: https://purl.dlib.indiana.edu/iudl/iucat/%s
       editable:
         - :identifier

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -113,10 +113,11 @@ default: &default
       default_upload_dropbox: <%= Rails.root.join("staged_files/uploaded") %>
       default_bagit_dir: <%= Rails.root.join("staged_files/work_bags") %>
     manifest_builder:
-      see_also_hash:
-        id: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=%s&recordSchema=marcxml&version=1.1
+      see_also_hash: # TODO: enable or deprecate
+        id: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=%s&recordSchema=marcxml&version=1.1
         format: application/xml
     metadata:
+      remote_lookup: http://metadata.remote.service.url
       url: https://purl.dlib.indiana.edu/iudl/iucat/%s
       editable:
         - :identifier

--- a/lib/iu_metadata/client.rb
+++ b/lib/iu_metadata/client.rb
@@ -39,12 +39,16 @@ module IuMetadata
       data
     end
 
+    private_class_method def self.remote_metadata_lookup_url
+      ESSI.config.dig(:essi, :metadata, :remote_lookup)
+    end
+
     private_class_method def self.retrieve_mods(id)
-      conn = Faraday.new(url: 'http://dlib.indiana.edu:9000')
+      conn = Faraday.new(url: remote_metadata_lookup_url)
       response = conn.get do |req|
         req.url '/iucatextract'
         req.params['query'] = "cql.serverChoice=#{id}"
-        req.params['recordSchema'] = 'mods'
+        req.params['recordSchema'] = 'MODS'
         req.params['operation'] = 'searchRetrieve'
         req.params['version'] = '1.1'
         req.params['maximumRecords'] = '1'
@@ -53,7 +57,7 @@ module IuMetadata
     end
 
     private_class_method def self.retrieve_marc(id)
-      conn = Faraday.new(url: 'http://dlib.indiana.edu:9000')
+      conn = Faraday.new(url: remote_metadata_lookup_url)
       response = conn.get do |req|
         req.url '/iucatextract'
         req.params['query'] = "cql.serverChoice=#{id}"

--- a/spec/fixtures/vcr_cassettes/bibdata.yml
+++ b/spec/fixtures/vcr_cassettes/bibdata.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=BHR9405&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=BHR9405&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -123,7 +123,7 @@ http_interactions:
   recorded_at: Tue, 19 Mar 2019 17:47:52 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=BHR9405&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=BHR9405&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -208,7 +208,7 @@ http_interactions:
   recorded_at: Tue, 19 Mar 2019 17:47:53 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAC1741-00231&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAC1741-00231&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -239,7 +239,7 @@ http_interactions:
   recorded_at: Thu, 14 May 2020 18:21:18 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAC1741-00231&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAC1741-00231&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/marc_VAD5427.yml
+++ b/spec/fixtures/vcr_cassettes/marc_VAD5427.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/mods_VAD5427.yml
+++ b/spec/fixtures/vcr_cassettes/mods_VAD5427.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/mods_deadbeef.yml
+++ b/spec/fixtures/vcr_cassettes/mods_deadbeef.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=missingrecorddeadbeef&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=missingrecorddeadbeef&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Changes the yazproxy call to use a configurable value, instead of a hardcoded one.
(The committed value does need to be changed to a working one, in deployment, through a config change.)

TBD: enable or deprecate the "see_also_hash"

Also, see equivalent pumpkin PR:
https://github.com/IU-Libraries-Joint-Development/pumpkin/pull/218