### PR TITLE
[ESSI-1598] Restore hyrax based_near behavior allinson_flex overrides

### DIFF
--- a/app/models/archival_material.rb
+++ b/app/models/archival_material.rb
@@ -30,5 +30,6 @@ class ArchivalMaterial < ActiveFedora::Base
   # schema (by adding accepts_nested_attributes)
 
   include AllinsonFlex::DynamicMetadataBehavior
+  include ESSI::DynamicMetadataBehavior
   include ::Hyrax::BasicMetadata
 end

--- a/app/models/bib_record.rb
+++ b/app/models/bib_record.rb
@@ -28,5 +28,6 @@ class BibRecord < ActiveFedora::Base
   # schema (by adding accepts_nested_attributes)
 
   include AllinsonFlex::DynamicMetadataBehavior
+  include ESSI::DynamicMetadataBehavior
   include ::Hyrax::BasicMetadata
 end

--- a/app/models/concerns/essi/dynamic_metadata_behavior.rb
+++ b/app/models/concerns/essi/dynamic_metadata_behavior.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ESSI
+  module DynamicMetadataBehavior
+    extend ActiveSupport::Concern
+
+    CUSTOM_PROPERTIES = { based_near: { class_name: Hyrax::ControlledVocabularies::Location } }.freeze
+
+    class_methods do
+      def late_add_property(name, properties)
+        if CUSTOM_PROPERTIES.keys.include?(name)
+          properties = CUSTOM_PROPERTIES[name].merge(properties)
+        end
+        super(name, properties)
+      end
+    end
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -24,5 +24,6 @@ class Image < ActiveFedora::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include AllinsonFlex::DynamicMetadataBehavior
+  include ESSI::DynamicMetadataBehavior
   include ::Hyrax::BasicMetadata
 end

--- a/app/models/paged_resource.rb
+++ b/app/models/paged_resource.rb
@@ -30,5 +30,6 @@ class PagedResource < ActiveFedora::Base
   # schema (by adding accepts_nested_attributes)
 
   include AllinsonFlex::DynamicMetadataBehavior
+  include ESSI::DynamicMetadataBehavior
   include ::Hyrax::BasicMetadata
 end

--- a/app/models/scientific.rb
+++ b/app/models/scientific.rb
@@ -25,6 +25,6 @@ class Scientific < ActiveFedora::Base
   # schema (by adding accepts_nested_attributes)
 
   include AllinsonFlex::DynamicMetadataBehavior
+  include ESSI::DynamicMetadataBehavior
   include ::Hyrax::BasicMetadata
-
 end

--- a/app/services/allinson_flex/dynamic_schema_service.rb
+++ b/app/services/allinson_flex/dynamic_schema_service.rb
@@ -83,6 +83,7 @@ module AllinsonFlex
 
     # @return [Hash] property => array of indexing
     # modified for essi to exclude modifier values like admin_only
+    # modified for essi to exclude :based_near
     def indexing_properties
       indexers = {}
       properties.each_pair do |prop_name, prop_value|
@@ -94,6 +95,7 @@ module AllinsonFlex
                                 end.compact.uniq
         end
       end
+      indexers.delete(:based_near)
       indexers[:profile_version] = ['profile_version_ssi']
       indexers[:dynamic_schema_id] = ['dynamic_schema_id_ssi']
       indexers


### PR DESCRIPTION
For `based_near`:
* restores normal hyrax indexing behavior
* injects `class_name: Hyrax::ControlledVocabularies::Location` into properties for the property

Without these, configuring a `based_near` property in allinson_flex breaks indexing of a work persisting any values to the attribute, raising a ruby error