### PR TITLE
Improve Selenium configuration and improve multiplatform support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN groupadd -g ${GROUP_ID} essi && \
       libreoffice-writer libreoffice-impress imagemagick unzip ghostscript \
       libtesseract-dev libleptonica-dev liblept5 tesseract-ocr \
       yarn libopenjp2-tools libjemalloc2 && \
-    apt-get clean all && rm -rf /var/lib/apt/lists/*
+    apt-get clean all && rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/lib/*-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so.2
 RUN yarn && \
     yarn config set no-progress && \
     yarn config set silent
@@ -24,7 +25,7 @@ RUN mkdir -p /opt/fits && \
 ENV PATH /opt/fits:$PATH
 ENV RUBY_THREAD_MACHINE_STACK_SIZE 16777216
 ENV RUBY_THREAD_VM_STACK_SIZE 16777216
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=/usr/local/lib/libjemalloc.so.2
 
 ###
 # ruby dev image

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
       simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
-    capybara (3.37.1)
+    capybara (3.39.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -216,7 +216,6 @@ GEM
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
       ssrf_filter (~> 1.0)
-    childprocess (4.1.0)
     clipboard-rails (1.7.1)
     coderay (1.1.3)
     coffee-rails (4.2.2)
@@ -929,8 +928,7 @@ GEM
     scanf (1.0.0)
     scrub_rb (1.0.1)
     select2-rails (3.5.11)
-    selenium-webdriver (4.2.1)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -246,6 +246,9 @@ test:
       url: "redis://redis_jobs:6379/10"
   rails:
       secret_key_base: c9dd75fe2cce941807d14e04c09aa1f9ae41b6e1f7ba9d2f33142659acf9491f4a7835aad0c4110bf2fa40f2a1e6f7a62048b5a1e1a32c361c8c16d772e40bf0
+  browse_everything:
+    file_system:
+      :home: <%= Rails.root.join("spec/fixtures") %>
 
 production:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,10 +158,13 @@ services:
       - "8984:8080"
 
   chrome:
-    image: selenium/standalone-chrome:4.9.0
+    image: seleniarm/standalone-chromium:4.9.0
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 2G
+    environment:
+      SE_SCREEN_WIDTH: 1920
+      SE_SCREEN_HEIGHT: 1080
     ports:
       - "4444:4444"
       - "5959:5900"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
       - "8984:8080"
 
   chrome:
-    image: selenium/standalone-chrome:4.2.1
+    image: selenium/standalone-chrome:4.9.0
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 2G

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -13,25 +13,27 @@ end
 
 if ENV['IN_DOCKER'].present?
   TEST_HOST='essi.docker'
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    'goog:chromeOptions': {
-      args: %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400] #run without headless so we can see the screenshots
-      #args: %w[headless disable-gpu no-sandbox whitelisted-ips window-size=1400,1400] # run headless
-    }
-  )
+
+  args = %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
+  args.push('headless') if ActiveModel::Type::Boolean.new.cast(ENV.fetch(['CHROME_HEADLESS_MODE'], true))
+
+  options = Selenium::WebDriver::Options.chrome("goog:chromeOptions" => { args: args })
 
   Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
-    d = Capybara::Selenium::Driver.new(app,
-                                       browser: :remote,
-                                       desired_capabilities: capabilities,
-                                       url: ENV['HUB_URL'])
+    driver = Capybara::Selenium::Driver.new(app,
+                                            browser: :remote,
+                                            capabilities: options,
+                                            url: ENV['HUB_URL'])
+
     # Fix for capybara vs remote files. Selenium handles this for us
-    d.browser.file_detector = lambda do |args|
+    driver.browser.file_detector = lambda do |args|
       str = args.first.to_s
       str if File.exist?(str)
     end
-    d
+
+    driver
   end
+
   Capybara.server_host = '0.0.0.0'
   Capybara.server_port = 3010
   # renamed container from app to essi  because the app domain is taken by google(gTLD)

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,7 +15,7 @@ if ENV['IN_DOCKER'].present?
   TEST_HOST='essi.docker'
 
   args = %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
-  args.push('headless') if ActiveModel::Type::Boolean.new.cast(ENV.fetch(['CHROME_HEADLESS_MODE'], true))
+  args.push('headless') if ActiveModel::Type::Boolean.new.cast(ENV.fetch('CHROME_HEADLESS_MODE', true))
 
   options = Selenium::WebDriver::Options.chrome("goog:chromeOptions" => { args: args })
 


### PR DESCRIPTION
This started out as a selenium update, but became "Make feature specs work on an ARM cpu"

- Update selenium and capybara
- Use seleniarm chromium image for ARM support
- Respect platform when setting up jemalloc
  - _This one had an innocuous warning at rails startup, but then caused Fedora to respond with a 500 because that "harmless" warning was being included as part of the mime type returned by the characterization tools._
- Set chromium resolution from ENV to workaround broken support for doing it from the spec.
- Add spec/fixtures to browse everything for testing in docker.