### PR TITLE
[ESSI-1453] Source and optionally override title in METS import

### DIFF
--- a/app/models/bulkrax/mets_xml_entry.rb
+++ b/app/models/bulkrax/mets_xml_entry.rb
@@ -82,8 +82,12 @@ module Bulkrax
       self.parsed_metadata
     end
 
+    def override_title
+      %w[true 1].include?(parser.parser_fields['override_title'].to_s)
+    end
+
     def add_title
-      self.parsed_metadata['title'] = [parser.parser_fields['title'] || record.identifier]
+      self.parsed_metadata['title'] = [parser.parser_fields['title']] if override_title || self.parsed_metadata['title'].blank?
     end
 
     def add_local_files

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -21,6 +21,14 @@ class METSDocument
                 "//mets:div[@TYPE='IsPartOf']/@CONTENTIDS").to_s
   end
 
+  def mets_id
+    @mets.xpath("/mets:mets/@ID").to_s
+  end
+
+  def label
+    @mets.xpath("/mets:mets/@LABEL").to_s
+  end
+
   def pudl_id
     @mets.xpath("/mets:mets/mets:metsHdr/mets:metsDocumentID")
          .first.content.gsub(/\.mets/, '')

--- a/app/views/bulkrax/importers/_mets_xml_fields.html.erb
+++ b/app/views/bulkrax/importers/_mets_xml_fields.html.erb
@@ -18,8 +18,11 @@
 
   <%= fi.input :title, 
     hint: 'Provide a title for this work',
-    input_html: { value: importer.parser_fields['title'] }
-    %>
+    input_html: { value: importer.parser_fields['title'] },
+    required: false
+  %>
+
+  <%= fi.input :override_title, as: :boolean, hint: 'If checked, always use the selected title. If unchecked, use title the record and only use the provided value if the record title is blank.', input_html: { checked: (importer.parser_fields['override_title'] == "1") } %>
 
   <%= fi.input :import_type, 
 		collection: [

--- a/lib/iu_metadata/mets_record.rb
+++ b/lib/iu_metadata/mets_record.rb
@@ -13,6 +13,7 @@ module IuMetadata
       identifier
       source_metadata_identifier
       viewing_direction
+      title
     ].freeze
 
     def attributes
@@ -25,6 +26,10 @@ module IuMetadata
 
     def source_metadata_identifier
       bib_id
+    end
+
+    def title
+      Array.wrap([label, mets_id].select(&:present?).first)
     end
 
     # no default metadata

--- a/spec/iu_metadata/mets_record_spec.rb
+++ b/spec/iu_metadata/mets_record_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe IuMetadata::METSRecord do
     {
       "source_metadata_identifier" => 'bhr9405',
       "identifier" => 'ark:/88435/7d278t10z',
-      "viewing_direction" => 'left-to-right'
+      "viewing_direction" => 'left-to-right',
+      "title" => []
     }
 
   describe "#attributes" do


### PR DESCRIPTION
* adds `label`, `id` methods to `MetsDocument`
* adds `title` method to `MetsRecord`
* adds `override_title` option to `MetsXmlEntry`, corresponding form