### PR TITLE
Increasing the scope of matching IDs in PURL resolver to work with legacy schemes

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -25,7 +25,7 @@ class PurlController < ApplicationController
 
   private
     FILESET_LOOKUPS = { FileSet => nil }.freeze
-    DEFAULT_WORK_PATTERN = /^[a-zA-Z\/]{0,}\w{3}\d{4}$/.freeze
+    DEFAULT_WORK_PATTERN = /^[a-zA-Z\/]{0,}\w{2,}\d{3,}$/.freeze
     DEFAULT_WORK_LOOKUPS = Hyrax.config.registered_curation_concern_types.sort.map do |klass|
       [klass.constantize, DEFAULT_WORK_PATTERN.dup]
     end.to_h.freeze

--- a/spec/controllers/purl_controller_spec.rb
+++ b/spec/controllers/purl_controller_spec.rb
@@ -10,6 +10,13 @@ describe PurlController do
                        source_metadata_identifier: 'BHR9405')
   }
   let(:paged_resource_path) { Rails.application.routes.url_helpers.hyrax_paged_resource_path(paged_resource) }
+  let(:legacy_paged_resource) {
+    FactoryBot.create(:paged_resource,
+                      user: user,
+                      purl: ['http://purl.dlib.indiana.edu/iudl/archives/cushman/P04259'],
+                      source_metadata_identifier: 'P04259')
+  }
+  let(:legacy_paged_resource_path) { Rails.application.routes.url_helpers.hyrax_paged_resource_path(legacy_paged_resource) }
   let(:file_set) {
     FactoryBot.create(:file_set,
                        user: user,
@@ -24,6 +31,7 @@ describe PurlController do
     before do
       sign_in user
       paged_resource
+      legacy_paged_resource
     end
     context 'with a matching id' do
       shared_examples 'responses for matches' do
@@ -63,6 +71,20 @@ describe PurlController do
 
         context 'matching a full PURL by purl' do
           let(:id) { 'iudl/variations/score/BHR9405' }
+          include_examples 'responses for matches'
+        end
+      end
+      context 'when for a legacy PagedResource' do
+        let(:target_path) { legacy_paged_resource_path }
+        let(:manifest_path) { legacy_paged_resource_path + '/manifest' }
+
+        context 'matching by source_metadata_identifier' do
+          let(:id) { legacy_paged_resource.source_metadata_identifier }
+          include_examples 'responses for matches'
+        end
+
+        context 'matching a full PURL by purl' do
+          let(:id) { 'iudl/archives/cushman/P04259' }
           include_examples 'responses for matches'
         end
       end


### PR DESCRIPTION
The default regex in the PURL resolver is tailored to match typical VA# schemes and is too opinionated in the breakdown of expected characters, so it fails to match older P# conventions like Cushman.  This increases the scope with a more inclusive regex, but it still expects a reasonable number of both prefix and serial digits.

