### PR TITLE
[ESSI-1617] add more properties to bulkrax mets ingest

### DIFF
--- a/lib/iu_metadata/mets_record.rb
+++ b/lib/iu_metadata/mets_record.rb
@@ -11,9 +11,11 @@ module IuMetadata
     # local metadata
     ATTRIBUTES = %w[
       identifier
+      related_url
+      series
       source_metadata_identifier
-      viewing_direction
       title
+      viewing_direction
     ].freeze
 
     def attributes
@@ -21,11 +23,13 @@ module IuMetadata
     end
 
     def identifier
-      ark_id
+      obj_id
     end
+    # deprecation planned for purl
+    alias_method :purl, :identifier
 
     def source_metadata_identifier
-      bib_id
+      mets_id
     end
 
     def title

--- a/lib/iu_metadata/mets_record.rb
+++ b/lib/iu_metadata/mets_record.rb
@@ -11,6 +11,7 @@ module IuMetadata
     # local metadata
     ATTRIBUTES = %w[
       identifier
+      purl
       related_url
       series
       source_metadata_identifier

--- a/spec/fixtures/iu_metadata/pudl0001-4609321-s42.mets
+++ b/spec/fixtures/iu_metadata/pudl0001-4609321-s42.mets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/7d278t10z" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="BHR9405" OBJID="ark:/88435/7d278t10z" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
   <mets:metsHdr CREATEDATE="2016-03-14T15:21:33.372-04:00" LASTMODDATE="2016-03-14T15:21:33.372-04:00">
     <mets:metsDocumentID TYPE="PUDL">pudl0001/4609321/s42.mets</mets:metsDocumentID>
   </mets:metsHdr>

--- a/spec/iu_metadata/mets_record_spec.rb
+++ b/spec/iu_metadata/mets_record_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe IuMetadata::METSRecord do
   record1_attributes =
     {
       "identifier" => 'ark:/88435/7d278t10z',
+      "purl" => 'ark:/88435/7d278t10z',
       "related_url" => [],
       "series" => [],
       "source_metadata_identifier" => 'BHR9405',

--- a/spec/iu_metadata/mets_record_spec.rb
+++ b/spec/iu_metadata/mets_record_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe IuMetadata::METSRecord do
 
   record1_attributes =
     {
-      "source_metadata_identifier" => 'bhr9405',
       "identifier" => 'ark:/88435/7d278t10z',
+      "related_url" => [],
+      "series" => [],
+      "source_metadata_identifier" => 'BHR9405',
+      "title" => ['BHR9405'],
       "viewing_direction" => 'left-to-right',
-      "title" => []
     }
 
   describe "#attributes" do

--- a/spec/models/bulkrax/mets_xml_entry_spec.rb
+++ b/spec/models/bulkrax/mets_xml_entry_spec.rb
@@ -72,7 +72,7 @@ module Bulkrax
           expect(xml_entry.parsed_metadata).to include('admin_set_id' => 'MyString',
                                                        'rights_statement' => [nil],
                                                        'source' => ["http://purl.dlib.indiana.edu/iudl/archives/VAC1741-00310"],
-                                                       'title' => ["http://purl.dlib.indiana.edu/iudl/archives/VAC1741-00310"],
+                                                       'title' => ["VAC1741-00310"],
                                                        #'viewing_direction' => 'left-to-right',
                                                        'visibility' => 'open',
                                                        'work_type' => ['PagedResource'])


### PR DESCRIPTION
Handling the XPATH for `series`, which incorporates a couple of additional namespaces, revealed a couple of things worth noting about handling of namespaces in `nokogiri`:
* by default, nokogiri only acknowledges namespaces declared in the root node
  * however, you can aggregate namespaces declared elsewhere with the `collect_namespaces` method
  * additional namespaces definitions can be passed in as a second, Hash, argument to the `xpath` method on an XML node
  
  Not sure how we missed the title match failing back in ESSI-1453, but resolved it here.