### PR TITLE
Essi-1838 Handle IO::WaitReadable errors

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -160,3 +160,6 @@ Seahorse::Client::NetHttp::Handler.prepend Extensions::Seahorse::Client::NetHttp
 
 # read pre-supplied file characterization, if present
 Hydra::Works::CharacterizationService.prepend Extensions::Hydra::Works::CharacterizationService::Precharacterization
+
+# Patch ShellBasedProcessor to handle IO::EAGAINWaitReadable
+Hydra::Derivatives::Processors::Jpeg2kImage.prepend Extensions::Hydra::Derivatives::Processors::WaitReadable

--- a/lib/extensions/hydra/derivatives/processors/wait_readable.rb
+++ b/lib/extensions/hydra/derivatives/processors/wait_readable.rb
@@ -1,0 +1,50 @@
+module Extensions
+  module Hydra
+    module Derivatives
+      module Processors
+        module WaitReadable
+          def self.prepended(base)
+            base.class_eval do
+              # Unmodified execute_without_timeout from hydra-derivatives
+              def self.execute_without_timeout(command, context)
+                err_str = ''
+                stdin, stdout, stderr, wait_thr = popen3(command)
+                context[:pid] = wait_thr[:pid]
+                files = [stderr, stdout]
+                stdin.close
+
+                until all_eof?(files)
+                  ready = IO.select(files, nil, nil, 60)
+
+                  next unless ready
+                  readable = ready[0]
+                  readable.each do |f|
+                    fileno = f.fileno
+
+                    begin
+                      data = f.read_nonblock(BLOCK_SIZE)
+
+                      case fileno
+                      when stderr.fileno
+                        err_str << data
+                      end
+                    rescue EOFError
+                      Hydra::Derivatives::Logger.debug "Caught an eof error in ShellBasedProcessor"
+                      # No big deal.
+                    end
+                  end
+                end
+
+                stdout.close
+                stderr.close
+                exit_status = wait_thr.value
+
+                raise "Unable to execute command \"#{command}\". Exit code: #{exit_status}\nError message: #{err_str}" unless exit_status.success?
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Patch Jpeg2k ShellBasedProcessor to handle IO::WaitReadable errors

This patches a method from ShellBasedProcessor but Processors::Jpeg2kImage is what the patch needs
to be applied to because it includes ShellBasedProcessor.

Can be removed when we start using hydra-derivatives 3.8