### PR TITLE
ESSI-1837 Load all work classes at startup

### DIFF
--- a/lib/extensions/allinson_flex_extensions.rb
+++ b/lib/extensions/allinson_flex_extensions.rb
@@ -29,3 +29,9 @@ AllinsonFlex::ProfileProperty.include Extensions::AllinsonFlex::IncludeProfilePr
 
 # profile texts
 AllinsonFlex::ProfileText.include Extensions::AllinsonFlex::IncludeProfileText
+
+# Create transient new objects for all registered work types. Attempts to work around failures to
+# define methods for some properties when loading works (e.g. missing ocr_state)
+Hyrax.config.registered_curation_concern_types.each do |klass|
+  klass.constantize.new
+end

--- a/lib/extensions/allinson_flex_extensions.rb
+++ b/lib/extensions/allinson_flex_extensions.rb
@@ -32,6 +32,8 @@ AllinsonFlex::ProfileText.include Extensions::AllinsonFlex::IncludeProfileText
 
 # Create transient new objects for all registered work types. Attempts to work around failures to
 # define methods for some properties when loading works (e.g. missing ocr_state)
-Hyrax.config.registered_curation_concern_types.each do |klass|
-  klass.constantize.new
+unless ActiveRecord::Base.connection.migration_context.needs_migration?
+  Hyrax.config.registered_curation_concern_types.each do |klass|
+    klass.constantize.new
+  end
 end


### PR DESCRIPTION
Create transient new objects for all registered work types. Attempts to work around failures to define methods for some properties when loading works (e.g. missing ocr_state)