### PR TITLE
[ESSI-1646] improve flexible metadata reliability in bulkrax import

### DIFF
--- a/app/models/bulkrax/mets_xml_entry.rb
+++ b/app/models/bulkrax/mets_xml_entry.rb
@@ -60,13 +60,18 @@ module Bulkrax
       @files ||= record.files
     end
 
+    def add_work_type
+      self.parsed_metadata ||= {}
+      self.parsed_metadata['work_type'] = [parser.parser_fields['work_type'] || 'PagedResource']
+    end
+
     def build_metadata
       raise StandardError, 'Record not found' if record.nil?
       raise StandardError, 'Missing source identifier' if source_identifier.blank?
       self.parsed_metadata = {}
       self.parsed_metadata['admin_set_id'] = self.importerexporter.admin_set_id
       self.parsed_metadata[self.class.source_identifier_export] = [source_identifier]
-      self.parsed_metadata['work_type'] = [parser.parser_fields['work_type'] || 'PagedResource']
+      add_work_type
       record.attributes.each do |k,v|
         add_metadata(k, v) unless v.blank?
       end

--- a/lib/extensions/bulkrax/csv_entry/add_work_type.rb
+++ b/lib/extensions/bulkrax/csv_entry/add_work_type.rb
@@ -1,0 +1,21 @@
+# new method to ensure work type is set, to ensure allinson_flex properties are loaded
+module Extensions
+  module Bulkrax
+    module CsvEntry
+      module AddWorkType
+        # modified from build_metadata method
+        def add_work_type
+          raise StandardError, 'Record not found' if record.nil?
+          self.parsed_metadata ||= {}
+          record.each do |key, value|
+            next unless key == 'model'
+    
+            index = key[/\d+/].to_i - 1 if key[/\d+/].to_i != 0
+            add_metadata(key_without_numbers(key), value, index)
+          end
+          self.parsed_metadata
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/bulkrax/entry/allinson_flex_fields.rb
+++ b/lib/extensions/bulkrax/entry/allinson_flex_fields.rb
@@ -3,7 +3,8 @@ module Extensions
     module Entry
       module AllinsonFlexFields
         def build_for_importer
-          # Ensure loading of all flexible metadata properties
+          # Ensure loading of all flexible metadata properties for the imported work type
+          try(:add_work_type)
           factory_class&.new
           super
         end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -62,6 +62,7 @@ Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::CreateAttribu
 Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::RemoveUpdateFilesets
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::AllinsonFlexFields
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::SingularizeRightsStatement
+Bulkrax::CsvEntry.prepend Extensions::Bulkrax::CsvEntry::AddWorkType
 Bulkrax::CsvEntry.prepend Extensions::Bulkrax::Entry::DynamicSchemaField
 Bulkrax::MetsXmlEntry.prepend Extensions::Bulkrax::Entry::DynamicSchemaField
 Bulkrax::CsvEntry.prepend Extensions::Bulkrax::Entry::OptionalRoundTrippableSave


### PR DESCRIPTION
Awhile back, #279 attempted to address the issue of bulkrax import not having loaded flexible metadata properties, but ESSI-1646 captures the finding that this fix only works _sometimes_.  This should be a more robust fix.

There's a little bit of a chicken-and-egg problem here:
* we need to know the imported work's class, in order to call `factory_class.new` and load the most recent allinsonflex profile
  * the imported work's class is stored in `parsed_metadata` during `build_metadata`
    * `build_metadata` filters which properties are stored in `parsed_metadata` based on what it believes the work class can receive...
      * ...which is determined by calling `factory_class`

So, we need to call `factory_class` first in order to get`build_metadata` to build all the flexible metadata, but we need to call at least _some_ of `build_metadata` first to ensure that we get the desired `factory_class` (and not just defaulting to `PagedResource`).

The approach applied here is to call a new method, `add_work_type`, which serves as a sort of stripped-down version of `build_metadata`, before calling `factory_class`.
