### PR TITLE
[ESSI-1566] Fix customized total_ methods that don't scale

### DIFF
--- a/lib/extensions/hyrax/collection_presenter/total_counts.rb
+++ b/lib/extensions/hyrax/collection_presenter/total_counts.rb
@@ -5,28 +5,20 @@ module Extensions
       module TotalCounts
         delegate :num_collections, :num_works, to: :solr_document
 
-        def tree_collection_ids
-          @tree_collection_ids ||= ::Collection.tree_collections_for(id).map(&:id)
-        end
-
-        def all_items
-          ::ActiveFedora::Base.where(member_of_collection_ids_ssim: tree_collection_ids)
-        end
-
         def total_items
-          all_items.count
+          num_works + num_collections
         end
     
         def total_viewable_items
-          all_items.accessible_by(current_ability).count
+          num_works + num_collections
         end
     
         def total_viewable_works
-          all_items.where(generic_type_sim: 'Work').accessible_by(current_ability).count
+          num_works
         end
     
         def total_viewable_collections
-          all_items.where(generic_type_sim: 'Collection').accessible_by(current_ability).count
+          num_collections
         end
       end
     end


### PR DESCRIPTION
Here's the issue:
[These original hyrax methods](app/presenters/hyrax/collection_presenter.rb) for counting collection members load ActiveFedora objects (instead of solr docs) because these can then run accessibility checks to get accurate user-specific counts of viewable items.

I [modified them to get accurate total counts for the collection subtree](https://github.com/IU-Libraries-Joint-Development/essi/blob/1.2.0-stable/lib/extensions/hyrax/collection_presenter/total_counts.rb), instead of immediate children.  (This was in an effort to make the displayed values consistent with the sorting results in the catalog, since that index is based on subtree counts and not just immediate children).

The issue is that the `all_items` call will error out (with rsolr query too long) if you pass enough ids in `tree_collection_ids` -- and we can't straightforwardly use the same post/rows solution we do elsewhere, because the `where` method doesn't accept them.

There are a few potential solutions:
1. revert to the original methods, which will filter by user accessibility but will only count immediate children
2. use this PR, which does not filter by user accessibility but counts the whole subtree and is more performant
3. similar to this PR, one could run live subtree counts using `search_with_conditions`, which may be more up-to-date than the saved num_works and num_collections values

My two cents on the original hyrax approach is that I'm not sure the performance hit for checking accessibility is worth the user-specific count, and I'm skeptical whether folks actually want or need a user-specific count vs the total count of what all's in the collection.  I speculatively suspect that we don't have a mix of private/public or published/unpublished items within the same collection, and may handle that by collection instead, but I haven't confirmed/denied that with POs.