### PR TITLE
[ESSI-1665] add CapybaraWatcher gem; add wait call in csv import spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara'
   gem 'capybara-screenshot', '~> 1.0'
+  gem 'capybara_watcher'
   gem 'selenium-webdriver'
   gem 'webdrivers'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
+    capybara_watcher (0.1.2)
     carrierwave (1.3.2)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -1079,6 +1080,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot (~> 1.0)
+  capybara_watcher
   coffee-rails (~> 4.2)
   country_select (~> 4.0)
   database_cleaner

--- a/spec/features/csv_importer_spec.rb
+++ b/spec/features/csv_importer_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 include ActiveJob::TestHelper
+include CapybaraWatcher
 
 # NOTE: If you generated more than one work, you have to set "js: true"
 RSpec.feature 'Create and run a CSV Importer', type: :system, js: true do
@@ -75,9 +76,12 @@ RSpec.feature 'Create and run a CSV Importer', type: :system, js: true do
         click_button 'Submit'
       end
 
+      # wait until modal has closed and Add Cloud Files button has updatedto Cloud Files Added
+      wait_until_content_has "Cloud Files Added" do |text|
+        page.should have_content text
+      end
       expect(page).to have_field 'selected_files[0][url]', type: 'hidden', with: /rgb\.png/
       expect(page).to have_field 'selected_files[1][url]', type: 'hidden', with: /world\.png/
-      expect(page).to have_content 'Cloud Files Added'
 
       perform_enqueued_jobs do
         click_button 'Create and Import'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,6 +77,7 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers, type: :request
   config.include Warden::Test::Helpers, type: :feature
   config.include(ControllerLevelHelpers, type: :view)
+  config.include CapybaraWatcher, type: :feature
   config.before(:each, type: :view) { initialize_controller_helpers(view) }
 
   # The following methods ensure proper handling of minted IDs via Noid to eliminate LDP conflict errors
@@ -151,4 +152,8 @@ VCR.configure do |config|
   # Ignore webdriver updates
   driver_hosts = Webdrivers::Common.subclasses.map { |driver| URI(driver.base_url).host }
   config.ignore_hosts(*driver_hosts)
+end
+
+CapybaraWatcher.configure do |options|
+  options[:timeout] = 5 # Time in seconds
 end


### PR DESCRIPTION
The theory on the csv import spec non-deterministically failing is that it's hitting a race condition on the closing the modal and the updating of the rest of the page.

This attempts to address that by adding the CapybaraWatcher gem, and adding a wait call around checking for "Cloud Files Added"