### PR TITLE
ESSI-1849 Disable parsing of IDs on dashes in PURL controller to set active page in UV

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -1,7 +1,7 @@
 class PurlController < ApplicationController
   before_action :add_headers
   def default
-    set_object(WORK_LOOKUPS, split_id: true)
+    set_object(WORK_LOOKUPS, split_id: false)
     respond_to do |f|
       f.html { redirect_to @url }
       f.json { render json: { url: @url }.to_json }
@@ -26,7 +26,7 @@ class PurlController < ApplicationController
 
   private
     FILESET_LOOKUPS = { FileSet => nil }.freeze
-    DEFAULT_WORK_PATTERN = /^[a-zA-Z\/]{0,}\w{2,}\d{3,}$/.freeze
+    DEFAULT_WORK_PATTERN = /^[a-zA-Z\/]{0,}\w{2,}\d{3,}-{0,}\d{0,}$/.freeze
     DEFAULT_WORK_LOOKUPS = Hyrax.config.registered_curation_concern_types.sort.map do |klass|
       [klass.constantize, DEFAULT_WORK_PATTERN.dup]
     end.to_h.freeze

--- a/spec/controllers/purl_controller_spec.rb
+++ b/spec/controllers/purl_controller_spec.rb
@@ -6,21 +6,21 @@ describe PurlController do
   let(:paged_resource) {
     FactoryBot.create(:paged_resource,
                        user: user,
-                       purl: ['http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405'],
-                       source_metadata_identifier: 'BHR9405')
+                       purl: ['http://purl.dlib.indiana.edu/iudl/collection/VAX1234'],
+                       source_metadata_identifier: 'VAX1234')
   }
   let(:paged_resource_path) { Rails.application.routes.url_helpers.hyrax_paged_resource_path(paged_resource) }
   let(:legacy_paged_resource) {
     FactoryBot.create(:paged_resource,
                       user: user,
-                      purl: ['http://purl.dlib.indiana.edu/iudl/archives/cushman/P04259'],
-                      source_metadata_identifier: 'P04259')
+                      purl: ['http://purl.dlib.indiana.edu/iudl/legacy/VAX3421-0001'],
+                      source_metadata_identifier: 'VAX3421-0001')
   }
   let(:legacy_paged_resource_path) { Rails.application.routes.url_helpers.hyrax_paged_resource_path(legacy_paged_resource) }
   let(:file_set) {
     FactoryBot.create(:file_set,
                        user: user,
-                       source_metadata_identifier: 'BHR9405-001-0005')
+                       source_metadata_identifier: 'VAX1234-001-0005')
   }
   let(:file_set_path) { Rails.application.routes.url_helpers.hyrax_file_set_path(file_set) }
   let(:original_file_id) { 'xk81jk36q/files/adac151d-9c08-4892-9bc1-a20b64443bb9' }
@@ -70,7 +70,7 @@ describe PurlController do
         end
 
         context 'matching a full PURL by purl' do
-          let(:id) { 'iudl/variations/score/BHR9405' }
+          let(:id) { 'iudl/collection/VAX1234' }
           include_examples 'responses for matches'
         end
       end
@@ -84,11 +84,13 @@ describe PurlController do
         end
 
         context 'matching a full PURL by purl' do
-          let(:id) { 'iudl/archives/cushman/P04259' }
+          let(:id) { 'iudl/legacy/VAX3421-0001' }
           include_examples 'responses for matches'
         end
       end
-      context 'when for a specific page' do
+      # Disable these examples until a redesign provides for a RESTful page qualifier
+      # See ESSI-1849
+      xcontext 'when for a specific page' do
         let(:id) { paged_resource.source_metadata_identifier + '-9-0042' }
         let(:target_path) { paged_resource_path + '?m=8&cv=41' }
         let(:manifest_path) { paged_resource_path + '/manifest' }


### PR DESCRIPTION
The functionality to set the active page in the UV, upon resolving a PURL and entering a work, was accomplished by parsing IDs on dashes and assuming that the extra values were appended as the desired volume/page, like:

VAX1234-1-0003 = Page 3 of volume 1

But this hijacks valid IDs like:

VAX1234-U-00003

It was decided that we should disable this behavior for now and implement something more RESTful that follows IIIF nomenclature to specify a target canvas (page.)  