### PR TITLE
Essi-1610 Eliminate fedora request during manifest generation

### DIFF
--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -12,7 +12,7 @@ module Hyrax
     #
     # @return [IIIFManifest::DisplayImage] the display image required by the manifest builder.
     def display_image
-      return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
+      return nil unless solr_document.image? && current_ability.can?(:read, id)
 
       latest_file_id = lookup_original_file_id
 


### PR DESCRIPTION
Generation of manifests is significantly slowed down by making a fedora request for every fileset. Removing this check might allow a manifest to include a missing image if the fileset has disappeared from fedora for some reason, but otherwise should not have any detrimental effect.

Increased visibility of such a problem might even be benefical?