### PR TITLE
[ESSI-1847] provide presenter #version method for manifest caching

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -65,4 +65,9 @@ class SolrDocument
       []
     end
   end
+
+  # for manifest caching
+  def version
+    self[Solrizer.solr_name('date_modified', Solrizer::Descriptor.new(:date, :stored, :indexed))]
+  end
 end

--- a/app/presenters/concerns/essi/presents_delegated_attributes.rb
+++ b/app/presenters/concerns/essi/presents_delegated_attributes.rb
@@ -1,5 +1,5 @@
 module ESSI
   module PresentsDelegatedAttributes
-    delegate :num_pages, :number_of_pages, :catalog_url, :related_url, to: :solr_document
+    delegate :num_pages, :number_of_pages, :catalog_url, :related_url, :version, to: :solr_document
   end
 end


### PR DESCRIPTION
For local testing, you can override the cache settings login in config/environments/development:20-31 by appending `config.cache_store = :file_store, "#{Rails.root}/tmp/cache"` and then watching the contents of that directory.