### PR TITLE
ESSI-1576 Quiet route errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,4 +19,9 @@ class ApplicationController < ActionController::Base
       Rack::MiniProfiler.authorize_request
     end
   end
+
+  rescue_from ActionController::UnknownFormat, with: :rescue_404
+  def rescue_404
+    render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,5 +104,9 @@ Rails.application.routes.draw do
   get '/purl/formats/:id', to: 'purl#formats', as: 'formats_purl'
   get '/purl/*id', to: 'purl#default', as: 'default_purl'
 
+  # Send ActionController::RoutingError to 404 page
+  # Must be the last route defined
+  match '*unmatched', to: 'application#rescue_404', via: :all
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Going to a missing page or unknown format is usually just a 404 sent to the client. Raising an exception and airbrake notice seems unnecessary.

Based on the new CircleCI config branch.