### PR TITLE
[ESSI-1482] Add action to (re)generate extracted_text OCR

### DIFF
--- a/app/jobs/create_ocr_job.rb
+++ b/app/jobs/create_ocr_job.rb
@@ -1,0 +1,18 @@
+class CreateOCRJob < CreateDerivativesJob
+  queue_as Hyrax.config.ingest_queue_name
+
+  # @param [FileSet] file_set
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
+  def perform(file_set, file_id, filepath = nil)
+    return if file_set.video? && !Hyrax.config.enable_ffmpeg
+    filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
+
+    file_set.send(:file_set_derivatives_service).send(:create_ocr_derivatives, filename)
+
+    # Reload from Fedora and reindex for thumbnail and extracted text
+    file_set.reload
+    file_set.update_index
+    file_set.parent.update_index if parent_needs_reindex?(file_set)
+  end
+end

--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -12,14 +12,16 @@
   <% else %>
     <dd>not available</dd>
   <% end %>
-  <%# FIXME: get better path %>
-  <dd>
-    <%= link_to 'Regenerate OCR',
-                file_set_fixity_checks_path(@presenter).sub('fixity_checks', 'regenerate_ocr'),
-                method: :post,
-                class: 'btn btn-danger',
-                data: { confirm: 'Are you sure you want to regenerate this OCR?' } %>
-  </dd>
+  <% if current_ability&.can?(:regenerate_ocr, FileSet) %>
+    <dd>
+      <%# FIXME: get better path %>
+      <%= link_to 'Regenerate OCR',
+                  file_set_fixity_checks_path(@presenter).sub('fixity_checks', 'regenerate_ocr'),
+                  method: :post,
+                  class: 'btn btn-danger',
+                  data: { confirm: 'Are you sure you want to regenerate this OCR?' } %>
+    </dd>
+  <% end %>
   <dt>Fixity Check</dt>
   <dd><%= @presenter.fixity_check_status %></dd>
   <dt>Characterization</dt>

--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -12,6 +12,14 @@
   <% else %>
     <dd>not available</dd>
   <% end %>
+  <%# FIXME: get better path %>
+  <dd>
+    <%= link_to 'Regenerate OCR',
+                file_set_fixity_checks_path(@presenter).sub('fixity_checks', 'regenerate_ocr'),
+                method: :post,
+                class: 'btn btn-danger',
+                data: { confirm: 'Are you sure you want to regenerate this OCR?' } %>
+  </dd>
   <dt>Fixity Check</dt>
   <dd><%= @presenter.fixity_check_status %></dd>
   <dt>Characterization</dt>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,11 @@ Rails.application.routes.draw do
         get '/pdf', action: :pdf, as: :pdf
       end
     end
+    resources :file_sets, only: [] do
+      member do
+        post :regenerate_ocr, action: :regenerate_ocr
+      end
+    end
   end
 
   concern :exportable, Blacklight::Routes::Exportable.new

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -16,6 +16,7 @@ end
 # extracted text support
 Hyrax::DownloadsController.prepend Extensions::Hyrax::DownloadsController::ExtractedText
 Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ExtractedText
+Hyrax::FileSetsController.include Extensions::Hyrax::FileSetsController::RegenerateOCR
 
 # viewing hint support
 IIIFManifest::ManifestBuilder::ImageBuilder.include Extensions::IIIFManifest::ManifestBuilder::ImageBuilder::ViewingHint

--- a/lib/extensions/hyrax/file_sets_controller/regenerate_ocr.rb
+++ b/lib/extensions/hyrax/file_sets_controller/regenerate_ocr.rb
@@ -1,0 +1,19 @@
+module Extensions
+  module Hyrax
+    module FileSetsController
+      module RegenerateOCR
+      
+        def regenerate_ocr
+          file_set = FileSet.find(presenter.id)
+          file_id = file_set&.original_file&.id
+          if file_set.present? && file_id.present?
+            CreateOCRJob.perform_later(file_set, file_id)
+            redirect_to [main_app, presenter], notice: 'Regenerating OCR'
+          else
+            redirect_to [main_app, presenter], alert: 'Unable to regenrate OCR due to misssing original file'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* adds a new job to call `create_ocr_derivatives` instead of `create_derivatives` on the FileSet
  * currently, all `create_derivatives` does is call `create_ocr_derivatives`, but relying on that seemed brittle
* adds a new `regenerate_ocr` controller action to call the job
* adds a link to the action
  * for some reason the path helper method doesn't exist, so I kludged around it :/