### PR TITLE
Skip attach_files when remote_files array is empty

### DIFF
--- a/app/actors/essi/actors/create_with_remote_files_ordered_members_structure_actor.rb
+++ b/app/actors/essi/actors/create_with_remote_files_ordered_members_structure_actor.rb
@@ -17,7 +17,7 @@ module ESSI
         # @param [HashWithIndifferentAccess] remote_files
         # @return [TrueClass]
         def attach_files(env, remote_files)
-          return true unless remote_files
+          return true if remote_files.blank?
           env.store(self, :ordered_members, env.curation_concern.ordered_members.to_a)
           remote_files.each do |file_info|
             next if file_info.blank? || file_info[:url].blank?


### PR DESCRIPTION
This is a small bug fix that will skip the whole attach_files method when the remote_files argument is an empty array (which occurs when updating a work with no file changes). This should avoid rebuilding the ordered_members data when it is not going to be changed anyways.