### PR TITLE
Use legacy openssl option for node 18 & webpack 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ default_environment: &default_environment
   WD_INSTALL_DIR: ./webdriver
   KARMA_BROWSER: ChromeHeadless
   KARMA_HOSTNAME: localhost
+  NODE_OPTIONS: --openssl-legacy-provider
 
 jobs:
   build:


### PR DESCRIPTION
Fixes CircleCI build

Webpack 4 is incompatible with the new OpenSSL support in Node 18. We're likely stuck on webpack 4 as it's a direct dependency of rails webpacker.