### PR TITLE
[ESSI-1622] add campus collection breadcrumbs to catalog results

### DIFF
--- a/app/assets/images/blacklight/repository.svg
+++ b/app/assets/images/blacklight/repository.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M4 10v7h3v-7H4zm6 0v7h3v-7h-3zM2 22h19v-3H2v3zm14-12v7h3v-7h-3zm-4.5-9L2 6v2h19V6l-9.5-5z"/></svg>

--- a/app/assets/stylesheets/brand_tweaks.css
+++ b/app/assets/stylesheets/brand_tweaks.css
@@ -86,3 +86,8 @@ html {
 }
 
 .button:focus{box-shadow:0 0 0 .2rem #fff,0 0 0 .35rem #900} 
+
+.blacklight-icons {
+	height: 1rem !important;
+	width: 1rem !important;
+}

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -57,4 +57,12 @@ class SolrDocument
   def catalog_url
     self[Solrizer.solr_name('related_url')]&.select { |url| url.match ESSI.config.dig(:essi, :metadata, :url).gsub('%s', '') }&.first
   end
+
+  def campus_collection_breadcrumbs
+    begin 
+      JSON::parse(self['campus_collection_breadcrumb_tesim'].first, symbolize_names: true)
+    rescue
+      []
+    end
+  end
 end

--- a/app/renderers/campus_attribute_renderer.rb
+++ b/app/renderers/campus_attribute_renderer.rb
@@ -3,32 +3,8 @@ class CampusAttributeRenderer < Hyrax::Renderers::AttributeRenderer
     super(:campus, values, options)
   end
 
+  # exclude campus value from display in favor of CampusCollectionBreadcrumbRenderer
   def value_html
-    Array(values).map do |value|
-      location_string(CampusService.find(value))
-    end.join("")
+    ''
   end
-
-  def campus_search_path(campus)
-    CampusSearchHelper.path(campus)
-  end
-
-  private
-
-    def attribute_value_to_html(value)
-      loc = CampusService.find(value)
-      li_value location_string(loc)
-    end
-
-   def location_string(loc)
-     return unless loc
-     content_tag(:a, loc.dig(:term), href: campus_search_path(loc))
-   end
-
-   class CampusSearchHelper
-     include Rails.application.routes.url_helpers
-     def self.path(campus)
-       self.new.search_catalog_path(f: { campus_sim: [campus.dig(:id)] })
-     end
-   end
 end

--- a/app/renderers/campus_collection_breadcrumb_renderer.rb
+++ b/app/renderers/campus_collection_breadcrumb_renderer.rb
@@ -1,0 +1,44 @@
+class CampusCollectionBreadcrumbRenderer < Hyrax::Renderers::AttributeRenderer
+  attr_reader :main_app
+
+  def initialize(value, main_app, options = {})
+    @main_app = main_app
+    super(:campus_collection_breadcrumb, value, options)
+  end
+
+  def value_html
+    content_tag(:p,
+                safe_join(values.map { |linkset| icon_and_breadcrumbs(linkset) },
+                          tag(:br)))
+  end
+
+  private
+
+    def icon_and_breadcrumbs(linkset)
+      text_links = breadcrumbs(linkset)
+      if linkset&.first&.[](:campus)
+        safe_join([repository_icon, text_links], "")
+      else
+        text_links
+      end
+    end
+
+    def breadcrumbs(linkset)
+      safe_join(linkset.map { |link| link_for(link) }, " » ")
+    end
+
+    def link_for(hash)
+      if hash[:campus]
+        f = { campus_sim: [hash[:campus]]}
+      elsif hash[:collection]
+        f = { member_of_collection_ids_ssim: [hash[:collection]]}
+      else
+        f = {}
+      end
+      content_tag(:a, hash[:text], href: main_app.search_catalog_path(f: f))
+    end
+
+    def repository_icon
+      ActionController::Base.helpers.image_tag('blacklight/repository.svg', class: 'blacklight-icons')
+    end
+end

--- a/app/services/essi/adapters/nesting_index_adapter.rb
+++ b/app/services/essi/adapters/nesting_index_adapter.rb
@@ -1,0 +1,174 @@
+# unmodified copy of Hyrax::Adapters::NestingIndexAdapter
+module ESSI
+  module Adapters
+    module NestingIndexAdapter
+      FULL_REINDEX = "full".freeze
+      LIMITED_REINDEX = "limited".freeze
+
+      # @!group Providing interface for a Samvera::NestingIndexer::Adapter
+      # @api public
+      # @param id [String]
+      # @return Samvera::NestingIndexer::Document::PreservationDocument
+      def self.find_preservation_document_by(id:)
+        # Not everything is guaranteed to have library_collection_ids
+        # If it doesn't have it, what do we do?
+        parent_ids = find_preservation_parent_ids_for(id: id)
+        Samvera::NestingIndexer::Documents::PreservationDocument.new(id: id, parent_ids: parent_ids)
+      end
+
+      # @api public
+      # @param id [String]
+      # @return Samvera::NestingIndexer::Document::PreservationDocument
+      def self.find_preservation_parent_ids_for(id:)
+        # Not everything is guaranteed to have library_collection_ids
+        # If it doesn't have it, what do we do?
+        fedora_object = ActiveFedora::Base.uncached do
+          fedora_object = ActiveFedora::Base.find(id)
+        end
+
+        if fedora_object.respond_to?(:member_of_collection_ids)
+          fedora_object.member_of_collection_ids
+        else
+          []
+        end
+      end
+
+      # @api public
+      # @param id [String]
+      # @return Samvera::NestingIndexer::Documents::IndexDocument
+      def self.find_index_document_by(id:)
+        solr_document = find_solr_document_by(id: id)
+        coerce_solr_document_to_index_document(original_solr_document: solr_document, id: id)
+      end
+
+      # @api public
+      # @yieldparam id [String]
+      # @yieldparam parent_id [Array<String>]
+      # Samvera::NestingIndexer.reindex_all!(extent: FULL_REINDEX)
+      # rubocop:disable Lint/UnusedMethodArgument
+      def self.each_perservation_document_id_and_parent_ids(&block)
+        ActiveFedora::Base.descendant_uris(ActiveFedora.fedora.base_uri, exclude_uri: true).each do |uri|
+          id = ActiveFedora::Base.uri_to_id(uri)
+          object = ActiveFedora::Base.find(id)
+          parent_ids = object.try(:member_of_collection_ids) || []
+
+          # note: we do not yield when the object has parents. Calling the nested indexer for the
+          # top id will reindex all descendants as well.
+          if object.try(:use_nested_reindexing?)
+            yield(id, parent_ids) if parent_ids.empty?
+          else
+            Rails.logger.info "Re-indexing via to_solr ... #{id}"
+            ActiveFedora::SolrService.add(object.to_solr, commit: true)
+          end
+        end
+      end
+      # rubocop:enable Lint/UnusedMethodArgument
+
+      # @api public
+      #
+      # From the nesting_document, we will need to add the nesting attributes to the underlying SOLR document for the object
+      #
+      # @param nesting_document [Samvera::NestingIndexer::Documents::IndexDocument]
+      # @return Hash - the attributes written to the indexing layer
+      def self.write_nesting_document_to_index_layer(nesting_document:)
+        solr_doc = ActiveFedora::Base.uncached do
+          ActiveFedora::Base.find(nesting_document.id).to_solr # What is the current state of the solr document
+        end
+
+        # Now add the details from the nesting indexer to the document
+        add_nesting_attributes(
+          solr_doc: solr_doc,
+          ancestors: nesting_document.ancestors,
+          parent_ids: nesting_document.parent_ids,
+          pathnames: nesting_document.pathnames,
+          depth: nesting_document.deepest_nested_depth
+        )
+      end
+
+      # @api public
+      #
+      # @param solr_doc [SolrDocument]
+      # @param ancestors [Array]
+      # @param parent_ids [Array]
+      # @param pathnames [Array]
+      # @param depth [Array] the object's deepest nesting depth
+      # @return solr_doc [SolrDocument]
+      def self.add_nesting_attributes(solr_doc:, ancestors:, parent_ids:, pathnames:, depth:)
+        solr_doc[solr_field_name_for_storing_ancestors] = ancestors
+        solr_doc[solr_field_name_for_storing_parent_ids] = parent_ids
+        solr_doc[solr_field_name_for_storing_pathnames] = pathnames
+        solr_doc[solr_field_name_for_deepest_nested_depth] = depth
+        ActiveFedora::SolrService.add(solr_doc, commit: true)
+        solr_doc
+      end
+
+      # @api public
+      # @param document [Samvera::NestingIndexer::Documents::IndexDocument]
+      # @param extent [String] if not "full" or nil, doesn't yield children for reindexing
+      # @param solr_field_name_for_ancestors [String] The SOLR field name we use to find children
+      # @yield Samvera::NestingIndexer::Documents::IndexDocument
+      def self.each_child_document_of(document:, extent:, &block)
+        raw_child_solr_documents_of(parent_document: document).each do |solr_document|
+          child_document = coerce_solr_document_to_index_document(original_solr_document: solr_document, id: solr_document.fetch('id'))
+          # during light reindexing, we want to reindex the child only if fields aren't already there
+          block.call(child_document) if full_reindex?(extent: extent) || child_document.pathnames.empty?
+        end
+      end
+      # @!endgroup
+
+      # @!group Supporting methods for interface implementation
+
+      # @api private
+      # @todo Need to implement retrieving parent_ids, pathnames, and ancestors from the given document
+      def self.coerce_solr_document_to_index_document(original_solr_document:, id:)
+        Samvera::NestingIndexer::Documents::IndexDocument.new(
+          id: id,
+          parent_ids: original_solr_document.fetch(solr_field_name_for_storing_parent_ids) { [] },
+          pathnames: original_solr_document.fetch(solr_field_name_for_storing_pathnames) { [] },
+          ancestors: original_solr_document.fetch(solr_field_name_for_storing_ancestors) { [] }
+        )
+      end
+      private_class_method :coerce_solr_document_to_index_document
+
+      # @api private
+      def self.find_solr_document_by(id:)
+        query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])
+        document = ActiveFedora::SolrService.query(query, rows: 1).first
+        document = ActiveFedora::Base.find(id).to_solr if document.nil?
+        raise "Unable to find SolrDocument with ID=#{id}" if document.nil?
+        document
+      end
+      private_class_method :find_solr_document_by
+
+      # @api private
+      def self.nesting_configuration
+        @nesting_configuration ||= Samvera::NestingIndexer.configuration
+      end
+
+      class << self
+        delegate :solr_field_name_for_storing_pathnames,
+                 :solr_field_name_for_storing_ancestors,
+                 :solr_field_name_for_storing_parent_ids,
+                 :solr_field_name_for_deepest_nested_depth, to: :nesting_configuration
+      end
+
+      # @api private
+      # @param parent_document [Curate::Indexer::Documents::IndexDocument]
+      # @return [Hash] A raw response document from SOLR
+      # @todo What is the appropriate suffix to apply to the solr_field_name?
+      def self.raw_child_solr_documents_of(parent_document:)
+        # query Solr for all of the documents included as a member_of_collection parent. Or up to 10000 of them.
+        child_query = ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: parent_document.id)
+        ActiveFedora::SolrService.query(child_query, rows: 10_000.to_i)
+      end
+      private_class_method :raw_child_solr_documents_of
+
+      def self.full_reindex?(extent:)
+        return true if extent == FULL_REINDEX
+        false
+      end
+      private_class_method :full_reindex?
+      # @!endgroup
+    end
+  end
+end

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -34,3 +34,6 @@
   </div>
 </div>
 <% end %>
+<div class="col-md-12">
+  <%= CampusCollectionBreadcrumbRenderer.new(document.campus_collection_breadcrumbs, main_app).value_html %>
+</div>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -10,6 +10,7 @@
           <% custom_renderer = "#{field.itemprop.titleize.gsub(' ','')}AttributeRenderer".constantize %>
           <% field_value = custom_renderer.new(field_value, { label: field_label }).value_html.html_safe %>
         <% end %>
+        <% next if field_value.blank? %>
         <dt><%= field_label %></dt>
         <% if field_value.match(/(<([^>]+)>)/i) %>
           <dd><%= field_value %></dd>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,0 +1,4 @@
+<div class="col-md-2">
+  <%= render_thumbnail_tag document, {}, suppress_link: true %>
+</div> 
+

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,4 +1,6 @@
 <div class="col-md-2">
-  <%= render_thumbnail_tag document, {}, suppress_link: true %>
+  <div class="list-thumbnail">
+    <%= render_thumbnail_tag document, {}, suppress_link: true %>
+  </div>
 </div> 
 

--- a/config/initializers/samvera-nesting_indexer_initializer.rb
+++ b/config/initializers/samvera-nesting_indexer_initializer.rb
@@ -8,7 +8,7 @@ Samvera::NestingIndexer.configure do |config|
   # For maximum_nesting_depth of 3 the following will raise an exception
   # C1 <- C2 <- C3 <- W1
   config.maximum_nesting_depth = 5
-  config.adapter = Hyrax::Adapters::NestingIndexAdapter
+  config.adapter = ESSI::Adapters::NestingIndexAdapter
   config.solr_field_name_for_storing_parent_ids = Solrizer.solr_name('nesting_collection__parent_ids', :symbol)
   config.solr_field_name_for_storing_ancestors =  Solrizer.solr_name('nesting_collection__ancestors', :symbol)
   config.solr_field_name_for_storing_pathnames =  Solrizer.solr_name('nesting_collection__pathnames', :symbol)

--- a/spec/renderers/campus_attribute_renderer_spec.rb
+++ b/spec/renderers/campus_attribute_renderer_spec.rb
@@ -12,16 +12,17 @@ RSpec.describe CampusAttributeRenderer do
       img_alt: 'The Sample Gates at IU Bloomington'
     }
   }
-  let(:rendered) { described_class.new(value).render }
+  let(:value_html) { described_class.new(value).value_html }
 
   before do
     allow(CampusService).to receive(:find).with(value).and_return(obj)
   end
 
-  context "with a rendered campus" do
-    it "renders the label and facet search link " do
-      expect(rendered).to include('IU Bloomington')
-      expect(rendered).to match /href=".*catalog.*campus_sim.*IUB/
+  describe "#value_html" do
+    context "with a campus" do
+      it "returns a blank string" do
+        expect(value_html).to be_blank
+      end
     end
   end
 end


### PR DESCRIPTION
The first couple of commits copy and modify hyrax's `NestingIndexAdapter` to add an additional property.
* It would probably be more elegant to monkeypatch the hyrax version, but I ran into repeated problems doing that, and reverted to a strict override
* Note that here's active work on deprecating `NestingIndexAdapter` in future versions of hyrax
  * At some future point, we can slim down the essi version to just the portion we're still using, or otherwise refactor
* Note that works and collections will need to be re-saved to update their solr indices, to provide values for the UI components

3rd commit adds UI components to render the breadcrumbs

The next couple of commits copy and modify a hyrax partial -- there are distinct partials to display collection thumbnail and work thumbnails, and the collection-specific version was missing a style class necessary to prevent the breadcrumbs from appearing uncomfortably closely below the thumbnail, in a context of sparse collection metadata that doesn't naturally push the next div lower.

The final commit effectively excludes campus from the catalog metadata display, by changing the custom renderer for campus to always return an empty string, and changing the field display logic to skip over fields if the value (most likely from a custom renderer) ends up being blank.