### PR TITLE
[ESSI-588] refactor manifest viewing hint

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -19,6 +19,7 @@ Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ExtractedTe
 Hyrax::FileSetsController.include Extensions::Hyrax::FileSetsController::RegenerateOCR
 
 # viewing hint support
+IIIFManifest::ManifestBuilder::CanvasBuilder.prepend Extensions::IIIFManifest::ManifestBuilder::CanvasBuilder::ViewingHint
 IIIFManifest::ManifestBuilder::ImageBuilder.prepend Extensions::IIIFManifest::ManifestBuilder::ImageBuilder::ViewingHint
 Hyrax::Forms::FileManagerForm.include Extensions::Hyrax::Forms::FileManagerForm::ViewingMetadata
 Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ViewingHint

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -19,7 +19,7 @@ Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ExtractedTe
 Hyrax::FileSetsController.include Extensions::Hyrax::FileSetsController::RegenerateOCR
 
 # viewing hint support
-IIIFManifest::ManifestBuilder::ImageBuilder.include Extensions::IIIFManifest::ManifestBuilder::ImageBuilder::ViewingHint
+IIIFManifest::ManifestBuilder::ImageBuilder.prepend Extensions::IIIFManifest::ManifestBuilder::ImageBuilder::ViewingHint
 Hyrax::Forms::FileManagerForm.include Extensions::Hyrax::Forms::FileManagerForm::ViewingMetadata
 Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ViewingHint
 

--- a/lib/extensions/hyrax/file_set_presenter/viewing_hint.rb
+++ b/lib/extensions/hyrax/file_set_presenter/viewing_hint.rb
@@ -3,8 +3,6 @@ module Extensions
     module FileSetPresenter
       module ViewingHint
         delegate :viewing_hint, :thumbnail_id, to: :solr_document
-        #@todo remove after upgrade to Hyrax 3.x
-        delegate :original_file_id, to: :solr_document
       end
     end
   end

--- a/lib/extensions/iiif_manifest/manifest_builder/canvas_builder/viewing_hint.rb
+++ b/lib/extensions/iiif_manifest/manifest_builder/canvas_builder/viewing_hint.rb
@@ -1,0 +1,15 @@
+module Extensions
+  module IIIFManifest
+    module ManifestBuilder
+      module CanvasBuilder
+        module ViewingHint
+          private
+            # unmodified from iiif_manifest
+            def attach_image
+              image_builder.new(display_image).apply(canvas)
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/iiif_manifest/manifest_builder/canvas_builder/viewing_hint.rb
+++ b/lib/extensions/iiif_manifest/manifest_builder/canvas_builder/viewing_hint.rb
@@ -4,9 +4,9 @@ module Extensions
       module CanvasBuilder
         module ViewingHint
           private
-            # unmodified from iiif_manifest
+            # modified from iiif_manifest to include viewing_hint
             def attach_image
-              image_builder.new(display_image).apply(canvas)
+              image_builder.new(display_image).apply(canvas, viewing_hint: record.viewing_hint)
             end
         end
       end

--- a/lib/extensions/iiif_manifest/manifest_builder/image_builder/viewing_hint.rb
+++ b/lib/extensions/iiif_manifest/manifest_builder/image_builder/viewing_hint.rb
@@ -3,14 +3,10 @@ module Extensions
     module ManifestBuilder
       module ImageBuilder
         module ViewingHint
-          def apply(canvas)
-            canvas['viewingHint'] = canvas_viewing_hint(canvas) if canvas_viewing_hint(canvas).present?
-            super
-          end
-        
-          def canvas_viewing_hint(canvas)
-            id = canvas['@id'].split('/').last
-            FileSet.search_with_conditions({ id: id }, rows: 1)&.first['viewing_hint_tesim']&.first
+          # modified from iiif_manifest to include viewing_hint
+          def apply(canvas, viewing_hint: nil)
+            canvas['viewingHint'] = viewing_hint if viewing_hint.present?
+            super(canvas)
           end
         end
       end


### PR DESCRIPTION
The ESSI-588 monkeypatch to add page-level viewingHint values in the manifest was:
1.  ineffective, due to inclusion via `include` instead of `prepend`
2. inefficient, due to running a solr query to look up the `FileSet` `viewing_hint` property, when that's available from the already-built `FileSetPresenter` that `CanvasBuilder` has access to when calling `image_builder`

This PR should resolve both issues.

Note that the current UV does not seem to actually file-specific viewing_hint properties; presumably a future version may.