### PR TITLE
Handle skipping OCR

### DIFF
--- a/app/helpers/prederivation_helper.rb
+++ b/app/helpers/prederivation_helper.rb
@@ -9,7 +9,7 @@ module PrederivationHelper
     folders = Array.wrap(derivatives_folder)
     folders << type.downcase if path_includes_type?
     folders << work_root_name(filename) if path_includes_work_root_name?
-    File.join(derivatives_folder, type.downcase, work_root_name(filename))
+    File.join(folders)
   end
 
   def pre_derived_file(filename, type: '', suffix: 'xml')

--- a/app/services/processors/ocr.rb
+++ b/app/services/processors/ocr.rb
@@ -23,11 +23,14 @@ module Processors
     end
 
     # imported from hydra-derivatives
+    # modified to skip calling output_file_service if file not present
     def encode_file(file_suffix, options)
       temp_file_name = output_file(file_suffix)
       self.class.encode(source_path, options, temp_file_name)
-      output_file_service.call(File.open(temp_file_name, 'rb'), directives)
-      File.unlink(temp_file_name)
+      if File.exist?(temp_file_name)
+        output_file_service.call(File.open(temp_file_name, 'rb'), directives)
+        File.unlink(temp_file_name)
+      end
     end
 
     def options_for(_format)

--- a/app/services/processors/ocr.rb
+++ b/app/services/processors/ocr.rb
@@ -22,6 +22,14 @@ module Processors
       end
     end
 
+    # imported from hydra-derivatives
+    def encode_file(file_suffix, options)
+      temp_file_name = output_file(file_suffix)
+      self.class.encode(source_path, options, temp_file_name)
+      output_file_service.call(File.open(temp_file_name, 'rb'), directives)
+      File.unlink(temp_file_name)
+    end
+
     def options_for(_format)
       {
         options: string_options

--- a/spec/services/hyrax/derivative_service_spec.rb
+++ b/spec/services/hyrax/derivative_service_spec.rb
@@ -66,12 +66,20 @@ RSpec.describe Hyrax::DerivativeService do
           expect(OCRRunner).to receive(:create)
           fsd_service.create_derivatives(image_file)
         end
-        # simulate action of stubbed OCRRunner#create
+        # simulate action of stubbed OCRRunner#create via Processor::OCR#encode_file
         it 'skips OCR generation in OCR Processor' do
           expect(Rails.logger).to receive(:info).with("Checking for a Pre-derived OCR folder.")
           expect(Processors::OCR).to receive(:skip_derivatives?).and_return(true)
           expect(Rails.logger).to receive(:info).with("No pre-derived file provided; skipping OCR generation")
-          Processors::OCR.encode(image_file, {}, '')
+          Processors::OCR.new(image_file,
+                              { label: "test123-alto.xml",
+                                mime_type: 'text/html; charset=utf-8',
+                                format: 'xml',
+                                container: 'extracted_text',
+                                language: 'en',
+                                url: 'www.example.com/test',
+                                source_file_service: ::Hydra::Derivatives.source_file_service },
+                              output_file_service: nil).process
         end
       end
       context 'with :skip_derivatives not set' do


### PR DESCRIPTION
It looks like the #encode_file action presumes #encode output something:
https://github.com/samvera/hydra-derivatives/blob/v3.6.1/lib/hydra/derivatives/processors/shell_based_processor.rb#L30-L35

But, it's possible that it didn't, in the case where we've got "skip_derivatives: true" and no pre-derived OCR was provided.

This changes #encode_file to only try to attach the file output by #encode, if that file actually exists.