### PR TITLE
[ESSI-1545] Fix bulkrax import post-unzip file selection

### DIFF
--- a/app/parsers/bulkrax/mets_xml_parser.rb
+++ b/app/parsers/bulkrax/mets_xml_parser.rb
@@ -70,7 +70,10 @@ module Bulkrax
         if file? && MIME::Types.type_for(import_file_path).include?('application/xml')
           [import_file_path]
         else
-          file_paths.select { |f| MIME::Types.type_for(f).include?('application/xml') }
+          file_paths.select do |f|
+            MIME::Types.type_for(f).include?('application/xml') &&
+              f.include?("import_#{importerexporter.id}")
+          end
         end
     end
 


### PR DESCRIPTION
Prior file selection logic was grabbing _every_ previously-imported XML file along with the current one.
This fixes that by copying the correct logic over from the current bulkrax `XmlParser`.