### PR TITLE
Essi 1488 purl 404

### DIFF
--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -103,7 +103,7 @@ default: &default
     store_files_as_jp2: true
     kdu_compress_path: 'opj_compress' # set as kdu_compress or opj_compress, or '' to use ImageMagick
     master_file_service_url: http://purl.dlib.indiana.edu/iudl/variations/master
-    purl_redirect_url: http://server1.variations2.indiana.edu/cgi-bin/access?%s
+    purl_redirect_url: /concern/works/%s
     skip_derivatives: false
     derivatives_folder: false
     ocr_language: [eng]

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -102,7 +102,7 @@ default: &default
     store_files_as_jp2: true
     kdu_compress_path: '' # set as kdu_compress or opj_compress, or '' to use ImageMagick
     master_file_service_url: http://purl.dlib.indiana.edu/iudl/variations/master
-    purl_redirect_url: http://server1.variations2.indiana.edu/cgi-bin/access?%s
+    purl_redirect_url: /concern/works/%s
     skip_derivatives: false
     derivatives_folder: false
     ocr_language: [eng]

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
+  <title>The page you were looking for was not found (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -15,41 +15,30 @@
   .rails-default-error-page div.dialog {
     width: 95%;
     max-width: 33em;
-    margin: 4em auto 0;
+    margin: 8em auto 0;
   }
 
   .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
+    border: 1px solid white;
     background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    padding: 12%;
   }
 
   .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
+    font-size: 60px;
+    color: #492d2f;
+    margin: 0;
+  }
+
+  .rails-default-error-page h2 {
+    color: #796e6f;
     line-height: 1.5em;
+    padding: 0 .5em 0 .5em;
   }
 
   .rails-default-error-page div.dialog > p {
     margin: 0 0 1em;
     padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
   </style>
 </head>
@@ -58,10 +47,10 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>404</h1>
+      <h2>The item or page you were looking for can't be found.</h2>
+      <p></p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
The current default behavior of the PURL resolver when it fails to find a match is to redirect out to the old Variations access CGI.  This behavior came from Pages Online, which was predominantly musical scores.  What we want now is to redirect to the global 404 response within the application.  

We already had the ability to configure the rescue URL in the application configuration YAML, so this just changes the default to be a generic works endpoint that should always force the 404 response, like:

https://localhost:3000/concern/works/missingWorkID


Note the "configuration change" label as a reminder to set the value on deployed instances.  This path can be taken from the example config (`/concern/works/%s`), but could be anything that will be handled internally as a 404, like:

/404
/404.html
/404/%s (appends given ID)
etc.

This also restyles the `public/404.html` page to look like a modern 404 response instead of what looks like a generic site error. The style was approved by PO's:

![DC_404-screenshot-2](https://user-images.githubusercontent.com/6411186/182882917-7ba4a9f6-47fb-46e8-8e24-9b2e2e08c47a.png)
