### PR TITLE
Fix ruby error for presenter missing a render method

### DIFF
--- a/app/views/hyrax/base/_attribute_row.html.erb
+++ b/app/views/hyrax/base/_attribute_row.html.erb
@@ -1,5 +1,5 @@
 <%# @todo internationalisation %>
-<% if presenter.send(prop_key).blank? %>
+<% if presenter.try(prop_key).blank? %>
   <%# no display %>
 <% elsif prop_value[:admin_only] && !presenter.current_ability.current_user.admin? %>
   <%# no display %>


### PR DESCRIPTION
Attempts to address issue with works on older profiles missing properties included in newer profile versions