### PR TITLE
ESSI-1577 Sidekiq dashboard link

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,7 +19,8 @@ class Ability
     #   can [:create], ActiveFedora::Base
     # end
     if current_user.admin?
-        can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy, :pdf], Role
+      can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy, :pdf], Role
+      can :manage, :sidekiq_dashboard
     end
   end
 

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -1,0 +1,33 @@
+  <li class="h5"><%= t('hyrax.admin.sidebar.activity') %></li>
+
+  <li>
+    <%= menu.collapsable_section t('hyrax.admin.sidebar.user_activity'),
+                                 icon_class: "fa fa-line-chart",
+                                 id: 'collapseUserActivity',
+                                 open: menu.user_activity_section? do %>
+      <%= menu.nav_link(hyrax.dashboard_profile_path(current_user),
+                        also_active_for: hyrax.edit_dashboard_profile_path(current_user)) do %>
+        <span class="fa fa-id-card" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.profile') %></span>
+      <% end %>
+
+      <%= menu.nav_link(hyrax.notifications_path) do %>
+        <span class="fa fa-bell" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.notifications') %></span>
+      <% end %>
+
+      <%= menu.nav_link(hyrax.transfers_path) do %>
+        <span class="fa fa-arrows-h" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.transfers') %></span>
+      <% end %>
+
+      <% if Flipflop.proxy_deposit? %>
+        <%= menu.nav_link(hyrax.depositors_path) do %>
+          <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.dashboard.manage_proxies') %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </li>
+
+  <% if can? :read, :admin_dashboard %>
+    <%= menu.nav_link(hyrax.admin_stats_path) do %>
+      <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.statistics') %></span>
+    <% end %>
+  <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -31,3 +31,9 @@
       <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.statistics') %></span>
     <% end %>
   <% end %>
+
+  <% if can? :manage, :sidekiq_dashboard %>
+    <%= menu.nav_link(url_for('/sidekiq')) do %>
+      <span class="fa fa-code-fork" aria-hidden="true"></span> <span class="sidebar-action-text">Sidekiq Dashboard</span>
+    <% end %>
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,7 +96,7 @@ Rails.application.routes.draw do
     end
   end
 
-  authenticate :user, lambda { |u| u.admin? } do
+  authenticate :user, lambda { |u| u.ability.can?(:manage, :sidekiq_dashboard) } do
     mount Sidekiq::Web => '/sidekiq'
   end
 


### PR DESCRIPTION
Add a Sidekiq dashboard link to the hyrax dashboard. Only visible to admins, which is now checked via the user's abilities to allow other user types to potentially access it in the future, if needed.

Note to devs: I could not find a route helper (e.g. sidekiq_web.root_path) so had to use a string instead.

Based on the new CircleCI config branch.