### PR TITLE
[ESSI-1667] additional holding locations

### DIFF
--- a/app/authorities/qa/authorities/iucat_libraries.rb
+++ b/app/authorities/qa/authorities/iucat_libraries.rb
@@ -17,7 +17,7 @@ module Qa::Authorities
     private
       def api_url(id)
         return nil unless ESSI.config[:iucat_libraries]
-        [ESSI.config[:iucat_libraries][:url], id].join('/')
+        [ESSI.config[:iucat_libraries][:url], ERB::Util.url_encode(id)].join('/')
       end
 
       def data_for(id)

--- a/app/authorities/qa/authorities/iucat_libraries.rb
+++ b/app/authorities/qa/authorities/iucat_libraries.rb
@@ -17,7 +17,7 @@ module Qa::Authorities
     private
       def api_url(id)
         return nil unless ESSI.config[:iucat_libraries]
-        [ESSI.config[:iucat_libraries][:url], ERB::Util.url_encode(id)].join('/')
+        [ESSI.config[:iucat_libraries][:url], ::Addressable::URI.escape(id)].join('/')
       end
 
       def api_data_for(id)

--- a/app/authorities/qa/authorities/iucat_libraries.rb
+++ b/app/authorities/qa/authorities/iucat_libraries.rb
@@ -7,11 +7,11 @@ module Qa::Authorities
     end
 
     def find(id)
-      data_for(id)[:library] || {}
+      api_data_for(id)[:library] || supplemental_data_for(id) || {}
     end
 
     def all
-      data_for('all')[:libraries] || []
+      ((api_data_for('all')[:libraries] || []) + supplemental_data).uniq { |r| r[:code] }
     end
 
     private
@@ -20,7 +20,7 @@ module Qa::Authorities
         [ESSI.config[:iucat_libraries][:url], ERB::Util.url_encode(id)].join('/')
       end
 
-      def data_for(id)
+      def api_data_for(id)
         return {} unless api_enabled? && api_url(id)
         begin
           result = json(api_url(id)).with_indifferent_access
@@ -33,6 +33,19 @@ module Qa::Authorities
       def api_enabled?
         return nil unless ESSI.config[:iucat_libraries]
         ESSI.config[:iucat_libraries][:api_enabled]
+      end
+
+      def supplemental_data_for(id)
+        supplemental_data.select { |e| e[:code] == id }.first
+      end
+
+      def supplemental_data
+        data_path = Rails.root.join('config', 'authorities', 'supplemental_holding_locations.yml')
+        @supplemental_data ||= begin
+          YAML.load_file(data_path).map { |h| h.with_indifferent_access }
+        rescue
+          []
+        end
       end
   end
 end

--- a/config/authorities/holding_locations.yml
+++ b/config/authorities/holding_locations.yml
@@ -1,3 +1,4 @@
+# file-based backup data for API
 ---
 terms:
 - id: 41

--- a/config/authorities/supplemental_holding_locations.yml
+++ b/config/authorities/supplemental_holding_locations.yml
@@ -1,0 +1,62 @@
+# file-based supplement to API results
+---
+- code: 'B-MEDIASCHOOL'
+  label: 'Bloomington - The Media School'
+  address: 'Franklin Hall'
+  address2: '601 East Kirkwood Ave'
+  city: 'Bloomington'
+  state: 'IN'
+  zip: '47405'
+  phone: '812-855-9247'
+  email: 'tmsarch@indiana.edu'
+  url: 'https://mediaschool.indiana.edu/about/archive.html'
+  urlHours: 'https://mediaschool.indiana.edu/about/facilities/index.html'
+  latitude: '39.166887'
+  longitude: '-86.526490'
+  parking: 'https://parking.indiana.edu/'
+  notes: ''
+- code: 'B-BFCA'
+  label: 'Bloomington - Black Film Center & Archive'
+  address: 'Herman B Wells Library, Room 044'
+  address2: '1320 East Tenth Street'
+  city: 'Bloomington'
+  state: 'IN'
+  zip: '47405'
+  phone: 812-855-6041
+  email: bfca@indiana.edu
+  url: https://bfca.indiana.edu/
+  urlHours: https://bfca.indiana.edu/contact/index.html
+  latitude: '39.17098'
+  longitude: '-86.516189'
+  parking: https://parking.indiana.edu/
+  notes: '' 
+- code: 'B-IUMAA'
+  label: 'Bloomington - Indiana University Museum of Archaeology and Anthropology'
+  address: '416 North Indiana Avenue'
+  address2: ''
+  city: 'Bloomington'
+  state: 'IN'
+  zip: '47408'
+  phone: 812-855-6873
+  email: iumaa@indiana.edu
+  url: https://iumaa.iu.edu/
+  urlHours: 
+  latitude: '39.1700233'
+  longitude: '-86.528326'
+  parking: https://iumaa.iu.edu/about/building-information.html
+  notes: ''
+- code: 'B-WYLIEHOUSE'
+  label: 'Bloomington - Wylie House Museum'
+  address: '317 East 2nd Street'
+  address2: ''
+  city: 'Bloomington'
+  state: 'IN'
+  zip: '47401'
+  phone: 812-855-6224
+  email: libwylie@indiana.edu
+  url: https://libraries.indiana.edu/wylie-house-museum
+  urlHours: https://libraries.indiana.edu/wylie-house-museum
+  latitude: '39.1616539'
+  longitude: '-86.5326939'
+  parking: https://libraries.indiana.edu/file/wylie-house-museum-parking-pdf
+  notes: ''

--- a/lib/extensions/active_fedora/file/escaping_obsoletions.rb
+++ b/lib/extensions/active_fedora/file/escaping_obsoletions.rb
@@ -2,10 +2,10 @@ module Extensions
   module ActiveFedora
     module File
       module EscapingObsoletions
-        # modified from active_fedora: update obsolete URI methods to CGI
+        # modified from active_fedora: replace obsolete URI.escape method calls with Addressable::URI.escape
         def ldp_headers
           headers = { 'Content-Type'.freeze => mime_type, 'Content-Length'.freeze => content.size.to_s }
-          headers['Content-Disposition'.freeze] = "attachment; filename=\"#{::CGI.escape(@original_name)}\"" if @original_name
+          headers['Content-Disposition'.freeze] = "attachment; filename=\"#{::Addressable::URI.escape(@original_name)}\"" if @original_name
           headers
         end
       end

--- a/lib/extensions/hydra/access_controls/permission/escaping_obsoletions.rb
+++ b/lib/extensions/hydra/access_controls/permission/escaping_obsoletions.rb
@@ -3,14 +3,14 @@ module Extensions
     module AccessControls
       module Permission
         module EscapingObsoletions
-          # modified to use CGI method instead of obsolete URI method
+          # modified to use Addressable::URI method instead of obsolete URI method
           def agent_name
-            ::CGI.unescape(parsed_agent.last)
+            ::Addressable::URI.unescape(parsed_agent.last)
           end
 
-          # modified to use CGI method instead of obsolete URI method
+          # modified to use Addressable::URI method instead of obsolete URI method
           def build_agent_resource(prefix, name)
-            [::Hydra::AccessControls::Agent.new(::RDF::URI.new("#{prefix}##{::CGI.escape(name)}"))]
+            [::Hydra::AccessControls::Agent.new(::RDF::URI.new("#{prefix}##{::Addressable::URI.escape(name)}"))]
           end
         end
       end

--- a/spec/authorities/qa/authorities/iucat_libraries_spec.rb
+++ b/spec/authorities/qa/authorities/iucat_libraries_spec.rb
@@ -3,33 +3,66 @@ require 'rails_helper'
 RSpec.describe Qa::Authorities::IucatLibraries do
   let(:authority) { described_class.new }
   let(:matching_id) { 'B-WELLS' }
+  let(:supplemental_id) { 'B-MEDIASCHOOL' }
   let(:nonmatching_id) { 'foobar' }
   let(:invalid_id) { 'B-WELLS and more' }
-  let(:api_config) { { url: 'https://iucat.iu.edu/api/library',
+  let(:api_enabled) { { url: 'https://iucat.iu.edu/api/library',
                        api_enabled: true } }
+  let(:api_disabled) { { url: 'http://some_unreachable_server',
+                       api_enabled: false } }
+  let(:supplemental_data) { authority.supplemental_data }
 
   context 'when configuration does not exist' do
-    describe '#all' do
-      let(:result) { authority.all }
-      it 'returns an empty Array' do
-        allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(nil)
-        expect(result).to be_a Array
-        expect(result).to be_empty
+    before do
+      allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(nil)
+    end
+    let(:result) { authority.all }
+    context 'with supplemental data' do
+      describe '#all' do
+        it 'returns only supplemental data' do
+          expect(result).to be_a Array
+          expect(result).not_to be_empty
+          expect(result.size).to eq 4
+        end
+      end
+    end
+    context 'without supplemental data' do
+      before do
+        allow(authority).to receive(:supplemental_data).and_return([])
+      end
+      describe '#all' do
+        it 'returns an empty Array' do
+          expect(result).to be_a Array
+          expect(result).to be_empty
+        end
       end
     end
   end
 
   context 'when api is disabled' do
-    describe '#all' do
-      let(:result) { authority.all }
-      let(:api_config) { { url: 'http://some_unreachable_server',
-                           api_enabled: false } }
-      #let(:api_config) { { api_enabled: false } }
-      it 'returns an empty Array' do
-        allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
-        expect(ESSI.config[:iucat_libraries][:api_enabled]).to_not be_truthy
-        expect(result).to be_a Array
-        expect(result).to be_empty
+    before do
+      allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_disabled)
+      expect(ESSI.config[:iucat_libraries][:api_enabled]).to_not be_truthy
+    end
+    let(:result) { authority.all }
+    context 'with supplemental data' do
+      describe '#all' do
+        it 'returns only supplemental data' do
+          expect(result).to be_a Array
+          expect(result).not_to be_empty
+          expect(result.size).to eq 4
+        end
+      end
+    end
+    context 'without supplemental data' do
+      before do
+        allow(authority).to receive(:supplemental_data).and_return([])
+      end
+      describe '#all' do
+        it 'returns an empty Array' do
+          expect(result).to be_a Array
+          expect(result).to be_empty
+        end
       end
     end
   end
@@ -38,17 +71,25 @@ RSpec.describe Qa::Authorities::IucatLibraries do
     describe '#all' do
       let(:result) { authority.all }
       it 'returns a populated Array' do
-        allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
+        allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_enabled)
         expect(result).to be_a Array
         expect(result).not_to be_empty
       end
     end
 
     describe '#find' do
-      context 'with a matching id' do
+      context 'with a matching id in the API' do
         let(:result) { authority.find(matching_id) }
         it 'returns a Hash' do
-          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
+          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_enabled)
+          expect(result).to be_a Hash
+          expect(result).not_to be_empty
+        end
+      end
+      context 'with a matching id in the supplemental data' do
+        let(:result) { authority.find(supplemental_id) }
+        it 'returns a Hash' do
+          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_enabled)
           expect(result).to be_a Hash
           expect(result).not_to be_empty
         end
@@ -56,7 +97,7 @@ RSpec.describe Qa::Authorities::IucatLibraries do
       context 'with a non-matching id' do
         let(:result) { authority.find(nonmatching_id) }
         it 'returns an empty Hash' do
-          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
+          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_enabled)
           expect(result).to be_a Hash
           expect(result).to be_empty
         end
@@ -64,7 +105,7 @@ RSpec.describe Qa::Authorities::IucatLibraries do
       context 'with an invalid id' do
         let(:result) { authority.find(invalid_id) }
         it 'returns an empty Hash' do
-          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
+          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_enabled)
           expect(result).to be_a Hash
           expect(result).to be_empty
         end
@@ -72,10 +113,19 @@ RSpec.describe Qa::Authorities::IucatLibraries do
     end
 
     describe '#search' do
-      context 'with a matching id' do
+      before do
+        allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_enabled)
+      end
+      context 'with a matching id in the API ' do
         let(:result) { authority.search(matching_id) }
         it 'returns a populated Array' do
-          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
+          expect(result).to be_a Array
+          expect(result).not_to be_empty
+        end
+      end
+      context 'with a matching id in the supplemental data ' do
+        let(:result) { authority.search(supplemental_id) }
+        it 'returns a populated Array' do
           expect(result).to be_a Array
           expect(result).not_to be_empty
         end
@@ -83,7 +133,6 @@ RSpec.describe Qa::Authorities::IucatLibraries do
       context 'with a non-matching id' do
         let(:result) { authority.search(nonmatching_id) }
         it 'returns an empty Array' do
-          allow(ESSI.config).to receive(:[]).with(:iucat_libraries).and_return(api_config)
           expect(result).to be_a Array
           expect(result).to be_empty
         end

--- a/spec/fixtures/vcr_cassettes/iucat_libraries_up.yml
+++ b/spec/fixtures/vcr_cassettes/iucat_libraries_up.yml
@@ -689,4 +689,104 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"success":false,"data":"error"}'
   recorded_at: Thu, 12 Aug 2021 17:41:35 GMT
-recorded_with: VCR 6.0.0
+- request:
+    method: get
+    uri: https://iucat.iu.edu/api/library/B-MEDIASCHOOL
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.5
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 01 Sep 2022 21:13:44 GMT
+      X-Request-Id:
+      - d467d19d-e16c-4276-8661-55bc3c20bb1e
+      Status:
+      - 200 OK
+      X-Runtime:
+      - '0.100173'
+      Transfer-Encoding:
+      - chunked
+      Etag:
+      - W/"04268f80c815fe5b2f5caf5007285560"
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _Blacklight5_session=70334bb47cf7de7de6f60ae99864b229; path=/; HttpOnly
+      X-Frame-Options:
+      - ALLOWALL
+      X-Powered-By:
+      - Phusion Passenger 5.1.2
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":false,"data":"error"}'
+  recorded_at: Thu, 01 Sep 2022 21:13:44 GMT
+- request:
+    method: get
+    uri: https://iucat.iu.edu/api/library/B-WELLS%20and%20more
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.5
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 01 Sep 2022 21:13:44 GMT
+      X-Request-Id:
+      - 786a7bc4-c511-4204-a806-8ca680a67ba2
+      Status:
+      - 200 OK
+      X-Runtime:
+      - '0.092915'
+      Transfer-Encoding:
+      - chunked
+      Etag:
+      - W/"04268f80c815fe5b2f5caf5007285560"
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _Blacklight5_session=4032df12e602902633bc0bc464daeb4d; path=/; HttpOnly
+      X-Frame-Options:
+      - ALLOWALL
+      X-Powered-By:
+      - Phusion Passenger 5.1.2
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":false,"data":"error"}'
+  recorded_at: Thu, 01 Sep 2022 21:13:44 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Adds a local YAML file to inject additional holding location into API results.  In the event both sources provide a holding location, the API's data is used.

Also includes a tweak to correctly handle API lookup of code values that contain spaces.  Note that this is done by `Addressable::URI.escape` rather than `CGI.escape` -- turns out the latter method encodes spaces as "+" instead of "%20" as `URI.escape` (deprecated) does.  3rd commit applies this fix in 2 other places, as well.