### PR TITLE
[ESSI-875] bulkrax csv import of page labels

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -119,8 +119,9 @@ module Hyrax
           original_path = io.path
           new_file = File.basename(original_path).sub(/\.tif+$/i, '.jp2')
           new_path = "#{Dir.mktmpdir}/#{new_file}" # makes tmp dir, later cleaned up via 'include_parent_dir' option
-          file_set.label = new_file
-          file_set.title = [new_file]
+          # retain original label, in case of user-provided bulkrax import values
+          # file_set.label = new_file
+          # file_set.title = [new_file]
           if Hydra::Derivatives.kdu_compress_path.present?
             url = URI("file://#{new_path}").to_s
             # FIXME: chokes on compressed tiffs

--- a/lib/extensions/attach_files_to_work_with_ordered_members_job/import_metadata.rb
+++ b/lib/extensions/attach_files_to_work_with_ordered_members_job/import_metadata.rb
@@ -1,21 +1,28 @@
-# unmodified from hyrax
+# modified from hyrax
 module Extensions
   module AttachFilesToWorkWithOrderedMembersJob
     module ImportMetadata
 
+      # modified to apply uploaded file metadata, if provided
       # @param [ActiveFedora::Base] work - the work object
       # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
       def perform(work, uploaded_files, **work_attributes)
+        # reintroduce file metadata somehow lost in direct actor --> job call
+        (work_attributes.delete(:files_metadata) || []).each_with_index do |file_metadata, index|
+          uploaded_files[index].metadata = file_metadata
+        end
         super
       end
 
       private
-    
+
+        # modified to apply uploaded file metadata, if provided  
         def add_uploaded_files(user, metadata, work)
           work_permissions = work.permissions.map(&:to_hash)
           uploaded_files.each do |uploaded_file|
             actor = file_set_actor_class.new(FileSet.create, user)
             actor.create_metadata(metadata)
+            actor.update_metadata(uploaded_file.metadata) if uploaded_file.metadata.present?
             actor.create_content(uploaded_file)
             actor.attach_to_work(work)
             actor.file_set.permissions_attributes = work_permissions

--- a/lib/extensions/attach_files_to_work_with_ordered_members_job/import_metadata.rb
+++ b/lib/extensions/attach_files_to_work_with_ordered_members_job/import_metadata.rb
@@ -1,0 +1,28 @@
+# unmodified from hyrax
+module Extensions
+  module AttachFilesToWorkWithOrderedMembersJob
+    module ImportMetadata
+
+      # @param [ActiveFedora::Base] work - the work object
+      # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
+      def perform(work, uploaded_files, **work_attributes)
+        super
+      end
+
+      private
+    
+        def add_uploaded_files(user, metadata, work)
+          work_permissions = work.permissions.map(&:to_hash)
+          uploaded_files.each do |uploaded_file|
+            actor = file_set_actor_class.new(FileSet.create, user)
+            actor.create_metadata(metadata)
+            actor.create_content(uploaded_file)
+            actor.attach_to_work(work)
+            actor.file_set.permissions_attributes = work_permissions
+            ordered_members << actor.file_set
+            uploaded_file.update(file_set_uri: actor.file_set.uri)
+          end
+        end
+    end
+  end
+end

--- a/lib/extensions/bulkrax/csv_entry/add_file_metadata.rb
+++ b/lib/extensions/bulkrax/csv_entry/add_file_metadata.rb
@@ -1,9 +1,25 @@
-# unmodified from bulkrax
+# modified from bulkrax
 module Extensions
   module Bulkrax
     module CsvEntry
       module AddFileMetadata
-       # unmodified from bulkrax
+        # modified to add file metadata
+        def add_file
+          super
+          add_file_metadata
+        end
+
+        def add_file_metadata
+          case record['file_label']
+          when String
+            labels = record['file_label'].split(/\s*[;|]\s*/)
+          when Array
+            labels = record['file_label']
+          else
+            labels = []
+          end
+          self.parsed_metadata['file_metadata'] = labels.map { |label| { label: label } }
+        end
       end
     end
   end

--- a/lib/extensions/bulkrax/csv_entry/add_file_metadata.rb
+++ b/lib/extensions/bulkrax/csv_entry/add_file_metadata.rb
@@ -1,0 +1,10 @@
+# unmodified from bulkrax
+module Extensions
+  module Bulkrax
+    module CsvEntry
+      module AddFileMetadata
+       # unmodified from bulkrax
+      end
+    end
+  end
+end

--- a/lib/extensions/bulkrax/object_factory/file_factory_metadata.rb
+++ b/lib/extensions/bulkrax/object_factory/file_factory_metadata.rb
@@ -1,0 +1,17 @@
+# unmodified from Bulkrax::FileFactory
+module Extensions
+  module Bulkrax
+    module ObjectFactory
+      module FileFactoryMetadata
+        def file_attributes(update_files = false)
+          @update_files = update_files
+          hash = {}
+          return hash if klass == Collection
+          hash[:uploaded_files] = upload_ids if attributes[:file].present?
+          hash[:remote_files] = new_remote_files if new_remote_files.present?
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/bulkrax/object_factory/file_factory_metadata.rb
+++ b/lib/extensions/bulkrax/object_factory/file_factory_metadata.rb
@@ -1,13 +1,20 @@
-# unmodified from Bulkrax::FileFactory
+# modified from Bulkrax::FileFactory
 module Extensions
   module Bulkrax
     module ObjectFactory
       module FileFactoryMetadata
+        # modified to include :metadata, if available, in :uploaded_files
         def file_attributes(update_files = false)
           @update_files = update_files
           hash = {}
           return hash if klass == Collection
           hash[:uploaded_files] = upload_ids if attributes[:file].present?
+          if attributes[:file_metadata].present?
+            hash[:uploaded_files] = hash[:uploaded_files].map { |id| { id: id } }
+            hash[:uploaded_files].each_with_index do |h, i|
+              h[:metadata] = attributes[:file_metadata][i]
+            end
+          end
           hash[:remote_files] = new_remote_files if new_remote_files.present?
           hash
         end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -74,6 +74,13 @@ Bulkrax::ExportersController.prepend Extensions::Bulkrax::ExportersController::S
 Bulkrax::ApplicationParser.prepend Extensions::Bulkrax::ApplicationParser::IdentifierHash
 Bulkrax::ApplicationMatcher.prepend Extensions::Bulkrax::ApplicationMatcher::ParseSubject
 Bulkrax::ImportWorkCollectionJob.prepend Extensions::Bulkrax::ImportWorkCollectionJob::AddUserToPermissionTemplate
+# bulkrax import of file-specific metadata
+AttachFilesToWorkWithOrderedMembersJob.prepend Extensions::AttachFilesToWorkWithOrderedMembersJob::ImportMetadata
+Bulkrax::CsvEntry.prepend Extensions::Bulkrax::CsvEntry::AddFileMetadata
+Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::FileFactoryMetadata
+Hyrax::Actors::CreateWithFilesActor.prepend Extensions::Hyrax::Actors::CreateWithFilesActor::UploadedFiles
+Hyrax::Actors::CreateWithFilesOrderedMembersActor.prepend Extensions::Hyrax::Actors::CreateWithFilesOrderedMembersActor::AttachFilesWithMetadata
+Hyrax::UploadedFile.prepend Extensions::Hyrax::UploadedFile::UploadedFileMetadata
 
 # actor customizations
 Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest, ESSI::Actors::PerformLaterActor

--- a/lib/extensions/hyrax/actors/create_with_files_actor/uploaded_files.rb
+++ b/lib/extensions/hyrax/actors/create_with_files_actor/uploaded_files.rb
@@ -1,0 +1,19 @@
+# unmodified from hyrax
+module Extensions
+  module Hyrax
+    module Actors
+      module CreateWithFilesActor
+        module UploadedFiles
+          private
+            # Fetch uploaded_files from the database
+            # @param [Integer] uploaded_file_ids
+            # @return [Array<Hyrax::UploadedFile]] array of uploaded files
+            def uploaded_files(uploaded_file_ids)
+              return [] if uploaded_file_ids.empty?
+              ::Hyrax::UploadedFile.find(uploaded_file_ids)
+            end 
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/actors/create_with_files_actor/uploaded_files.rb
+++ b/lib/extensions/hyrax/actors/create_with_files_actor/uploaded_files.rb
@@ -1,16 +1,28 @@
-# unmodified from hyrax
+# modified from hyrax
 module Extensions
   module Hyrax
     module Actors
       module CreateWithFilesActor
         module UploadedFiles
           private
+            # modified to process raw ids or Hashes of :id, :metadata
             # Fetch uploaded_files from the database
-            # @param [Integer] uploaded_file_ids
+            # @param [Integer, Hash] uploaded_file_ids as raw ids or Hash of :id, :metadata values
             # @return [Array<Hyrax::UploadedFile]] array of uploaded files
             def uploaded_files(uploaded_file_ids)
               return [] if uploaded_file_ids.empty?
-              ::Hyrax::UploadedFile.find(uploaded_file_ids)
+              case uploaded_file_ids.first
+              when String, Integer
+                ::Hyrax::UploadedFile.find(uploaded_file_ids)
+              when Hash
+                uploaded_file_ids.map do |hash|
+                  uploaded_file = ::Hyrax::UploadedFile.find(hash[:id])
+                  uploaded_file.metadata = hash[:metadata]
+                  uploaded_file
+                end
+              else
+                []
+              end
             end 
         end
       end

--- a/lib/extensions/hyrax/actors/create_with_files_ordered_members_actor/attach_files_with_metadata.rb
+++ b/lib/extensions/hyrax/actors/create_with_files_ordered_members_actor/attach_files_with_metadata.rb
@@ -1,0 +1,17 @@
+# unmodified from hyrax
+module Extensions
+  module Hyrax
+    module Actors
+      module CreateWithFilesOrderedMembersActor
+        module AttachFilesWithMetadata
+          # @return [TrueClass]
+          def attach_files(files, env)
+            return true if files.blank?
+            ::AttachFilesToWorkWithOrderedMembersJob.perform_later(env.curation_concern, files, env.attributes.to_h.symbolize_keys)
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/actors/create_with_files_ordered_members_actor/attach_files_with_metadata.rb
+++ b/lib/extensions/hyrax/actors/create_with_files_ordered_members_actor/attach_files_with_metadata.rb
@@ -1,13 +1,17 @@
-# unmodified from hyrax
+# modified from hyrax
 module Extensions
   module Hyrax
     module Actors
       module CreateWithFilesOrderedMembersActor
         module AttachFilesWithMetadata
+          # modified to pass files metadata to job
           # @return [TrueClass]
           def attach_files(files, env)
             return true if files.blank?
-            ::AttachFilesToWorkWithOrderedMembersJob.perform_later(env.curation_concern, files, env.attributes.to_h.symbolize_keys)
+            # UploadedFile objects have metadata values, but they seem to be dropped when passed to the job
+            # workaround is storing them in the attributes argument, where they get retained
+            files_metadata = { files_metadata: files.map { |f| f.metadata || {} } }
+            ::AttachFilesToWorkWithOrderedMembersJob.perform_later(env.curation_concern, files, env.attributes.to_h.merge(files_metadata).symbolize_keys)
             true
           end
         end

--- a/lib/extensions/hyrax/uploaded_file/uploaded_file_metadata.rb
+++ b/lib/extensions/hyrax/uploaded_file/uploaded_file_metadata.rb
@@ -1,0 +1,9 @@
+module Extensions
+  module Hyrax
+    module UploadedFile
+      module UploadedFileMetadata
+        # prep monkeypatch
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/uploaded_file/uploaded_file_metadata.rb
+++ b/lib/extensions/hyrax/uploaded_file/uploaded_file_metadata.rb
@@ -2,7 +2,12 @@ module Extensions
   module Hyrax
     module UploadedFile
       module UploadedFileMetadata
-        # prep monkeypatch
+        def self.prepended(base)
+          base.class_eval do
+            # values are stashed in memory, only, and lost in some actor/job transitions
+            attr_accessor :metadata
+          end
+        end
       end
     end
   end

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -81,10 +81,10 @@ describe Hyrax::Actors::FileActor do
           expect(file_actor).to receive(:transform_to_jp2)
           file_actor.ingest_file(io)
         end
-        it 'changes FileSet extension' do
+        it 'leaves label unchanged' do
           expect(file_set.label).not_to match /jp2$/
           file_actor.ingest_file(io)
-          expect(file_set.label).to match /jp2$/
+          expect(file_set.label).not_to match /jp2$/
         end
         it 'changes FileSet mimetype' do
           expect(file_set.mime_type).not_to match /jp2/


### PR DESCRIPTION
In bulkrax CSV import, the `file` column provides a list of filenames to ingest.  This adds a `file_label` column to optionally provide file label values, and discontinues the `transform_to_jp2` method overwriting the file label value (substituting .jp2 for .tif+).

~~A test is currently failing that _looks_ like it would be pertinent, but it's coincidentally one that sometimes fails non-deterministically, so I'm re-running it and hoping it will pass in CircleCI like it does locally.~~ Test is passing after a retry :)