### PR TITLE
Essi-1657 Update to Rails 5.2.8.1 and remove debase, ruby-debug-ide gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.2.4'
+gem 'rails', '~> 5.2.8'
 # Use sqlite3 as the database for Active Record
 group :development, :test do
   gem 'sqlite3'
@@ -65,9 +65,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'better_errors'
   gem 'binding_of_caller'
-
-  gem 'debase'
-  gem 'ruby-debug-ide'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       rubocop-performance
       rubocop-rails
       rubocop-rspec
-    blacklight (6.24.0)
+    blacklight (6.25.0)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,25 +20,25 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (5.2.8)
-      actionpack (= 5.2.8)
+    actioncable (5.2.8.1)
+      actionpack (= 5.2.8.1)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailer (5.2.8)
-      actionpack (= 5.2.8)
-      actionview (= 5.2.8)
-      activejob (= 5.2.8)
+    actionmailer (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (5.2.8)
-      actionview (= 5.2.8)
-      activesupport (= 5.2.8)
+    actionpack (5.2.8.1)
+      actionview (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.8)
-      activesupport (= 5.2.8)
+    actionview (5.2.8.1)
+      activesupport (= 5.2.8.1)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
@@ -62,26 +62,26 @@ GEM
     active_encode (0.8.2)
       rails
       sprockets (< 4)
-    activejob (5.2.8)
-      activesupport (= 5.2.8)
+    activejob (5.2.8.1)
+      activesupport (= 5.2.8.1)
       globalid (>= 0.3.6)
-    activemodel (5.2.8)
-      activesupport (= 5.2.8)
+    activemodel (5.2.8.1)
+      activesupport (= 5.2.8.1)
     activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
       activesupport (> 5.x)
       builder (~> 3.1)
-    activerecord (5.2.8)
-      activemodel (= 5.2.8)
-      activesupport (= 5.2.8)
+    activerecord (5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
       arel (>= 9.0)
     activerecord-import (1.4.0)
       activerecord (>= 4.2)
-    activestorage (5.2.8)
-      actionpack (= 5.2.8)
-      activerecord (= 5.2.8)
+    activestorage (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      activerecord (= 5.2.8.1)
       marcel (~> 1.0.0)
-    activesupport (5.2.8)
+    activesupport (5.2.8.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -243,9 +243,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    debase (0.2.4.1)
-      debase-ruby_core_source (>= 0.10.2)
-    debase-ruby_core_source (0.10.16)
     debug_inspector (1.1.0)
     declarative (0.0.20)
     deprecation (1.1.0)
@@ -741,18 +738,18 @@ GEM
       rack
     rack-test (2.0.2)
       rack (>= 1.3)
-    rails (5.2.8)
-      actioncable (= 5.2.8)
-      actionmailer (= 5.2.8)
-      actionpack (= 5.2.8)
-      actionview (= 5.2.8)
-      activejob (= 5.2.8)
-      activemodel (= 5.2.8)
-      activerecord (= 5.2.8)
-      activestorage (= 5.2.8)
-      activesupport (= 5.2.8)
+    rails (5.2.8.1)
+      actioncable (= 5.2.8.1)
+      actionmailer (= 5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activerecord (= 5.2.8.1)
+      activestorage (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
       bundler (>= 1.3.0)
-      railties (= 5.2.8)
+      railties (= 5.2.8.1)
       sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
@@ -765,9 +762,9 @@ GEM
       loofah (~> 2.3)
     rails_autolink (1.1.6)
       rails (> 3.1)
-    railties (5.2.8)
-      actionpack (= 5.2.8)
-      activesupport (= 5.2.8)
+    railties (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
@@ -909,8 +906,6 @@ GEM
       json
       multipart-post
       oauth2
-    ruby-debug-ide (0.7.3)
-      rake (>= 0.8.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     ruby_dep (1.5.0)
@@ -1087,7 +1082,6 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   country_select (~> 4.0)
   database_cleaner
-  debase
   devise
   devise-guests (~> 0.6)
   devise-i18n
@@ -1111,14 +1105,13 @@ DEPENDENCIES
   prawn
   puma
   rack-mini-profiler
-  rails (~> 5.2.4)
+  rails (~> 5.2.8)
   rails-controller-testing
   react-rails
   riiif (~> 2.0)
   rsolr
   rspec-rails
   rspec_junit_formatter
-  ruby-debug-ide
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module ESSI
 
     # avoid deprecation warning for ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer
     config.active_record.sqlite3.represent_boolean_as_integer = true
+    config.active_record.yaml_column_permitted_classes = [Symbol, Hash, Array, ActiveSupport::HashWithIndifferentAccess]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
Addresses CVE-2022-32224
Removes some debugging gems from the Gemfile that Rubymine installs custom versions of.