### PR TITLE
[ESSI-1805] [ESSI-1812] ingest prederived characterization

### DIFF
--- a/app/helpers/prederivation_helper.rb
+++ b/app/helpers/prederivation_helper.rb
@@ -1,0 +1,44 @@
+module PrederivationHelper
+  def work_root_name(filename)
+    filename.split('/').last.split('-').first
+  end
+
+  def derivatives_folder_for(filename, type: '')
+    derivatives_folder = ESSI.config.dig(:essi, :derivatives_folder)
+    return false unless derivatives_folder
+    folders = Array.wrap(derivatives_folder)
+    folders << type.downcase if path_includes_type?
+    folders << work_root_name(filename) if path_includes_work_root_name?
+    File.join(derivatives_folder, type.downcase, work_root_name(filename))
+  end
+
+  def pre_derived_file(filename, type: '', suffix: 'xml')
+    Rails.logger.info "Checking for a Pre-derived #{type} folder."
+    derivatives_folder = derivatives_folder_for(filename, type: type)
+    return false unless derivatives_folder && Dir.exists?(derivatives_folder.to_s)
+
+    Rails.logger.info "Checking for a Pre-derived #{type} file."
+    if file_includes_type?
+      pre_derived_filename = "#{File.basename(filename, '.*')}-#{type.downcase}.#{suffix}"
+    else
+      pre_derived_filename = "#{File.basename(filename, '.*')}.#{suffix}"
+    end
+    pre_derived_file = File.join(derivatives_folder, pre_derived_filename)
+    return false unless File.exist?(pre_derived_file)
+
+    Rails.logger.info "Using Pre-derived #{type} file."
+    pre_derived_file
+  end
+
+  def path_includes_type?
+    ESSI.config.dig(:essi, :derivatives_type_subfolder)
+  end
+
+  def path_includes_work_root_name?
+    ESSI.config.dig(:essi, :derivatives_work_subfolder)
+  end
+
+  def file_includes_type?
+    ESSI.config.dig(:essi, :derivatives_type_suffix)
+  end
+end

--- a/app/services/essi/file_set_ocr_derivatives_service.rb
+++ b/app/services/essi/file_set_ocr_derivatives_service.rb
@@ -7,8 +7,6 @@ module ESSI
     end
 
     def create_derivatives(filename)
-      return if ESSI.config.dig(:essi, :skip_derivatives)
-
       # FIXME: Fix MiniMagick problems so we can still call super here to create thumbnails?
       # When we call create_derivatives upstream via super, we initiate thumbnail creation via MiniMagick.
       # This is randomly failing, which causes OCR jobs to get missed on affected FileSets.

--- a/app/services/processors/ocr.rb
+++ b/app/services/processors/ocr.rb
@@ -1,6 +1,7 @@
 module Processors
   class OCR < Hydra::Derivatives::Processors::Processor
     include Hydra::Derivatives::Processors::ShellBasedProcessor
+    extend PrederivationHelper
 
     def self.encode(path, options, output_file)
       file_name = File.basename(path)
@@ -26,15 +27,7 @@ module Processors
     end
 
     def self.pre_ocr_file(filename)
-      Rails.logger.info 'Checking for a Pre-derived OCR folder.'
-      return false unless ESSI.config.dig(:essi, :derivatives_folder)
-
-      Rails.logger.info 'Checking for a Pre-derived OCR file.'
-      ocr_filename = "#{File.basename(filename, '.*')}-alto.xml"
-      ocr_file = File.join(ESSI.config.dig(:essi, :derivatives_folder), ocr_filename)
-      return false unless File.exist?(ocr_file)
-
-      ocr_file
+      self.pre_derived_file(filename, type: 'OCR')
     end
 
     def self.preprocess_ocr?

--- a/app/services/processors/ocr.rb
+++ b/app/services/processors/ocr.rb
@@ -9,6 +9,8 @@ module Processors
       if existing_file
         Rails.logger.info "Copying Pre-derived OCR file #{existing_file} to #{output_file}."
         execute "cp #{existing_file} #{output_file}"
+      elsif skip_derivatives?
+        Rails.logger.info "No pre-derived file provided; skipping OCR generation"
       elsif preprocess_ocr?
         Rails.logger.info "Pre-processing #{path} before OCR derivation."
         bitonal_file = ocr_clean_file(path)
@@ -46,6 +48,10 @@ module Processors
 
     def self.remove_tmp_file(file)
       execute "rm #{file}"
+    end
+
+    def self.skip_derivatives?
+      ESSI.config.dig(:essi, :skip_derivatives)
     end
 
     private

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -112,7 +112,8 @@ default: &default
     master_file_service_url: http://purl.dlib.indiana.edu/iudl/variations/master
     purl_redirect_url: /concern/works/%s
     skip_derivatives: false
-    derivatives_folder: false
+    derivatives_folder: 'staged_files'
+    characterization_folder: 'staged_files'
     ocr_language: [eng]
     ocr_preprocessor_path: <%= Rails.root.join('bin', 'ocr_preprocessor') %>
     create_ocr_files: true

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -113,7 +113,9 @@ default: &default
     purl_redirect_url: /concern/works/%s
     skip_derivatives: false
     derivatives_folder: 'staged_files'
-    characterization_folder: 'staged_files'
+    derivatives_type_suffix: true
+    derivatives_type_subfolder: true
+    derivatives_work_subfolder: true
     ocr_language: [eng]
     ocr_preprocessor_path: <%= Rails.root.join('bin', 'ocr_preprocessor') %>
     create_ocr_files: true

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -112,9 +112,10 @@ default: &default
     master_file_service_url: http://purl.dlib.indiana.edu/iudl/variations/master
     purl_redirect_url: /concern/works/%s
     skip_derivatives: false
-    derivatives_folder: false
     derivatives_folder: 'staged_files'
-    characterization_folder: 'staged_files'
+    derivatives_type_suffix: true
+    derivatives_type_subfolder: true
+    derivatives_work_subfolder: true
     ocr_language: [eng]
     ocr_preprocessor_path: <%= Rails.root.join('bin', 'ocr_preprocessor') %>
     create_ocr_files: true

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -113,6 +113,8 @@ default: &default
     purl_redirect_url: /concern/works/%s
     skip_derivatives: false
     derivatives_folder: false
+    derivatives_folder: 'staged_files'
+    characterization_folder: 'staged_files'
     ocr_language: [eng]
     ocr_preprocessor_path: <%= Rails.root.join('bin', 'ocr_preprocessor') %>
     create_ocr_files: true

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -154,3 +154,6 @@ Hyrax::PresenterFactory.prepend Extensions::Hyrax::PresenterFactory::SolrRowLimi
 
 # prevent double-display of description from flexible metadata
 IIIFManifest::ManifestBuilder::RecordPropertyBuilder.prepend Extensions::IIIFManifest::ManifestBuilder::RecordPropertyBuilder::DynamicDescription
+
+# read pre-supplied file characterization, if present
+Hydra::Works::CharacterizationService.prepend Extensions::Hydra::Works::CharacterizationService::Precharacterization

--- a/lib/extensions/hydra/works/characterization_service/precharacterization.rb
+++ b/lib/extensions/hydra/works/characterization_service/precharacterization.rb
@@ -1,4 +1,4 @@
-# unmodified from Hydra::Works
+# modified from Hydra::Works
 module Extensions
   module Hydra::Works
     module CharacterizationService
@@ -9,10 +9,28 @@ module Extensions
         # Get the terms (and their values) from the extracted metadata
         # Assign the values of the terms to the properties of the object
         def characterize
-          content = source_to_content
-          extracted_md = extract_metadata(content)
+          existing_file = precharacterization(source)
+          if existing_file
+            extracted_md = File.read(existing_file)
+          else
+            content = source_to_content
+            extracted_md = extract_metadata(content)
+          end
           terms = parse_metadata(extracted_md)
           store_metadata(terms)
+        end
+  
+        def precharacterization(filename)
+          Rails.logger.info 'Checking for a Pre-derived characterization folder.'
+          return false unless ESSI.config.dig(:essi, :characterization_folder)
+    
+          Rails.logger.info 'Checking for a Pre-derived characterization file.'
+          characterization_filename = "#{File.basename(filename, '.*')}-characterization.xml"
+          characterization_file = File.join(ESSI.config.dig(:essi, :characterization_folder), characterization_filename)
+          return false unless File.exist?(characterization_file)
+    
+          Rails.logger.info 'Using Pre-derived characterization file.'
+          characterization_file
         end
       end
     end

--- a/lib/extensions/hydra/works/characterization_service/precharacterization.rb
+++ b/lib/extensions/hydra/works/characterization_service/precharacterization.rb
@@ -1,0 +1,20 @@
+# unmodified from Hydra::Works
+module Extensions
+  module Hydra::Works
+    module CharacterizationService
+      module Precharacterization
+
+        # Get given source into form that can be passed to Hydra::FileCharacterization
+        # Use Hydra::FileCharacterization to extract metadata (an OM XML document)
+        # Get the terms (and their values) from the extracted metadata
+        # Assign the values of the terms to the properties of the object
+        def characterize
+          content = source_to_content
+          extracted_md = extract_metadata(content)
+          terms = parse_metadata(extracted_md)
+          store_metadata(terms)
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hydra/works/characterization_service/precharacterization.rb
+++ b/lib/extensions/hydra/works/characterization_service/precharacterization.rb
@@ -3,6 +3,7 @@ module Extensions
   module Hydra::Works
     module CharacterizationService
       module Precharacterization
+        include PrederivationHelper
 
         # Get given source into form that can be passed to Hydra::FileCharacterization
         # Use Hydra::FileCharacterization to extract metadata (an OM XML document)
@@ -21,16 +22,7 @@ module Extensions
         end
   
         def precharacterization(filename)
-          Rails.logger.info 'Checking for a Pre-derived characterization folder.'
-          return false unless ESSI.config.dig(:essi, :characterization_folder)
-    
-          Rails.logger.info 'Checking for a Pre-derived characterization file.'
-          characterization_filename = "#{File.basename(filename, '.*')}-characterization.xml"
-          characterization_file = File.join(ESSI.config.dig(:essi, :characterization_folder), characterization_filename)
-          return false unless File.exist?(characterization_file)
-    
-          Rails.logger.info 'Using Pre-derived characterization file.'
-          characterization_file
+          pre_derived_file(filename, type: 'characterization')
         end
       end
     end

--- a/spec/services/hyrax/derivative_service_spec.rb
+++ b/spec/services/hyrax/derivative_service_spec.rb
@@ -64,9 +64,16 @@ RSpec.describe Hyrax::DerivativeService do
           ESSI.config[:essi][:skip_derivatives] = true
           ESSI.config[:essi][:create_ocr_files] = true
         end
-        it 'does not call OCRunner' do
-          expect(OCRRunner).not_to receive(:create)
+        it 'calls OCRunner' do
+          expect(OCRRunner).to receive(:create)
           fsd_service.create_derivatives(image_file)
+        end
+        # simulate action of stubbed OCRRunner#create
+        it 'skips OCR generation in OCR Processor' do
+          expect(Rails.logger).to receive(:info).with("Checking for a Pre-derived OCR folder.")
+          expect(Processors::OCR).to receive(:skip_derivatives?).and_return(true)
+          expect(Rails.logger).to receive(:info).with("No pre-derived file provided; skipping OCR generation")
+          Processors::OCR.encode(image_file, {}, '')
         end
       end
       context 'with :skip_derivatives not set' do


### PR DESCRIPTION
Follows the same pattern we have for using pre-derived OCR:

1. Look for a pre-derived file, in the configured directory, with a filename matching the original but substituting "-characterization.xml" for the original file suffix
2. If found, use that file; if not, revert to original behavior (generating characterization via the hyrax stack)

Third commit:
1. refactors into a module, code that was common across the two pre-derivation cases (file characterization, OCR)
2. allows for both IUPUI and IUB style of specifying a derivation folder -- a single folder for everything, vs nested work_id/type subfolders

Fourth commit changes the `skip_derivatives` setting from (when true) doing a "hard skip" of OCR (neither generating it, nor reading pre-provided) to a "soft skip" (using pre-derived when provided, but not generating if nothing was pre-derived)