### PR TITLE
[ESSI-1645] import collection field (via bulkrax METS import)

### DIFF
--- a/app/models/bulkrax/mets_xml_entry.rb
+++ b/app/models/bulkrax/mets_xml_entry.rb
@@ -108,6 +108,16 @@ module Bulkrax
     def add_logical_structure
       self.parsed_metadata['structure'] = record.structure 
     end
+
+    # the form only allows selecting an existing collection
+    def find_or_create_collection_ids
+      if parser.parser_fields['collection_id'].present?
+        self.collection_ids = Array.wrap(parser.parser_fields['collection_id'])
+      else
+        self.collection_ids = []
+      end
+      self.collection_ids
+    end
   end
 end
 

--- a/app/presenters/hyrax/select_collection_list_presenter.rb
+++ b/app/presenters/hyrax/select_collection_list_presenter.rb
@@ -1,0 +1,53 @@
+module Hyrax
+  # Presents the list of collection options available to a user
+  class SelectCollectionListPresenter
+    # @param current_ability [Ability]
+    def initialize(current_ability)
+      @current_ability = current_ability
+    end
+
+    class_attribute :row_presenter
+    self.row_presenter = CollectionPresenter
+
+    # @return [Boolean] are there many different collections to choose?
+    def many?
+      authorized_collections.size > 1
+    end
+
+    # @return [Boolean] are there any authorized collections?
+    def any?
+      return true if authorized_collections.present?
+      false
+    end
+
+    # Return an array of authorized collections
+
+    def authorized_collections
+      @authorized_collections ||= Collection.search_with_conditions(id: authorized_collection_ids).map { |collection| ::SolrDocument.new(collection) }
+    end
+
+    def authorized_collection_ids
+      @authorized_collection_ids ||= Hyrax::Collections::PermissionsService.collection_ids_for_deposit(ability: @current_ability)
+    end
+
+    # Return or yield the first type in the list. This is used when the list
+    # only has a single element.
+    # @yieldparam [CollectionType] a Hyrax::CollectionType
+    # @return [CollectionType] a Hyrax::CollectionType
+    def first_collection_type
+      yield(authorized_collections.first) if block_given?
+      authorized_collections.first
+    end
+
+    # @yieldparam [CollectionPresenter] a presenter for the collection
+    def each
+      authorized_collections.each { |collection| yield row_presenter.new(collection, @current_ability) }
+    end
+
+    def options_for_select
+      options = []
+      self.each { |r| options << [r.title.first, r.id] }
+      options.sort
+    end
+  end
+end

--- a/app/views/bulkrax/importers/_mets_xml_fields.html.erb
+++ b/app/views/bulkrax/importers/_mets_xml_fields.html.erb
@@ -1,5 +1,14 @@
 <div class='mets_xml_fields'>
 
+  <%= fi.input :collection_id,
+    hint: 'Select a collection to use for import',
+    collection: Hyrax::SelectCollectionListPresenter.new(current_ability).options_for_select,
+    selected: importer.parser_fields['collection_id'],
+    include_blank: true,
+    input_html: { class: 'form-control' },
+    required: false
+  %>
+
   <%= fi.input :profile_id, 
     collection: available_profiles, 
     selected: importer.parser_fields['profile_id'] || available_profiles.first.last
@@ -14,7 +23,8 @@
   <%= fi.input :record_element, 
     hint: 'Provide the xml element name to use to identify the record, or records, eg. ROW - each record in the attached XML is wrapped in a <ROW> tag.', 
     input_html: { value: importer.parser_fields['record_element'] || 'mets:mets' }
-    %>
+   %>
+
 
   <%= fi.input :title, 
     hint: 'Provide a title for this work',

--- a/app/views/bulkrax/importers/_mets_xml_fields.html.erb
+++ b/app/views/bulkrax/importers/_mets_xml_fields.html.erb
@@ -13,7 +13,7 @@
   %>
   <%= fi.input :record_element, 
     hint: 'Provide the xml element name to use to identify the record, or records, eg. ROW - each record in the attached XML is wrapped in a <ROW> tag.', 
-    input_html: { value: importer.parser_fields['record_element'] }
+    input_html: { value: importer.parser_fields['record_element'] || 'mets:mets' }
     %>
 
   <%= fi.input :title, 

--- a/spec/presenters/hyrax/select_collection_list_presenter.rb
+++ b/spec/presenters/hyrax/select_collection_list_presenter.rb
@@ -1,0 +1,16 @@
+RSpec.describe Hyrax::SelectCollectionTypeListPresenter, :clean_repo do
+  let(:user) { create(:user) }
+  let(:ability) { ::Ability.new(user) }
+  let(:instance) { described_class.new(ability) }
+  let(:authorized_collection) { create(:collection_lw, title: ['Authorized Collection'], user: user) }
+  let(:forbidden_collection) { create(:collection_lw, title: ['Forbidden Collection']) }
+
+  describe '#options_for_select' do
+    let(:subject) { subject.options_for_select.map(&:reverse).to_h }
+
+    it 'returns a sorted array of authorized collection titles, ids (as Strings)' do
+      expect(subject[authorized_collection.id]).to eq authorized_collection.to_s
+      expect(subject[forbidden_collection.id]).to be_nil
+    end
+  end
+end

--- a/spec/presenters/hyrax/select_collection_list_presenter.rb
+++ b/spec/presenters/hyrax/select_collection_list_presenter.rb
@@ -1,14 +1,39 @@
-RSpec.describe Hyrax::SelectCollectionTypeListPresenter, :clean_repo do
+RSpec.describe Hyrax::SelectCollectionTypeListPresenter do
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
   let(:instance) { described_class.new(ability) }
   let(:authorized_collection) { create(:collection_lw, title: ['Authorized Collection'], user: user) }
+  let(:authorized_collection2) { create(:collection_lw, title: ['Authorized Collection 2'], user: user) }
   let(:forbidden_collection) { create(:collection_lw, title: ['Forbidden Collection']) }
 
-  describe '#options_for_select' do
+  describe "#many?" do
+    context "without 0/1 authorized collections" do
+      expect(instance.many?).to eq false
+    end
+    context "without multiple authorized collections", :clean do
+      authorized_collection
+      authorized_collection2
+      expect(instance.many?).to be true
+    end
+  end
+
+  describe "#any?" do
+    context "without any authorized collections" do
+      forbidden_collection
+      expect(instance.any?).to eq true
+    end
+    context "with authorized collections", :clean do
+      authorized_collection
+      expect(instance.many?).to be true
+    end
+  end
+
+  describe '#options_for_select', :clean do
     let(:subject) { subject.options_for_select.map(&:reverse).to_h }
 
     it 'returns a sorted array of authorized collection titles, ids (as Strings)' do
+      authorized_collection
+      forbidden_collection
       expect(subject[authorized_collection.id]).to eq authorized_collection.to_s
       expect(subject[forbidden_collection.id]).to be_nil
     end


### PR DESCRIPTION
Adds optional selection of a Collection to use for METS ingest.

Note that unlike CSV ingest, which looks up a collection by title/source value and will create a collection if a match is not found, this only finds an existing collection that the user has deposit rights to.  See wiki page "Bulkrax: collection import and association" for more details.