### PR TITLE
Configurable switch_user in development without login

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -25,13 +25,28 @@
         <li><%= link_to 'Log In As ...', main_app.log_in_as_path %></li>
         <% end %>
       </ul>
-
     </li><!-- /.btn-group -->
   <% else %>
     <li>
       <%= link_to main_app.new_user_session_path do %>
         <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
       <% end %>
+    </li>
+  <% end %>
+  <% if !user_signed_in? && Rails.env.development? && ESSI.config.dig(:essi, :allow_dev_login) %>
+    <li class="dropdown">
+      <%= link_to '/', role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>
+        <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+        <span class="hidden-xs">&nbsp;<%= current_user&.name %></span>
+        <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+        <span class="fa fa-user"></span>
+        <span class="caret"></span>
+      <% end %>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <% if switch_user_select.present? %>
+        <li><%= link_to 'Log In As ...', main_app.log_in_as_path %></li>
+        <% end %>
+      </ul>
     </li>
   <% end %>
 </ul>

--- a/app/views/users/sessions/log_in_as.html.erb
+++ b/app/views/users/sessions/log_in_as.html.erb
@@ -4,5 +4,5 @@
   <p>Check the box if you want the ability to return as current user.</p>
   <%= switch_user_select %>
   <% end %>
-  <h3>Current User: <%= current_user.uid %></h3>
+  <h3>Current User: <%= current_user&.uid %></h3>
 </div>

--- a/app/views/users/sessions/log_in_as.html.erb
+++ b/app/views/users/sessions/log_in_as.html.erb
@@ -4,5 +4,5 @@
   <p>Check the box if you want the ability to return as current user.</p>
   <%= switch_user_select %>
   <% end %>
-  <h3>Current User: <%= current_user&.uid %></h3>
+  <h3>Current User: <%= current_user ? "#{current_user.uid} (#{current_user.email})" : "(none)" %>
 </div>

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -94,6 +94,7 @@ default: &default
   authorized_ldap_groups:
     - ESSI-USERS
   essi:
+    allow_dev_login: false
     iiif_host: essi.docker  # riiif only
     notifier_email: example@test.test
     store_original_files: true

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -93,6 +93,7 @@ default: &default
   authorized_ldap_groups:
     - ESSI-USERS
   essi:
+    allow_dev_login: false
     iiif_host: localhost:3000  # riiif only
     notifier_email: example@test.test
     store_original_files: true

--- a/config/initializers/switch_user.rb
+++ b/config/initializers/switch_user.rb
@@ -48,5 +48,5 @@ SwitchUser.setup do |config|
 
   # switch_back allows you to switch back to a previously selected user. See
   # README for more details.
-  config.switch_back = true
+  config.switch_back = !(Rails.env.development? && ESSI.config.dig(:essi, :allow_dev_login))
 end

--- a/config/initializers/switch_user.rb
+++ b/config/initializers/switch_user.rb
@@ -26,13 +26,13 @@ SwitchUser.setup do |config|
   # if it returns true, the request will continue,
   # else the request will be refused and returns "Permission Denied"
   # if you switch from "admin" to user, the current_user param is "admin"
-  config.controller_guard = ->(current_user, _request, original_user) { current_user && current_user.admin? || original_user && original_user.admin?}
+  config.controller_guard = ->(current_user, _request, original_user) { current_user&.admin? || original_user&.admin? || Rails.env.development? && ESSI.config.dig(:essi, :allow_dev_login) }
 
   # view_guard is a block,
   # if it returns true, the switch user select box will be shown,
   # else the select box will not be shown
   # if you switch from admin to "user", the current_user param is "user"
-  config.view_guard = ->(current_user, _request, original_user) { current_user && current_user.admin? || original_user && original_user.admin?}
+  config.view_guard = ->(current_user, _request, original_user) { current_user&.admin? || original_user&.admin? || Rails.env.development? && ESSI.config.dig(:essi, :allow_dev_login) }
 
   # redirect_path is a block, it returns which page will be redirected
   # after switching a user.


### PR DESCRIPTION
If configured to "true" for local development, allows direct access to switch_user without first logging in.

(_Not_ tagging this for configuration change, since we don't need or want any configuration change on the servers.)