### PR TITLE
[ESSI-1690] bugfix for missing csv import fields

### DIFF
--- a/lib/extensions/bulkrax/csv_entry/add_work_type.rb
+++ b/lib/extensions/bulkrax/csv_entry/add_work_type.rb
@@ -15,6 +15,28 @@ module Extensions
           end
           self.parsed_metadata
         end
+
+        # unmodified from bulkrax
+        def build_metadata
+          raise StandardError, 'Record not found' if record.nil?
+          raise StandardError, "Missing required elements, missing element(s) are: #{importerexporter.parser.missing_elements(keys_without_numbers(record.keys)).join(', ')}" unless importerexporter.parser.required_elements?(keys_without_numbers(record.keys))
+    
+          self.parsed_metadata = {}
+          self.parsed_metadata[work_identifier] = [record[source_identifier]]
+          record.each do |key, value|
+            next if key == 'collection'
+    
+            index = key[/\d+/].to_i - 1 if key[/\d+/].to_i != 0
+            add_metadata(key_without_numbers(key), value, index)
+          end
+          add_file
+          add_visibility
+          add_rights_statement
+          add_admin_set_id
+          add_collections
+          add_local
+          self.parsed_metadata
+        end
       end
     end
   end


### PR DESCRIPTION
CSV import is dependent upon having "model" positioned in the first column, in order to assign the correct `factory_class` and accurately determine `field_supported?` results appropriate for the specified import class (instead of just assuming the default class of `Image`) while parsing the remaining columns.

This PR monkeypatches the `build_metadata` logic to robustly handle the "model" value being in any column.

