### PR TITLE
ESSI-1675 Add config to support airbrake proxy use

### DIFF
--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -78,6 +78,13 @@ default: &default
   airbrake:
     project_id:
     project_key:
+    proxy:
+      enabled: false
+      config:
+        host:
+        port:
+        user:
+        password:
   rack_profiler:
     enabled: true
   ldap:

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -77,6 +77,13 @@ default: &default
   airbrake:
     project_id:
     project_key:
+    proxy:
+      enabled: false
+      config:
+        host:
+        port:
+        user:
+        password:
   rack_profiler:
     enabled: true
   ldap:

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -17,6 +17,12 @@ Airbrake.configure do |c|
   c.project_id = ESSI.config.dig :airbrake, :project_id
   c.project_key = ESSI.config.dig :airbrake, :project_key
 
+  # Outbound proxy settings
+  # https://docs.airbrake.io/docs/platforms/ruby/#configuring-airbrake-v5-to-use-a-proxy
+  if ESSI.config.dig :airbrake, :proxy, :enabled
+    c.proxy = ESSI.config.dig :airbrake, :proxy, :config
+  end
+
   # Configures the root directory of your project. Expects a String or a
   # Pathname, which represents the path to your project. Providing this option
   # helps us to filter out repetitive data from backtrace frames and link to


### PR DESCRIPTION
When configured this should allow the ESS hosted applications to access Airbrake's servers.