### PR TITLE
[ESSI-1750] support s3 connections patched for HCP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,3 +110,6 @@ gem 'stackprof', require: false
 
 # hold back hydra-head due to implicit Blacklight 7 requirement in newer versions
 gem 'hydra-head', '10.6.1'
+
+# s3 support for HCP
+gem 'aws-sdk-s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1070,6 +1070,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake
   allinson_flex!
+  aws-sdk-s3
   bagit
   better_errors
   binding_of_caller

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -154,3 +154,6 @@ Hyrax::PresenterFactory.prepend Extensions::Hyrax::PresenterFactory::SolrRowLimi
 
 # prevent double-display of description from flexible metadata
 IIIFManifest::ManifestBuilder::RecordPropertyBuilder.prepend Extensions::IIIFManifest::ManifestBuilder::RecordPropertyBuilder::DynamicDescription
+
+# s3 support for HCP
+Seahorse::Client::NetHttp::Handler.prepend Extensions::Seahorse::Client::NetHttp::Handler::HeadersPatch

--- a/lib/extensions/seahorse/client/net_http/handler/headers_patch.rb
+++ b/lib/extensions/seahorse/client/net_http/handler/headers_patch.rb
@@ -1,0 +1,26 @@
+# unmodified from aws-sdk-core:3.131.1
+module Extensions
+  module Seahorse
+    module Client
+      module NetHttp
+        module Handler
+          module HeadersPatch
+            def headers(request)
+              # Net::HTTP adds a default header for accept-encoding (2.0.0+).
+              # Setting a default empty value defeats this.
+              #
+              # Removing this is necessary for most services to not break request
+              # signatures as well as dynamodb crc32 checks (these fail if the
+              # response is gzipped).
+              headers = { 'accept-encoding' => '' }
+              request.headers.each_pair do |key, value|
+                headers[key] = value
+              end
+              headers
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/seahorse/client/net_http/handler/headers_patch.rb
+++ b/lib/extensions/seahorse/client/net_http/handler/headers_patch.rb
@@ -1,4 +1,5 @@
-# unmodified from aws-sdk-core:3.131.1
+# modified from aws-sdk-core:3.131.1
+# provides accept-encoding value of "identity" instead of ""
 module Extensions
   module Seahorse
     module Client
@@ -12,7 +13,7 @@ module Extensions
               # Removing this is necessary for most services to not break request
               # signatures as well as dynamodb crc32 checks (these fail if the
               # response is gzipped).
-              headers = { 'accept-encoding' => '' }
+              headers = { 'accept-encoding' => 'identity' }
               request.headers.each_pair do |key, value|
                 headers[key] = value
               end


### PR DESCRIPTION
While it does appear that a blank header value for `accept-encoding`  should be treated equivalently to an `identity` value, the Hitach HCP S3 server isn't doing that.  So this monkeypatches the aws gem to explicitly provide the accepted header value.