### PR TITLE
[ESSI-1616] "description" display configurable via allinson_flex

### DIFF
--- a/app/views/records/edit_fields/_description.html.erb
+++ b/app/views/records/edit_fields/_description.html.erb
@@ -1,6 +1,14 @@
-<%# imported from hyrax to override %>
+<%# modified from hyrax as modified copy of "default" partial %>
 <% if f.object.multiple? key %>
-  <%= f.input :description, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+  <%= f.input key, as: :multi_value,
+      label: dynamic_label(key),
+      input_html: { rows: '14', type: 'textarea'},
+      required: f.object.required?(key),
+      hint: dynamic_hint(key) %>
 <% else %>
-  <%= f.input :description, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+  <%= f.input key, as: :text,
+      label: dynamic_label(key),
+      input_html: { rows: '14', type: 'textarea'},
+      required: f.object.required?(key),
+      hint: dynamic_hint(key) %>
 <% end %>

--- a/app/views/records/edit_fields/_description.html.erb
+++ b/app/views/records/edit_fields/_description.html.erb
@@ -1,0 +1,6 @@
+<%# imported from hyrax to override %>
+<% if f.object.multiple? key %>
+  <%= f.input :description, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :description, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+<% end %>


### PR DESCRIPTION
Property-specific view partials are used when available, instead of the default partial (which accounts for allinson_flex dynamic label and hint values).  Hyrax provides partials for some basic/core metadata, including "description", which prevents allinsonflex configuration for label, hint values taking effect.  The applied fix is to override the property-specific partial with a copy of the default partial.

The current list of hyrax-provided edit partials is available here:
https://github.com/samvera/hyrax/tree/v2.9.6/app/views/records/edit_fields
and the up-to-date list for the newest version of hyrax is always available here:
https://github.com/samvera/hyrax/tree/main/app/views/records/edit_fields

To review this change, you will need to have a "description" property configured via your local allinson_flex profile.