### PR TITLE
Adding CORS allow headers to the PURL resolver's response.

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -1,4 +1,5 @@
 class PurlController < ApplicationController
+  before_action :add_headers
   def default
     set_object(WORK_LOOKUPS, split_id: true)
     respond_to do |f|
@@ -95,5 +96,9 @@ class PurlController < ApplicationController
 
     def normalize_number(n)
       [n.to_i - 1, 0].max
+    end
+
+    def add_headers
+      headers['Access-Control-Allow-Origin'] = '*'
     end
 end


### PR DESCRIPTION
For cases where other services want to pull a manifest from Digital Collections into a viewer, the CORS headers must be set to allow access across domains.  We already [add the headers in the `manifest` action](https://github.com/IU-Libraries-Joint-Development/essi/blob/main/app/controllers/concerns/essi/works_controller_behavior.rb#L25), but the first point of entry to get to a manifest is usually going to be the DC PURL resolver, which lacks the headers.

Though I would prefer that the stack not be this opinionated and let the web proxies handle this detail, we don't control all deployments (i.e. public DC in ESS) so we can't reliably ensure that the headers will be present.