### PR TITLE
Test initialization refactor

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,8 @@ development:
 test:
   <<: *default
   timeout: 20000
+  variables:
+    innodb_lock_wait_timeout: 120
 
 production:
   <<: *default

--- a/spec/features/log_in_as_spec.rb
+++ b/spec/features/log_in_as_spec.rb
@@ -1,26 +1,28 @@
 require 'rails_helper'
 
 RSpec.feature 'Switch User' do
-  let(:user_attributes) do
-    { email: 'test@example.com' }
-  end
-  let(:user) do
-    User.new(user_attributes) { |u| u.save(validate: false) }
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'Non-admin user', :clean do
+    before do
+      login_as user
+    end
+    scenario 'is not allowed to see switch user form' do
+      visit '/users/sessions/log_in_as'
+      expect(page).to have_no_selector('select#switch_user_identifier')
+      logout
+    end
   end
 
-  before do
-    login_as user
-  end
-
-  scenario 'Non-admin user is not allowed to see switch user form' do
-    visit '/users/sessions/log_in_as'
-    expect(page).to have_no_selector('select#switch_user_identifier')
-  end
-
-  scenario 'Admin user is allowed to see switch user form' do
-    admin = Role.where(name: 'admin').first_or_create
-    admin.users << user
-    visit '/users/sessions/log_in_as'
-    expect(page).to have_css('select#switch_user_identifier')
+  context 'Admin user', :clean do
+    before do
+      login_as user
+      allow(user).to receive(:admin?).and_return(true)
+    end
+    scenario 'is allowed to see switch user form' do
+      visit '/users/sessions/log_in_as'
+      expect(page).to have_css('select#switch_user_identifier')
+      logout
+    end
   end
 end


### PR DESCRIPTION
This PR gets the `log_in_as` specs passing, which started consistently failing after measures were put in place to ensure proper creation of default admin set/permission templates. It was failing while waiting for a lock on the `User` table:
```
ActiveRecord::LockWaitTimeout:
       Mysql2::Error::TimeoutError: Lock wait timeout exceeded; try restarting transaction: INSERT INTO `users` (`email`, `created_at`, `updated_at`, `provider`, `uid`) VALUES ('user130@example.com', '2023-08-11 19:54:15', '2023-08-11 19:54:15', 'cas', 'username130')
     # ./spec/features/log_in_as_spec.rb:4:in `block (2 levels) in <top (required)>'
     # ./spec/features/log_in_as_spec.rb:8:in `block (3 levels) in <top (required)>
```
I wasn't able to determine what was really holding the database lock, but I was able to get past it by increasing the INNODB lock timeout in the test database configuration.  This has resulted in at least a 50 second wait in the suite, which you can see at work in the test analysis.  It points at the "login as" specs as being the second slowest example, when in actuality it's really just waiting for the lock on the User table to be released:
```
Top 10 slowest examples (426.94 seconds, 51.7% of total time):
  Jasmine expects all jasmine tests to pass
    180.86 seconds ./spec/javascripts/jasmine_spec.rb:14
  Switch User Non-admin user is not allowed to see switch user form
    54.43 seconds ./spec/features/log_in_as_spec.rb:10
...
```
The example run above would have failed on the "Switch User" test because it was 4 seconds over the default lock timeout.