### PR TITLE
ESSI 1578 Passes query terms to UV from collection search context

### DIFF
--- a/app/controllers/concerns/essi/ocr_search.rb
+++ b/app/controllers/concerns/essi/ocr_search.rb
@@ -7,13 +7,8 @@ module ESSI
     end
 
     def set_catalog_search_term_for_uv_search
-      return unless request&.referer&.present? && request&.referer&.include?('catalog')
-      url_args = request&.referer&.split('&')
-      search_term = []
-      url_args&.each do |arg|
-        next unless arg.match?('q=')
-        search_term << CGI::parse(arg)['q']
-      end
+      return unless params[:query].present?
+      search_term = CGI::parse(params[:query])
       params[:highlight] = search_term&.flatten&.first
     end
   end

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -1,0 +1,25 @@
+<% id = document.id %>
+<tr id="document_<%= id %>">
+  <td>&nbsp;
+    <% if current_user and document.depositor != current_user.user_key %>
+      <i class="glyphicon glyphicon-share-alt" />
+    <% end %>
+  </td>
+  <td>
+    <div class="media">
+      <%= link_to [main_app, document], class: "media-left" do %>
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+      <% end %>
+      <div class="media-body">
+        <p class="media-heading">
+          <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
+        </p>
+        <%= render_collection_links(document) %>
+      </div>
+    </div>
+  </td>
+  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center">
+    <%= render_visibility_link(document) %>
+  </td>
+</tr>

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -7,12 +7,14 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], class: "media-left" do %>
+      <% link_destination = [main_app, document] %>
+      <% link_destination << { query: params['cq'] } if params['cq'].present? %>
+      <%= link_to link_destination, class: "media-left" do %>
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
         <p class="media-heading">
-          <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
+        <strong><%= link_to document.title_or_label, link_destination, id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
         </p>
         <%= render_collection_links(document) %>
       </div>


### PR DESCRIPTION
When searching in collections for matching works, the query term isn't passed in to the detail view to activate the Universal Viewer search.  This overrides the appropriate views to add the query term to the request parameters and changes the method in OCRSearch that sets the highlight parameter so that it comes from the item request params instead of reaching back to the referrer (i.e. the original catalog search URL.) 