### PR TITLE
`bundle install` before starting docker services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   essi:
     << : *default-app
-    command: bash -l -c "bundle exec rake db:migrate db:seed yarn:install && bundle exec rails s"
+    command: bash -l -c "bundle install && bundle exec rake db:migrate db:seed yarn:install && bundle exec rails s"
     environment:
       VIRTUAL_HOST: essi.docker
       VIRTUAL_PORT: 3000
@@ -54,7 +54,7 @@ services:
 
   worker:
     << : *default-app
-    command: sidekiq -c 10
+    command: bash -l -c "bundle install && sidekiq -c 4"
 
   db:
     image: mysql:8.0


### PR DESCRIPTION
Solves issues with git sourced gem availability in docker-compose.

Also reduce sidekiq threads to match deployed configurations.