### PR TITLE
update airbrake-ruby gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrake (13.0.3)
       airbrake-ruby (~> 6.0)
-    airbrake-ruby (6.1.0)
+    airbrake-ruby (6.2.0)
       rbtree3 (~> 0.5)
     almond-rails (0.3.0)
       rails (>= 4.2)


### PR DESCRIPTION
To resolve airbrake dashboard warning about "outdated notifier library."