### PR TITLE
Adding jobs to provide finer control over batch index operations

### DIFF
--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Triggers reindexing on all collections
+class ReindexCollectionsJob < ApplicationJob
+  def perform
+    Collection.find_each do |col|
+      Rails.logger.info "Reindexing #{col.class}: #{col.id}"
+      col.update_index
+    end
+  end
+end

--- a/app/jobs/reindex_file_sets_job.rb
+++ b/app/jobs/reindex_file_sets_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Triggers reindexing on all FileSets
+class ReindexFileSetsJob < ApplicationJob
+  def perform
+    FileSet.find_each do |fs|
+      Rails.logger.info "Reindexing #{fs.class}: #{fs.id}"
+      fs.update_index
+    end
+  end
+end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Triggers reindexing on all works
+class ReindexWorksJob < ApplicationJob
+  def perform
+    Hyrax.config.registered_curation_concern_types.each do |work_type|
+      work_type.constantize.find_each do |work|
+        Rails.logger.info "Reindexing #{work.class}: #{work.id}"
+        work.update_index
+      end
+    end
+  end
+end


### PR DESCRIPTION
A starting point for jobs that can reindex works, file_sets, or collections independently.  

Note that the `update_index` method for Collection triggers the nested indexer, which we want to find a way around before using for large amounts of data.