### PR TITLE
ESSI-1578 Adds Solr logic to collection search to find FileSets with matches in full text

### DIFF
--- a/app/search_builders/essi/tree_collection_member_search_builder.rb
+++ b/app/search_builders/essi/tree_collection_member_search_builder.rb
@@ -1,6 +1,6 @@
 module ESSI
   # This search builder requires that a accessor named "collection" exists in the scope
-  class TreeCollectionMemberSearchBuilder < ::SearchBuilder
+  class TreeCollectionMemberSearchBuilder < Hyrax::CatalogSearchBuilder
     include Hyrax::FilterByType
     attr_reader :collection, :search_includes_models
 
@@ -8,7 +8,10 @@ module ESSI
     self.collection_membership_field = 'member_of_collection_ids_ssim'
 
     # Defines which search_params_logic should be used when searching for Collection members
-    self.default_processor_chain += [:member_of_collection]
+    self.default_processor_chain += [
+      :member_of_collection,
+      :show_works_or_works_that_contain_files
+    ]
 
     # @param [scope] Typically the controller object
     # @param [Symbol] :works, :collections, (anything else retrieves both)


### PR DESCRIPTION
The previously merged PR #424 ensured recursive searching through the subcollection tree and to also make sure the same fields were being searched as those in the default global search.  But, it failed to consider that it's the FileSets that actually contain the searchable text from OCR extraction, and it only searched for works.

This PR adds to the search processing chain by calling a method in a Hyrax search builder that finds and joins matching child FileSet IDs.  To do so, it also changes which search builder to inherit from instead of the default Blacklight builder.