### PR TITLE
Move circleci checkout above browser-tools install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.3.0
+  browser-tools: circleci/browser-tools@1.4.0
   ruby: circleci/ruby@1.8.0
 
 default_environment: &default_environment
@@ -46,9 +46,9 @@ jobs:
       <<: *default_environment
 
     steps:
+      - checkout
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-      - checkout
 
       # BUNDLE_PATH is unset to allow for `bundle config path` to take precedence.
       - run:


### PR DESCRIPTION
Also updates the browser-tools orb, but this is likely not the cause of the git checkout error. Reports are the chrome license file was being left behind.