### PR TITLE
Essi-1611 Adjust size of UV thumbnails to match file manager thumbnails

### DIFF
--- a/config/uv/uv_config.json
+++ b/config/uv/uv_config.json
@@ -5,6 +5,10 @@
   "modules": {
     "contentLeftPanel": {
       "options": {
+        "galleryThumbHeight": 400,
+        "galleryThumbWidth": 250,
+        "oneColThumbHeight": 400,
+        "oneColThumbWidth": 250,
         "defaultToTreeEnabled": true,
         "thumbsCacheInvalidation": {
           "enabled": false


### PR DESCRIPTION
This should increase the IIIF server's cache hit rate.