### PR TITLE
Pushes images to packages at ghcr.io

### DIFF
--- a/.github/workflows/dockerimage_test.yml
+++ b/.github/workflows/dockerimage_test.yml
@@ -5,24 +5,44 @@ on:
     branches: [ test-** ]
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
-
-  build:
-
+  build-and-push-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Get branch name
-        id: get_branch
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
-      - name: Build and push to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
         with:
-          name: iublibtech/essi
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_AUTH_TOKEN }}
-          buildargs: SOURCE_COMMIT
-          tags: "test,${{ env.BRANCH_NAME }}"
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          tags: |
+            type=raw,value=test
+            type=raw,value={{branch}}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: SOURCE_COMMIT
         env:
           SOURCE_COMMIT: ${{ github.sha }}


### PR DESCRIPTION
NOTE: The initial impetus to make this switch was the sudden decision by Docker to take away the kind of free team account we use for hosting/pushing images.  They have since [reversed that decision](https://www.docker.com/developers/free-team-faq/?) and this can be de-prioritized.  This draft PR can serve as the example we need to follow when we decide it is a priority, or they change their minds again.

This PR changes the GH Actions workflows to stop building/pushing images to Docker Hub and pushes to packages at ghcr.io instead.  In doing so, it converts steps to those provided by Docker Actions, which are well supported and documented.

Workflows can be tested from this branch, without being merged to main, via the following procedure:

1. Go to Actions tab
2. Choose the desired workflow
3. Pull down "Run workflow" button and switch branch to ghcr-testing
4. Run workflow

The procedure above allows for testing main, test, and stable independently as new definitions are committed to this branch.

Successful test run produced container packages at:
https://github.com/IU-Libraries-Joint-Development/essi/pkgs/container/essi 