### PR TITLE
[ESSI-1556] Block blacklight bookmark actions that create persistent guest accounts

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,12 @@ Rails.application.routes.draw do
 
   mount Riiif::Engine => 'iiif/2', as: :riiif if Hyrax.config.iiif_image_server?
 
+  # block Blacklight bookmark routes
+  get '/bookmarks', to: 'application#rescue_404'
+  post '/bookmarks', to: 'application#rescue_404'
+  get '/bookmarks/*all', to: 'application#rescue_404'
+  post '/bookmarks/*all', to: 'application#rescue_404'
+
   mount Blacklight::Engine => '/'
   mount Hydra::RoleManagement::Engine => '/'
 


### PR DESCRIPTION
When called by an unathenticated user, bookmarks actions create one-off guest accounts in the database, that then stick around forever.  This change blocks those routes.