### PR TITLE
[ESSI-1614] catch errors rendering #new with a new AllinsonFlex profile

### DIFF
--- a/app/controllers/concerns/essi/works_controller_behavior.rb
+++ b/app/controllers/concerns/essi/works_controller_behavior.rb
@@ -38,6 +38,15 @@ module ESSI
         ::IIIFManifest::ManifestFactory.new(presenter).to_h.to_json
       end
     end
+
+    # Overrides stock Hyrax method to catch AllinsonFlex errors during build_form
+    def new
+      begin 
+        super
+      rescue ::AllinsonFlex::NoAllinsonFlexContextError, ::AllinsonFlex::NoAllinsonFlexSchemaError => e
+        redirect_to my_works_path, alert: 'Error retrieving AllinsonFlex properties.  A new profile version may still be saving.'
+      end
+    end
   
     private
       def after_create_response

--- a/app/services/allinson_flex/dynamic_schema_service.rb
+++ b/app/services/allinson_flex/dynamic_schema_service.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/hash/keys'
 module AllinsonFlex
   # @todo move custom error classes to a single location
   class NoAllinsonFlexContextError < StandardError; end
+  class NoAllinsonFlexSchemaError < StandardError; end
 
   class DynamicSchemaService
     attr_accessor :dynamic_schema, :context, :context_id, :model
@@ -154,6 +155,11 @@ module AllinsonFlex
                             else
                               AllinsonFlex::DynamicSchema.find_by(context_id: context_id, allinson_flex_class: work_class_name.to_s)
                             end
+        if @dynamic_schema.nil?
+          raise AllinsonFlex::NoAllinsonFlexSchemaError.new(
+            "No Metadata Schema for ID #{dynamic_schema_id}, context #{context_id}, class #{work_class_name.to_s}"
+          )
+        end
       end
 
       def properties

--- a/lib/extensions/allinson_flex/prepend_work_dynamic_schema.rb
+++ b/lib/extensions/allinson_flex/prepend_work_dynamic_schema.rb
@@ -26,7 +26,11 @@ module Extensions
         @ldp_source = build_ldp_resource(id)
         raise IllegalOperation, "Attempting to recreate existing ldp_source: `#{ldp_source.subject}'" unless ldp_source.new?
         self.dynamic_schema_id = attributes&.delete(:dynamic_schema_id)
-        load_allinson_flex ## This is the new part
+        begin
+          load_allinson_flex ## This is the new part
+        rescue ::AllinsonFlex::NoAllinsonFlexContextError, ::AllinsonFlex::NoAllinsonFlexSchemaError => e
+          Rails.logger.error(e.inspect)
+        end
         assign_attributes(attributes) if attributes
         assert_content_model
         load_attached_files


### PR DESCRIPTION
There's a time window after a new AllinsonFlex profile has been saved where trying to render #new for a work generates a Ruby error.  This occurs when #load_allinson_flex in DynamicMetadataBehavior assumes dynamic_schema has returned a non-nil value, when that's the condition we're hitting.

The fix applied here:
* Adds a NoAllinsonFlexSchemaError case to parallel the NoAllinsonFlexContextError case
* in work models, catches and logs the errors
* in work controllers, catches and redirects the errors 