### PR TITLE
Essi-1520 Collection wildcard search

### DIFF
--- a/lib/extensions/qa/authorities/collections/collections_search.rb
+++ b/lib/extensions/qa/authorities/collections/collections_search.rb
@@ -8,6 +8,7 @@ module Extensions
             # The Hyrax::CollectionSearchBuilder expects a current_user
             return [] unless controller.current_user
             repo = ::CatalogController.new(skip_allinson_flex: true).repository
+            controller.params[:q] << '*' if controller.params[:q].to_s.size >= 2
             builder = search_builder(controller)
             response = repo.search(builder)
             docs = response.documents

--- a/spec/authorities/qa/authorities/collections_spec.rb
+++ b/spec/authorities/qa/authorities/collections_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Qa::Authorities::Collections do
+  subject(:service) { described_class.new }
+  let(:controller) { Qa::TermsController.new }
+  let(:user1) { FactoryBot.build(:user) }
+
+  let!(:collection1) do
+    FactoryBot.build(:collection_lw,
+                     title: ['foo bar'],
+                     user: user1,
+                     with_solr_document: true)
+  end
+
+  let!(:collection2) do
+    FactoryBot.build(:collection_lw,
+                     title: ['foo'],
+                     user: user1,
+                     with_solr_document: true)
+  end
+
+  before do
+    allow(controller).to receive(:params).and_return(params)
+    allow(controller).to receive(:current_user).and_return(user1)
+  end
+
+  describe '#search' do
+    context 'with partial starting term' do
+      let(:params) { ActionController::Parameters.new(q: 'fo') }
+
+      it 'lists collection' do
+        expect(service.search(nil, controller))
+          .to contain_exactly(include(id: collection1.id), include(id: collection2.id))
+      end
+    end
+
+    context 'with partial middle term' do
+      let(:params) { ActionController::Parameters.new(q: 'ba') }
+
+      it 'lists collection' do
+        expect(service.search(nil, controller))
+          .to contain_exactly(include(id: collection1.id))
+      end
+    end
+
+    context 'with full term' do
+      let(:params) { ActionController::Parameters.new(q: 'foo bar') }
+
+      it 'lists collection' do
+        expect(service.search(nil, controller))
+          .to contain_exactly(include(id: collection1.id))
+      end
+    end
+
+    context 'with unmatched term' do
+      let(:params) { ActionController::Parameters.new(q: 'deadbeef') }
+
+      it 'lists nothing' do
+        expect(service.search(nil, controller))
+          .to match_array ([])
+      end
+    end
+
+    context 'with too short term' do
+      let(:params) { ActionController::Parameters.new(q: 'f') }
+
+      it 'lists nothing' do
+        expect(service.search(nil, controller))
+          .to match_array ([])
+      end
+    end
+
+    context 'with no term' do
+      let(:params) { ActionController::Parameters.new() }
+
+      it 'lists everything' do
+        expect(service.search(nil, controller))
+          .to contain_exactly(include(id: collection1.id), include(id: collection2.id))
+      end
+    end
+  end
+end

--- a/spec/factories/object_id.rb
+++ b/spec/factories/object_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# Defines a new sequence
+FactoryBot.define do
+  sequence :object_id do |n|
+    "object_id_#{n}"
+  end
+end


### PR DESCRIPTION
Adds an * to the query used to search for collections when adding a collection or work to a collection.

The collection factory for the specs depends on another factory that we had not yet copied in from hyrax.

Based on the new CircleCI config.