### PR TITLE
Move AdminSet, workflow initialization inside migration safety check

### DIFF
--- a/lib/extensions/allinson_flex_extensions.rb
+++ b/lib/extensions/allinson_flex_extensions.rb
@@ -30,23 +30,24 @@ AllinsonFlex::ProfileProperty.include Extensions::AllinsonFlex::IncludeProfilePr
 # profile texts
 AllinsonFlex::ProfileText.include Extensions::AllinsonFlex::IncludeProfileText
 
- # Recreate only the AdminSet, not the associated permission template that is still in the database.
- # (Instead of AdminSet.find_or_create_default_admin_set_id)
-if AdminSet.count.zero?
-   AdminSet.create id: AdminSet::DEFAULT_ID, title: Array.wrap(AdminSet::DEFAULT_TITLE)
- end
-# recreate permission template if it's not in the database, after all
-if ActiveRecord::Base.connection.table_exists?('permission_templates') && Hyrax::PermissionTemplate.count.zero?
-  hascs = Hyrax::AdminSetCreateService.new(admin_set: AdminSet.first, creating_user: nil)
-  pt = hascs.send :create_permission_template
-  workflow = hascs.send :create_workflows_for, permission_template: pt
-  access = hascs.send :create_default_access_for, permission_template: pt, workflow: workflow
-end
-
-# Create transient new objects for all registered work types. Attempts to work around failures to
-# define methods for some properties when loading works (e.g. missing ocr_state)
 unless ActiveRecord::Base.connection.migration_context.needs_migration?
+  # Create transient new objects for all registered work types. Attempts to work around failures to
+  # define methods for some properties when loading works (e.g. missing ocr_state)
   Hyrax.config.registered_curation_concern_types.each do |klass|
     klass.constantize.new
   end
+
+  # Recreate only the AdminSet, not the associated permission template that is still (?) in the database.
+  # (Instead of AdminSet.find_or_create_default_admin_set_id)
+  if AdminSet.count.zero?
+    AdminSet.create id: AdminSet::DEFAULT_ID, title: Array.wrap(AdminSet::DEFAULT_TITLE)
+  end
+  # recreate permission template if it's not in the database, after all
+  if ActiveRecord::Base.connection.table_exists?('permission_templates') && Hyrax::PermissionTemplate.count.zero?
+    hascs = Hyrax::AdminSetCreateService.new(admin_set: AdminSet.first, creating_user: nil)
+    pt = hascs.send :create_permission_template
+    workflow = hascs.send :create_workflows_for, permission_template: pt
+    access = hascs.send :create_default_access_for, permission_template: pt, workflow: workflow
+  end
+
 end


### PR DESCRIPTION
The changed extension gets loaded and executed during application initialization, which happens during image build when `assets:precompile` is invoked.  This causes the build to fail if it's in a context where Solr/Fedora/Database is unavailable (like the Github Action build/push) so moving the AdminSet conditional into an existing safety check added to fix a similar problem.