### PR TITLE
[i20]-Use IIIF Print's manifest metadata

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build and push to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: iublibtech/essi
         username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/dockerimage_stable.yml
+++ b/.github/workflows/dockerimage_stable.yml
@@ -17,7 +17,7 @@ jobs:
         id: get_branch
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
       - name: Build and push stable to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: iublibtech/essi
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/dockerimage_test.yml
+++ b/.github/workflows/dockerimage_test.yml
@@ -17,7 +17,7 @@ jobs:
         id: get_branch
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
       - name: Build and push to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: iublibtech/essi
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # system dependency image
-FROM ruby:2.7.6-bullseye AS essi-sys-deps
+FROM ruby:2.7.7-bullseye AS essi-sys-deps
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
@@ -13,8 +13,9 @@ RUN groupadd -g ${GROUP_ID} essi && \
     apt-get install -y --no-install-recommends build-essential default-jre-headless libpq-dev nodejs \
       libreoffice-writer libreoffice-impress poppler-utils unzip ghostscript \
       libtesseract-dev libleptonica-dev liblept5 tesseract-ocr \
-      yarn libopenjp2-tools && \
-    apt-get clean all && rm -rf /var/lib/apt/lists/*
+      yarn libopenjp2-tools libjemalloc2 && \
+    apt-get clean all && rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/lib/*-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so.2
 RUN yarn && \
     yarn config set no-progress && \
     yarn config set silent
@@ -24,6 +25,7 @@ RUN mkdir -p /opt/fits && \
 ENV PATH /opt/fits:$PATH
 ENV RUBY_THREAD_MACHINE_STACK_SIZE 16777216
 ENV RUBY_THREAD_VM_STACK_SIZE 16777216
+ENV LD_PRELOAD=/usr/local/lib/libjemalloc.so.2
 
 # Installs specific version of ImageMagick to work with iiif_print
 RUN wget https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0-57.tar.gz && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: d8246e1d95f340ae769dbd05be5a500930c9162a
+  revision: 3dce3e40baeceefda54c03b9405fc94618cce4a2
   ref: main
   specs:
     iiif_print (1.0.0)
@@ -29,6 +29,7 @@ GIT
       nokogiri (>= 1.13.2)
       rails (~> 5.0)
       rdf-vocab (~> 3.0)
+      reform-rails (= 0.2.3)
 
 GEM
   remote: https://rubygems.org/
@@ -271,6 +272,9 @@ GEM
     devise-i18n (1.10.2)
       devise (>= 4.8.0)
     diff-lcs (1.5.0)
+    disposable (0.6.3)
+      declarative (>= 0.0.9, < 1.0.0)
+      representable (>= 3.1.1, < 4)
     docopt (0.5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -693,6 +697,8 @@ GEM
     noid-rails (3.0.3)
       actionpack (>= 5.0.0, < 7)
       noid (~> 0.9)
+    nokogiri (1.14.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     nokogumbo (2.0.5)
@@ -856,6 +862,13 @@ GEM
       redis (>= 3.0.4)
     redlock (1.2.2)
       redis (>= 3.0.0, < 5.0)
+    reform (2.6.2)
+      disposable (>= 0.5.0, < 1.0.0)
+      representable (>= 3.1.1, < 4)
+      uber (< 0.2.0)
+    reform-rails (0.2.3)
+      activemodel (>= 5.0)
+      reform (>= 2.3.1, < 3.0.0)
     regexp_parser (2.5.0)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -1147,4 +1160,4 @@ DEPENDENCIES
   willow_sword!
 
 BUNDLED WITH
-   2.4.7
+   2.4.12

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 516d2b74051f29e86684e3dc891fe1246c0ff250
+  revision: d8246e1d95f340ae769dbd05be5a500930c9162a
   ref: main
   specs:
     iiif_print (1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
-    capybara (3.37.1)
+    capybara (3.39.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -229,7 +229,6 @@ GEM
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
       ssrf_filter (~> 1.0)
-    childprocess (4.1.0)
     clipboard-rails (1.7.1)
     coderay (1.1.3)
     coffee-rails (4.2.2)
@@ -694,9 +693,7 @@ GEM
     noid-rails (3.0.3)
       actionpack (>= 5.0.0, < 7)
       noid (~> 0.9)
-    nokogiri (1.13.10-aarch64-linux)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -746,7 +743,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.2)
       rdf
-    racc (1.6.1)
+    racc (1.6.2)
     rack (2.2.6.4)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
@@ -944,8 +941,7 @@ GEM
     scanf (1.0.0)
     scrub_rb (1.0.1)
     select2-rails (3.5.11)
-    selenium-webdriver (4.2.1)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -246,6 +246,9 @@ test:
       url: "redis://redis_jobs:6379/10"
   rails:
       secret_key_base: c9dd75fe2cce941807d14e04c09aa1f9ae41b6e1f7ba9d2f33142659acf9491f4a7835aad0c4110bf2fa40f2a1e6f7a62048b5a1e1a32c361c8c16d772e40bf0
+  browse_everything:
+    file_system:
+      :home: <%= Rails.root.join("spec/fixtures") %>
 
 production:
   <<: *default

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -3,6 +3,8 @@ default: &default
   password: <%= ESSI.config[:fedora][:password] %>
   url: <%= ESSI.config[:fedora][:url] %>
   base_path: <%= ESSI.config[:fedora][:base_path] %>
+  request:
+    timeout: 300
 development:
   <<: *default
 test:

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -41,4 +41,6 @@ IiifPrint.config do |config|
   config.all_text_generator_function = lambda do |object:|
     IiifPrint::TextExtraction::AltoReader.new(object.extracted_text.content).text if object.extracted_text.present?
   end
+
+  config.iiif_metadata_field_presentation_order = Hyrax.config.iiif_metadata_fields
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -19,12 +19,15 @@ sidekiq_config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'sidek
 # 2. Or the named option is set from the default Sidekiq YAML configuration file if exists
 # 3. Or no options are set and Sidekiq defaults to internal defaults
 
-# If no queue names are set in either the ESSI or Sidekiq config files, the queue
+# The environment variable SIDEKIQ_QUEUES takes priority when setting the monitored queues.
+# If no queue names are set in either the ENV var, the ESSI or Sidekiq config files, the queue
 # will be set to the Sidekiq internal of default.
-Sidekiq.options[:queues] = ESSI.config.fetch(:sidekiq,{}).fetch(:queue_names,nil) ||
-    sidekiq_config.fetch(:queues,['default']) if sidekiq_config
+env_queues = ENV.fetch('SIDEKIQ_QUEUES', '').split(',')
+Sidekiq.options[:queues] = (env_queues.empty? ? nil : env_queues) ||
+  ESSI.config.fetch(:sidekiq,{}).fetch(:queue_names,nil) ||
+  sidekiq_config.fetch(:queues,['default']) if sidekiq_config
 
 # If max_retries is not set in either the ESSI or Sidekiq config files, the value
 # will be set to the Sidekiq internal default (10?)
 Sidekiq.options[:max_retries] = ESSI.config.fetch(:sidekiq,{}).fetch(:max_retries,nil) ||
-    sidekiq_config.fetch(:max_retries,3) if sidekiq_config
+  sidekiq_config.fetch(:max_retries,3) if sidekiq_config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,10 +158,13 @@ services:
       - "8984:8080"
 
   chrome:
-    image: selenium/standalone-chrome:4.2.1
+    image: seleniarm/standalone-chromium:4.9.0
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 2G
+    environment:
+      SE_SCREEN_WIDTH: 1920
+      SE_SCREEN_HEIGHT: 1080
     ports:
       - "4444:4444"
       - "5959:5900"

--- a/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
+++ b/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
@@ -9,25 +9,10 @@ module Extensions
         #
         # @return [Array] array of metadata hashes
         def manifest_metadata
-          metadata = []
-          (static_iiif_metadata_fields | public_view_properties.keys).each do |field|
-            next unless methods.include?(field.to_sym)
-            if field.to_sym.in? (self.class.try(:custom_rendered_properties) || [])
-              value = send(field, options: { iiif: true })
-            else
-              value = send(field)
-            end
-
-            next if value.blank?
-
-            metadata << {
-              'label' => label_for(field),
-              'value' => Array.wrap(value)
-            }
-          end
-          metadata
+          # Using IIIF Print's approach to display parent metadata
+          ::Hyrax::IiifManifestPresenter.new(self).manifest_metadata
         end
- 
+
         def static_iiif_metadata_fields
           ::Hyrax.config.iiif_metadata_fields
         end

--- a/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
+++ b/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
@@ -10,7 +10,9 @@ module Extensions
         # @return [Array] array of metadata hashes
         def manifest_metadata
           # Using IIIF Print's approach to display parent metadata
-          ::Hyrax::IiifManifestPresenter.new(self).manifest_metadata
+          iiif_manifest_presenter = ::Hyrax::IiifManifestPresenter.new(self)
+          iiif_manifest_presenter.ability = current_ability
+          iiif_manifest_presenter.manifest_metadata
         end
 
         def static_iiif_metadata_fields


### PR DESCRIPTION
ref: https://github.com/scientist-softserv/essi/issues/20

This commit updates the #manifest_metadata to use the IIIF Print implementation.  We add a configuration to account for the additional metadata that is found in `ESSI.config[:essi][:metadata][:iiif]`.

<img width="277" alt="image" src="https://user-images.githubusercontent.com/19597776/236059755-09941f70-bc50-415f-8d8b-0798a0cadfa1.png">
