### PR TITLE
Essi-1604 Increase presenters' solr row limit

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -136,3 +136,5 @@ ActiveFedora::File.prepend Extensions::ActiveFedora::File::EscapingObsoletions
 # change total count methods to cover all descendants in the tree
 Hyrax::CollectionPresenter.prepend Extensions::Hyrax::CollectionPresenter::TotalCounts
 
+# Increase solr row limit
+Hyrax::PresenterFactory.prepend Extensions::Hyrax::PresenterFactory::SolrRowLimit

--- a/lib/extensions/hyrax/presenter_factory/solr_row_limit.rb
+++ b/lib/extensions/hyrax/presenter_factory/solr_row_limit.rb
@@ -1,0 +1,15 @@
+module Extensions
+  module Hyrax
+    module PresenterFactory
+      module SolrRowLimit
+        # Modified with increased row limit
+        #
+        # @return [Array<SolrDocument>] a list of solr documents in no particular order
+        def load_docs
+          query("{!terms f=id}#{ids.join(',')}", rows: 5000)
+            .map { |res| ::SolrDocument.new(res) }
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/presenter_factory_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+# Tests Extensions::Hyrax::PresenterFactory::SolrRowLimit
+# Adapted from hyrax gem's presenter_factory_spec.rb
+RSpec.describe Hyrax::PresenterFactory do
+  describe "#build_for" do
+    let(:presenter_class) { Hyrax::FileSetPresenter }
+
+    subject { described_class.build_for(ids: ['12', '13'], presenter_class: presenter_class, presenter_args: nil) }
+
+    context "when some ids are found in solr" do
+      let(:results) { [{ "id" => "12" }, { "id" => "13" }] }
+
+      it "has increased rows limit and has two results" do
+        expect(ActiveFedora::SolrService.instance.conn).to receive(:post)
+                                                             .with('select', data: { q: "{!terms f=id}12,13", rows: 5000, qt: 'standard' })
+                                                             .and_return('response' => { 'docs' => results })
+        expect(subject.size).to eq 2
+      end
+    end
+  end
+end


### PR DESCRIPTION
I noticed a paged resource with 1111 pages only rendered 1000 pages in UV. This fixes that by raising the limit hard coded in Hyrax::PresenterFactory. Tested with an adapted version of the hyrax presenter_factory_spec.rb