### PR TITLE
Catch unusable admin sets before work creation

### DIFF
--- a/app/helpers/allinson_flex/allinson_flex_modified_helper.rb
+++ b/app/helpers/allinson_flex/allinson_flex_modified_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# override (from Hyrax 2.5.0) - new module
+module AllinsonFlex::AllinsonFlexModifiedHelper
+  # unmodified from allinson_flex
+  # borrowd from batch-importer https://github.com/samvera-labs/hyrax-batch_ingest/blob/master/app/controllers/hyrax/batch_ingest/batches_controller.rb
+  def available_admin_sets
+    # Restrict available_admin_sets to only those current user can desposit to.
+    @available_admin_sets ||= Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set').map do |admin_set_id|
+      [AdminSet.find(admin_set_id).title.first, admin_set_id]
+    end
+  end
+end
+

--- a/app/helpers/allinson_flex/allinson_flex_modified_helper.rb
+++ b/app/helpers/allinson_flex/allinson_flex_modified_helper.rb
@@ -2,13 +2,31 @@
 
 # override (from Hyrax 2.5.0) - new module
 module AllinsonFlex::AllinsonFlexModifiedHelper
-  # unmodified from allinson_flex
-  # borrowd from batch-importer https://github.com/samvera-labs/hyrax-batch_ingest/blob/master/app/controllers/hyrax/batch_ingest/batches_controller.rb
-  def available_admin_sets
-    # Restrict available_admin_sets to only those current user can desposit to.
-    @available_admin_sets ||= Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set').map do |admin_set_id|
-      [AdminSet.find(admin_set_id).title.first, admin_set_id]
-    end
+  # borrowed from batch-importer https://github.com/samvera-labs/hyrax-batch_ingest/blob/master/app/controllers/hyrax/batch_ingest/batches_controller.rb
+  def accessible_admin_sets
+    # Restrict accessible_admin_sets to only those current user can desposit to.
+    @accessible_admin_sets ||= Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set')
+    @accessible_admin_sets ||= []
   end
+
+  # an AdminSet is only usable if it has an active_workflow
+  def accessible_admin_sets_with_active_workflow
+    accessible_admin_sets.select { |admin_set_id| Hyrax::PermissionTemplate.find_by(source_id: admin_set_id)&.active_workflow.present? }
+  end
+
+  def usable_admin_sets
+    @usable_admin_sets ||= format_admin_set_ids(accessible_admin_sets_with_active_workflow)
+  end
+
+  def unusable_admin_sets
+    @unusable_admin_sets ||= format_admin_set_ids(accessible_admin_sets - accessible_admin_sets_with_active_workflow)
+  end
+
+  private
+    def format_admin_set_ids(admin_set_ids)
+      AdminSet.search_with_conditions(id: admin_set_ids).map do |solr_hit|
+        [solr_hit['title_tesim'].first, solr_hit.id]
+      end
+    end
 end
 

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -3,4 +3,5 @@ module HyraxHelper
   include Hyrax::BlacklightOverride
   include Hyrax::HyraxHelperBehavior
   include AllinsonFlex::AllinsonFlexHelper
+  include AllinsonFlex::AllinsonFlexModifiedHelper
 end

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -1,0 +1,42 @@
+<% # Override from Hyrax 2.6 - Admin set for flexible contexts %>
+<% # TODO: This should not live in views/shared.  It does not need to be included on every page. %>
+<div class="modal worktypes fade" id="worktypes-to-create" tabindex="-1" role="dialog" aria-labelledby="select-worktype-label">
+  <div class="modal-dialog" role="document">
+    <form class="modal-content new-work-select">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
+        <h2 class="modal-title">Select Admin Set</h2>
+      </div>
+      <div class="modal_body">
+        <div class="select-work-admin-set">
+          <%= select_tag :admin_set_id, options_for_select(available_admin_sets) %>
+        </div>
+      </div>
+      <div class="modal-header">
+        <h2 class="modal-title" id="select-worktype-label"><%= t('hyrax.dashboard.heading_actions.select_type_of_work') %></h2>
+      </div>
+      <div class="modal-body">
+        <% create_work_presenter.each do |row_presenter| %>
+          <div class="select-worktype">
+            <label>
+              <input type="radio" name="payload_concern" value="<%= row_presenter.concern %>"
+                                                           data-single="<%= row_presenter.switch_to_new_work_path(route_set: main_app, params: params) %>"
+                                                           data-batch="<%= row_presenter.switch_to_batch_upload_path(route_set: hyrax, params: params) %>" />
+              <div class="select-work-icon">
+                <span class="<%= row_presenter.icon_class %>"></span>
+              </div>
+              <div class="select-work-description">
+                <h3 class="work-type-title"><%= row_presenter.name %></h3>
+                <p><%= row_presenter.description %></p>
+              </div>
+            </label>
+          </div>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('hyrax.dashboard.heading_actions.close') %></button>
+        <input type="submit" class="btn btn-primary" value="<%= t('hyrax.dashboard.heading_actions.create_work') %>" />
+      </div>
+    </form>
+  </div>
+</div>

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -9,7 +9,15 @@
       </div>
       <div class="modal_body">
         <div class="select-work-admin-set">
-          <%= select_tag :admin_set_id, options_for_select(available_admin_sets) %>
+          <%= select_tag :admin_set_id, options_for_select(usable_admin_sets) %>
+          <% if unusable_admin_sets.any? %>
+            The following Admin Sets are missing a permission template or an active workflow:
+            <ul>
+              <% unusable_admin_sets.each do |title_id| %>
+                <li><%= title_id.first %> (<%= title_id.last %>)</li>
+              <% end %>
+            </u>
+          <% end %>
         </div>
       </div>
       <div class="modal-header">


### PR DESCRIPTION
An issue I sometimes have locally is that I'll try to create a work using an AdminSet that lacks an active_workflow (or a PermissionTemplate on which to hang an active_workflow), and get a Ruby error after submission.

This moves that check into the UI, before selecting an AdminSet.  It also changes the select population to use Solr instead of ActiveFedora for looking up AdminSet titles.

