### PR TITLE
load default AdminSet prior to allinson_flex initialization

### DIFF
--- a/lib/extensions/allinson_flex_extensions.rb
+++ b/lib/extensions/allinson_flex_extensions.rb
@@ -30,6 +30,19 @@ AllinsonFlex::ProfileProperty.include Extensions::AllinsonFlex::IncludeProfilePr
 # profile texts
 AllinsonFlex::ProfileText.include Extensions::AllinsonFlex::IncludeProfileText
 
+ # Recreate only the AdminSet, not the associated permission template that is still in the database.
+ # (Instead of AdminSet.find_or_create_default_admin_set_id)
+if AdminSet.count.zero?
+   AdminSet.create id: AdminSet::DEFAULT_ID, title: Array.wrap(AdminSet::DEFAULT_TITLE)
+ end
+# recreate permission template if it's not in the database, after all
+if ActiveRecord::Base.connection.table_exists?('permission_templates') && Hyrax::PermissionTemplate.count.zero?
+  hascs = Hyrax::AdminSetCreateService.new(admin_set: AdminSet.first, creating_user: nil)
+  pt = hascs.send :create_permission_template
+  workflow = hascs.send :create_workflows_for, permission_template: pt
+  access = hascs.send :create_default_access_for, permission_template: pt, workflow: workflow
+end
+
 # Create transient new objects for all registered work types. Attempts to work around failures to
 # define methods for some properties when loading works (e.g. missing ocr_state)
 unless ActiveRecord::Base.connection.migration_context.needs_migration?


### PR DESCRIPTION
In draft status pending a rewrite, to an approach that works across all of local, docker, circleCI, and production.

I'm coming across two issues:
**1) AdminSet**
We ensure the existence of the default AdminSet at the start of each test suite:
https://github.com/IU-Libraries-Joint-Development/essi/blob/v1.4.8/spec/rails_helper.rb#L85-L88
but now that we also load allinson_flex classes during server initialization:
https://github.com/IU-Libraries-Joint-Development/essi/blob/v1.4.8/lib/extensions/allinson_flex_extensions.rb#L33-L38
and that happens, first, I'm finding that specs choke during the allinson_flex initialization, here:
https://github.com/IU-Libraries-Joint-Development/essi/blob/v1.4.8/app/services/allinson_flex/dynamic_schema_service.rb#L141
since the default admin set hasn't necessarily been created, yet.

**2) Permission Templates and Workflow**
In `spec/rails_helper.rb`, we've got a block to directly create the default AdminSet, bypassing the normal create service under the rationale that the permission template records have persisted.  In my experience locally, the permission templates haven't necessarily been created -- so this adds an "if" block to create them, if needed.