### PR TITLE
[ESSI-1822] remove hyrax-inherited display label for contributor

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,7 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+    search:
+      fields:
+        show:
+          contributor: # nullify to override hyrax inheritance, use flexible metadata label


### PR DESCRIPTION
The flexible metadata label is being ignored because [the hyrax attribute render preferentially uses blacklight-configured values, if provided](https://github.com/samvera/hyrax/blob/v2.9.6/app/renderers/hyrax/renderers/attribute_renderer.rb#L50-L60) and [we're inheriting such values from hyrax](https://github.com/samvera/hyrax/blob/v2.9.6/config/locales/hyrax.en.yml#L16-L28).

This resolves the issue by nullifying the hyrax-inherited value.  Possibly alternative approaches include rewriting `#label` to give preference to flexible metadata label values over hardcoded blacklight locale config values.  Also note that we should expect to find the same behavior with the other properties given search.fields.show values:
* admin_set
* based_near_label
* keyword