### PR TITLE
Essi-1809 derivatives/imageproc queue; Sidekiq 7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
+    connection_pool (2.4.0)
     countries (3.1.0)
       i18n_data (~> 0.11.0)
       sixarm_ruby_unaccent (~> 1.1)
@@ -731,7 +731,7 @@ GEM
       rails (>= 5.0, < 6.2)
       rdf
     racc (1.6.2)
-    rack (2.2.6.4)
+    rack (2.2.7)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
     rack-proxy (0.7.2)
@@ -838,7 +838,9 @@ GEM
       tilt
     redic (1.5.3)
       hiredis
-    redis (4.8.0)
+    redis (4.8.1)
+    redis-client (0.14.1)
+      connection_pool
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
     redlock (1.2.2)
@@ -942,10 +944,11 @@ GEM
       rdf-xsd (~> 3.2)
       sparql (~> 3.2)
       sxp (~> 1.2)
-    sidekiq (6.5.7)
-      connection_pool (>= 2.2.5)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.1.0)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
     signet (0.16.1)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.0)

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,5 +1,5 @@
 class CharacterizeJob < ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
+  queue_as 'derivatives'
 
   # Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository
   # and runs characterization on that file.
@@ -19,7 +19,7 @@ class CharacterizeJob < ApplicationJob
     file_set.update_index
     file_set.parent&.in_collections&.each(&:update_index)
     derivation_path = filepath unless derivation_path && File.exist?(derivation_path)
-    CreateDerivativesJob.perform_later(file_set, file_id, derivation_path)
+    CreateDerivativesJob.set(queue: queue_name).perform_later(file_set, file_id, derivation_path)
     unlink_filepath(filepath, delete_characterization_path.to_s) if delete_characterization_path
   end
 

--- a/app/jobs/concerns/sequential_job.rb
+++ b/app/jobs/concerns/sequential_job.rb
@@ -35,4 +35,13 @@ module SequentialJob
       end
     end
   end
+
+  def perform_later(*args)
+    if Thread.current[:seq_job_parent_id].nil?  # Lowest perform_later call in stack, act normal.
+      super(*args)
+    else  # Nested perform call, store job for later.
+      Rails.logger.debug { "SequentialJob: Thread storing #{self.name} with #{Thread.current[:seq_job_queue].size} jobs in the queue." }
+      Thread.current[:seq_job_queue].push(new(*args))
+    end
+  end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,31 +3,32 @@
 
 redis_config = ESSI.config[:redis][:sidekiq]
 
+# Retrieve Sidekiq options set in the default configuration file
+sidekiq_config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'sidekiq.yml'))).result,[Symbol], [], true)
+
+env_queues = ENV.fetch('SIDEKIQ_QUEUES', '').split(',')
+
 Sidekiq.configure_server do |c|
   c.redis = redis_config
+
+  # The following calls to Sidekiq.options establishes the following order of precedence:
+  # 1. The named option is set from the ESSI configuration file if exists
+  # 2. Or the named option is set from the default Sidekiq YAML configuration file if exists
+  # 3. Or no options are set and Sidekiq defaults to internal defaults
+
+  # The environment variable SIDEKIQ_QUEUES takes priority when setting the monitored queues.
+  # If no queue names are set in either the ENV var, the ESSI or Sidekiq config files, the queue
+  # will be set to the Sidekiq internal of default.
+  c.queues = (env_queues.empty? ? nil : env_queues) ||
+    ESSI.config.fetch(:sidekiq,{}).fetch(:queue_names,nil) ||
+    sidekiq_config.fetch(:queues,['default']) if sidekiq_config
+
+  # If max_retries is not set in either the ESSI or Sidekiq config files, the value
+  # will be set to the Sidekiq internal default (10?)
+  c[:max_retries] = ESSI.config.fetch(:sidekiq,{}).fetch(:max_retries,nil) ||
+    sidekiq_config.fetch(:max_retries,3) if sidekiq_config
 end
 
 Sidekiq.configure_client do |c|
   c.redis = redis_config
 end
-
-# Retrieve Sidekiq options set in the default configuration file
-sidekiq_config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'sidekiq.yml'))).result,[Symbol], [], true)
-
-# The following calls to Sidekiq.options establishes the following order of precedence:
-# 1. The named option is set from the ESSI configuration file if exists
-# 2. Or the named option is set from the default Sidekiq YAML configuration file if exists
-# 3. Or no options are set and Sidekiq defaults to internal defaults
-
-# The environment variable SIDEKIQ_QUEUES takes priority when setting the monitored queues.
-# If no queue names are set in either the ENV var, the ESSI or Sidekiq config files, the queue
-# will be set to the Sidekiq internal of default.
-env_queues = ENV.fetch('SIDEKIQ_QUEUES', '').split(',')
-Sidekiq.options[:queues] = (env_queues.empty? ? nil : env_queues) ||
-  ESSI.config.fetch(:sidekiq,{}).fetch(:queue_names,nil) ||
-  sidekiq_config.fetch(:queues,['default']) if sidekiq_config
-
-# If max_retries is not set in either the ESSI or Sidekiq config files, the value
-# will be set to the Sidekiq internal default (10?)
-Sidekiq.options[:max_retries] = ESSI.config.fetch(:sidekiq,{}).fetch(:max_retries,nil) ||
-  sidekiq_config.fetch(:max_retries,3) if sidekiq_config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     depends_on:
       - essi
       - worker
+      - derivatives
 
   essi:
     << : *default-app
@@ -54,6 +55,13 @@ services:
 
   worker:
     << : *default-app
+    command: bash -c "bundle install && bundle exec sidekiq -c 4"
+
+  derivatives:
+    <<: *default-app
+    environment:
+      IN_DOCKER: 'true'
+      SIDEKIQ_QUEUES: imageproc,derivatives
     command: bash -l -c "bundle install && bundle exec sidekiq -c 4"
 
   db:


### PR DESCRIPTION
Update to Sidekiq 7 which required refactoring of our configuration.
CharacterizationJob is sent to the 'derivatives' queue, and CreateDerivativesJob follows suit.
A dedicated sidekiq worker process is setup to allow parallel processing.
