### PR TITLE
[ESSI-1595] use POST in collection descendant counts

### DIFF
--- a/app/models/concerns/essi/collection_behavior.rb
+++ b/app/models/concerns/essi/collection_behavior.rb
@@ -21,6 +21,7 @@ module ESSI
     module ClassMethods
       # POST to avoid URI Too Long error from solr, and raise row limit
       def child_objects_for(id, models: [])
+        id = Array.wrap(id)
         return [] if id.empty?
         conditions = { nesting_collection__parent_ids_ssim: id }
         models = Array.wrap(models).map(&:to_s)

--- a/app/models/concerns/essi/collection_behavior.rb
+++ b/app/models/concerns/essi/collection_behavior.rb
@@ -19,18 +19,14 @@ module ESSI
     end
 
     module ClassMethods
-      # solr queries break if you pass an id set with greater than 96 members
-      def constrain_ids(ids)
-        Array.wrap(ids)[0,96]
-      end
-      
+      # POST to avoid URI Too Long error from solr, and raise row limit
       def child_objects_for(id, models: [])
-        id = constrain_ids(id)
         return [] if id.empty?
         conditions = { nesting_collection__parent_ids_ssim: id }
         models = Array.wrap(models).map(&:to_s)
         conditions[:has_model_ssim] = models if models.any?
-        ActiveFedora::Base.search_with_conditions(conditions, rows: 100_000)
+        options = { method: :post, rows: 100_000 }
+        ActiveFedora::Base.search_with_conditions(conditions, options)
       end
     
       def child_collections_for(id)


### PR DESCRIPTION
Constraining the id argument was a kludge workaround for the rsolr query length limit, and it turns out my constraint was too generous because the query was still too long if you added any other arguments to it.  Changing to a POST call is a proper fix, which will also get us the complete and accurate count.  (There's some eventual limit we could still hit, but some light testing in console suggests we're at least an order of magnitude away from it.)