### PR TITLE
[ESSI-1765] have CharacterizeJob optionally unlink characterization file, parent dir

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -6,6 +6,7 @@ class CharacterizeJob < ApplicationJob
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
+  # @param [FalseClass, TrueClass, String, NilClass] delete_characterization_path triggers deleting the file on any truthy value, and the parent directory on 'include_parent_dir'
   def perform(file_set, file_id, filepath = nil, derivation_path = nil, delete_characterization_path = false)
     raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
     unless filepath && File.exist?(filepath)
@@ -19,13 +20,13 @@ class CharacterizeJob < ApplicationJob
     file_set.parent&.in_collections&.each(&:update_index)
     derivation_path = filepath unless derivation_path && File.exist?(derivation_path)
     CreateDerivativesJob.perform_later(file_set, file_id, derivation_path)
-    unlink_filepath(filepath, delete_characterization_path) if delete_characterization_path
+    unlink_filepath(filepath, delete_characterization_path.to_s) if delete_characterization_path
   end
 
   # Removes characterization file and optionally parent directory
   # @param [String] filepath file to unlink
-  # @param [Boolean, String] options option to remove parent directory
-  def unlink_filepath(filepath, options)
+  # @param [String, NilClass] options option to remove parent directory
+  def unlink_filepath(filepath, options = nil)
     File.unlink(filepath)
     Dir.rmdir(File.dirname(filepath)) if options == 'include_parent_dir'
   end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -6,9 +6,12 @@ class CharacterizeJob < ApplicationJob
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
-  def perform(file_set, file_id, filepath = nil, derivation_path = nil)
+  def perform(file_set, file_id, filepath = nil, derivation_path = nil, delete_characterization_path = false)
     raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
-    filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id) unless filepath && File.exist?(filepath)
+    unless filepath && File.exist?(filepath)
+      filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id) unless filepath && File.exist?(filepath)
+      delete_characterization_path = false
+    end
     Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filepath)
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.save!
@@ -16,6 +19,15 @@ class CharacterizeJob < ApplicationJob
     file_set.parent&.in_collections&.each(&:update_index)
     derivation_path = filepath unless derivation_path && File.exist?(derivation_path)
     CreateDerivativesJob.perform_later(file_set, file_id, derivation_path)
+    unlink_filepath(filepath, delete_characterization_path) if delete_characterization_path
+  end
+
+  # Removes characterization file and optionally parent directory
+  # @param [String] filepath file to unlink
+  # @param [Boolean, String] options option to remove parent directory
+  def unlink_filepath(filepath, options)
+    File.unlink(filepath)
+    Dir.rmdir(File.dirname(filepath)) if options == 'include_parent_dir'
   end
 end
 

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -67,7 +67,7 @@ describe Hyrax::Actors::FileActor do
         end
         it 'runs characterization' do
           expect(CharacterizeJob).to receive(:perform_later) \
-            .with(file_set, String, String, String)
+            .with(file_set, String, String, String, false)
           file_actor.ingest_file(io)
         end
       end
@@ -93,7 +93,7 @@ describe Hyrax::Actors::FileActor do
         end
         it 'runs jp2-based characterization, tiff-based derivation' do
           expect(CharacterizeJob).to receive(:perform_later) \
-            .with(file_set, String, /jp2/, tiff_filename)
+            .with(file_set, String, /jp2/, tiff_filename, 'include_parent_dir')
           file_actor.ingest_file(io)
         end
       end
@@ -119,7 +119,7 @@ describe Hyrax::Actors::FileActor do
         end
         it 'runs tiff-based characterization and derivation' do
           expect(CharacterizeJob).to receive(:perform_later) \
-            .with(file_set, String, tiff_filename, tiff_filename)
+            .with(file_set, String, tiff_filename, tiff_filename, false)
           file_actor.ingest_file(io)
         end
       end


### PR DESCRIPTION
File ingest, in the case of both `store_files?` and `transform_to_jp2?` being true, was leaving a .jp2 file around indefinitely post-ingest, in the pattern of:
`/tmp/{tmpdir}/{original file}.jp2`
e.g.
`/tmp/d20221230-1-zz7hny/VAB8235-U-00446-00002.jp2`

This commit adds an argument to trigger cleanup at the end of `CharacterizeJob`, when the .jp2 is no longer needed.  (The `CreateDerivativesJob` called next uses the original .tiff file.)