### PR TITLE
Essi-1602 Specify row limit for AdminSet solr query

### DIFF
--- a/app/helpers/allinson_flex/allinson_flex_modified_helper.rb
+++ b/app/helpers/allinson_flex/allinson_flex_modified_helper.rb
@@ -24,7 +24,7 @@ module AllinsonFlex::AllinsonFlexModifiedHelper
 
   private
     def format_admin_set_ids(admin_set_ids)
-      AdminSet.search_with_conditions(id: admin_set_ids).map do |solr_hit|
+      AdminSet.search_with_conditions({ id: admin_set_ids }, rows: 1000).map do |solr_hit|
         [solr_hit['title_tesim'].first, solr_hit.id]
       end
     end


### PR DESCRIPTION
The list of adminsets in the new work dialog was using the default solr row limit of 10. This increases it to 1000. I hope we never need that many.