### PR TITLE
[ESSI-1692] dynamic manifest metadata

### DIFF
--- a/app/renderers/campus_attribute_renderer.rb
+++ b/app/renderers/campus_attribute_renderer.rb
@@ -3,8 +3,14 @@ class CampusAttributeRenderer < Hyrax::Renderers::AttributeRenderer
     super(:campus, values, options)
   end
 
-  # exclude campus value from display in favor of CampusCollectionBreadcrumbRenderer
+  # exclude campus value from catalog display in favor of CampusCollectionBreadcrumbRenderer
   def value_html
     ''
   end
+
+  private
+    # campus display value for work show page, iiif metadata
+    def attribute_value_to_html(value)
+      CampusService.find(value)[:term]
+    end
 end

--- a/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
+++ b/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
@@ -3,7 +3,7 @@ module Extensions
   module Hyrax
     module WorkShowPresenter
       module ManifestMetadata
-        HTML_RENDERED_FIELDS = [:holding_location].freeze
+        HTML_RENDERED_FIELDS = [:campus, :holding_location].freeze
         # Copied from Hyrax gem
         # IIIF metadata for inclusion in the manifest
         #  Called by the `iiif_manifest` gem to add metadata

--- a/spec/renderers/campus_attribute_renderer_spec.rb
+++ b/spec/renderers/campus_attribute_renderer_spec.rb
@@ -1,27 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe CampusAttributeRenderer do
-  let(:value) { 'IUB' }
+  let(:code) { 'IUB' }
+  let(:label) { 'IU Bloomington' }
   let(:obj) {
     {
-      id: 'IUB',
-      term: 'IU Bloomington',
+      id: code, 
+      term: label, 
       active: true,
       url: 'https://www.indiana.edu',
       img_src: 'campuses/iub.jpg',
       img_alt: 'The Sample Gates at IU Bloomington'
     }
   }
-  let(:value_html) { described_class.new(value).value_html }
+  subject { described_class.new([code]) }
 
   before do
-    allow(CampusService).to receive(:find).with(value).and_return(obj)
+    allow(CampusService).to receive(:find).with(code).and_return(obj)
   end
 
   describe "#value_html" do
     context "with a campus" do
       it "returns a blank string" do
-        expect(value_html).to be_blank
+        expect(subject.value_html).to be_blank
+      end
+    end
+  end
+
+  describe "#attribute_value_to_html" do
+    context "with a campus" do
+      it "returns the campus display label" do
+        expect(subject.send(:attribute_value_to_html, code)).to eq label
       end
     end
   end


### PR DESCRIPTION
Adds allinson_flex metadata fields in the IIIF manifest.

Adds handling of campus as another specially-rendered field (along with holding_location), and fixes display on the work show page to use the campus label (rather than internal code value).