### PR TITLE
Essi-1636 Control rack_mini_profiler gem activation from config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,8 +107,8 @@ gem 'webpacker'
 gem 'react-rails'
 
 # Profiling
-gem 'rack-mini-profiler'
-gem 'stackprof'
+gem 'rack-mini-profiler', require: ['prepend_net_http_patch']
+gem 'stackprof', require: false
 
 # hold back hydra-head due to implicit Blacklight 7 requirement in newer versions
 gem 'hydra-head', '10.6.1'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action do
-    if current_user && current_user.admin?
+    if defined?(Rack::MiniProfiler) && current_user && current_user.admin?
       Rack::MiniProfiler.authorize_request
     end
   end

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -78,6 +78,8 @@ default: &default
   airbrake:
     project_id:
     project_key:
+  rack_profiler:
+    enabled: true
   ldap:
     enabled: false
     host: ads.iu.edu

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -77,6 +77,8 @@ default: &default
   airbrake:
     project_id:
     project_key:
+  rack_profiler:
+    enabled: true
   ldap:
     enabled: false
     host: ads.iu.edu

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+if ESSI.config.dig(:rack_profiler, :enabled)
+  require 'stackprof'
+  require 'rack-mini-profiler'
+
+  # initialization is skipped so trigger it
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+end


### PR DESCRIPTION
Adds a configuration option to control activation of rack_mini_profiler. It is disabled when the config is omitted, but should be enabled on the devel (and possibly staging?) servers.