### PR TITLE
ESSI-1698 Adds okcomputer check to compare image commit levels

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
     checks.register "fcrepo", EssiDevOps::FcrepoCheck.new(fcrepo_url, 10,
                                                         auth_options)
 
+    checks.register "image_sync", EssiDevOps::ImageSyncCheck.new if File.file?('/run/secrets/distributed_deployment')
+
     # TODO: Remove this when CheckCollection instances not setting
     # registrant_name is fixed.
     checks.collection.each do |check_name, check_obj|

--- a/lib/essi_dev_ops/image_sync_check.rb
+++ b/lib/essi_dev_ops/image_sync_check.rb
@@ -1,0 +1,47 @@
+module EssiDevOps
+  # Checks to make sure images are running the same commit level when jobs/admin are distributed across servers
+  include OkComputer
+  class ImageSyncCheck < Check
+    @admin_image_commit = 'NA'
+    @jobs_image_commit = 'NA'
+
+    def check
+      retrieve_image_commits
+      if images_in_sync? # rubocop:disable Style/GuardClause
+        mark_message 'Deployed images are in sync'
+      else
+        raise StandardError, images_out_of_sync
+      end
+    rescue StandardError => e
+      mark_failure
+      mark_message e
+    end
+
+    def retrieve_image_commits
+      admin_image_file = File.read('/run/secrets/inspect_image-admin.json')
+      jobs_image_file = File.read('/run/secrets/inspect_image-jobs.json')
+      admin_image_data = JSON.parse(admin_image_file)
+      jobs_image_data = JSON.parse(jobs_image_file)
+
+      @admin_image_commit = parse_image_data(admin_image_data)
+      @jobs_image_commit = parse_image_data(jobs_image_data)
+    end
+
+    def parse_image_data(image_data)
+      image_env = image_data.dig(0, 'Config', 'Env')
+      image_commit = image_env.find { |env| env.include?('SOURCE') }
+      _key, value = image_commit.split '='
+      value
+    end
+
+    def images_in_sync?
+      @admin_image_commit == @jobs_image_commit
+    end
+
+    def images_out_of_sync
+      admin_abbr = @admin_image_commit[0, 7]
+      jobs_abbr = @jobs_image_commit[0, 7]
+      "The admin image at #{admin_abbr} is different than job image at #{jobs_abbr}"
+    end
+  end
+end


### PR DESCRIPTION
Since Sidekiq is likely to run in a separate container, possibly on a separate server, it is important to have some way of making sure that it is running the same commit level as the web container.  This adds a check to OK Computer that compares commit levels from image data extracted during the deployment process.  

It is a bit opinionated in that it assumes the existence of certain files created by running `podman image inspect` on the web and job  images.  Those files are visible from either container due to their location in the shared secrets directory, which allows this status check to open them and compare the environment variable SOURCE_COMMIT.

The status check is only registered if it detects a certain flag file in the secrets directory.  This allows easily configuring this check to occur per instance instead of having to coordinate whether or not keys exist in the main secrets configuration file.