### PR TITLE
Improvements to indexing jobs to handle large scale reindexing operations

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -23,6 +23,7 @@ class CatalogController < ApplicationController
 
     # configuration for Blacklight IIIF Content Search
     config.iiif_search = {
+      iiif_index_strategy: 'iiif_print_v1.0',
       full_text_field: 'all_text_tsimv',
       object_relation_field: 'is_page_of_ssim',
       supported_params: %w[q page],

--- a/app/indexers/essi/file_set_indexer.rb
+++ b/app/indexers/essi/file_set_indexer.rb
@@ -11,7 +11,7 @@ module ESSI
 
         # Preserving `ocr_text_tesi` for backwards compatibility with existing implementations until we fully transition
         # to just `all_text_tsimv` from IIIF Print
-        solr_doc['ocr_text_tesi'] = object.extracted_text.content if object.extracted_text.present?
+        # solr_doc['ocr_text_tesi'] = object.extracted_text.content if object.extracted_text.present?
         solr_doc['word_boundary_tsi'] = IiifPrint::TextExtraction::AltoReader.new(object.extracted_text.content).json if object.extracted_text.present?
         solr_doc[Solrizer.solr_name('iiif_index_strategy')] = IndexerHelper.iiif_index_strategy
       end

--- a/app/indexers/essi/file_set_indexer.rb
+++ b/app/indexers/essi/file_set_indexer.rb
@@ -8,10 +8,6 @@ module ESSI
       super.tap do |solr_doc|
         solr_doc['is_page_of_ssi'] = object.parent.id if object.parent
         solr_doc['parent_path_tesi'] = Rails.application.routes.url_helpers.polymorphic_path(object.parent) if object.parent
-
-        # Preserving `ocr_text_tesi` for backwards compatibility with existing implementations until we fully transition
-        # to just `all_text_tsimv` from IIIF Print
-        # solr_doc['ocr_text_tesi'] = object.extracted_text.content if object.extracted_text.present?
         solr_doc['word_boundary_tsi'] = IiifPrint::TextExtraction::AltoReader.new(object.extracted_text.content).json if object.extracted_text.present?
         solr_doc[Solrizer.solr_name('iiif_index_strategy')] = IndexerHelper.iiif_index_strategy
       end

--- a/app/indexers/essi/file_set_indexer.rb
+++ b/app/indexers/essi/file_set_indexer.rb
@@ -13,6 +13,7 @@ module ESSI
         # to just `all_text_tsimv` from IIIF Print
         solr_doc['ocr_text_tesi'] = object.extracted_text.content if object.extracted_text.present?
         solr_doc['word_boundary_tsi'] = IiifPrint::TextExtraction::AltoReader.new(object.extracted_text.content).json if object.extracted_text.present?
+        solr_doc[Solrizer.solr_name('iiif_index_strategy')] = IndexerHelper.iiif_index_strategy
       end
     end
   end

--- a/app/indexers/indexer_helper.rb
+++ b/app/indexers/indexer_helper.rb
@@ -1,0 +1,7 @@
+module IndexerHelper
+
+ def self.iiif_index_strategy
+   ESSI.config.dig(:essi, :iiif_index_strategy) || \
+   CatalogController.blacklight_config.iiif_search[:iiif_index_strategy]
+ end
+end

--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -5,7 +5,13 @@ class ReindexCollectionsJob < ApplicationJob
   def perform
     Collection.find_each do |col|
       Rails.logger.info "Reindexing #{col.class}: #{col.id}"
-      col.update_index
+      begin
+        col.update_index
+      rescue Samvera::NestingIndexer::Exceptions::ExceededMaximumNestingDepthError
+        Rails.logger.info "ReindexCollectionsJob: Children of #{col.class} #{col.id} not indexed; exceeds nested depth maximum."
+      rescue => error
+        Rails.logger.error "ReindexCollectionsJob: Reindexing #{col.id} failed,  #{error.message}"
+      end
     end
   end
 end

--- a/app/jobs/reindex_file_sets_job.rb
+++ b/app/jobs/reindex_file_sets_job.rb
@@ -1,11 +1,45 @@
 # frozen_string_literal: true
 
-# Triggers reindexing on all FileSets
 class ReindexFileSetsJob < ApplicationJob
-  def perform
-    FileSet.find_each do |fs|
-      Rails.logger.info "Reindexing #{fs.class}: #{fs.id}"
-      fs.update_index
+  def perform(file_set_ids = [], opts = {})
+    index_query_field = opts.dig(:index_query_field) || 'iiif_index_strategy_tesim'
+    index_query_value = opts.dig(:index_query_value) || IndexerHelper.iiif_index_strategy
+    row_count = opts.dig(:row_count) || 500
+    sleep_break = opts.dig(:row_count) || 10
+    if file_set_ids.empty?
+      index_query = "-#{index_query_field}:#{index_query_value}"
+      model_query = "has_model_ssim:FileSet"
+      loop do
+        results = ActiveFedora::SolrService.instance.conn.get(
+          ActiveFedora::SolrService.select_path,
+          params: { qt: "search", q: [model_query], fq: [index_query], fl: "id", rows: row_count}
+        )
+
+        break if results["response"]["numFound"] == 0
+
+        results["response"]["docs"].each do |solr_hit|
+          index_file_set(solr_hit["id"])
+        end
+        # Give the backend and the jobs a break...
+        sleep sleep_break
+      end
+    else
+      file_set_ids.each do |id|
+        index_file_set(id)
+      end
     end
   end
+
+  private
+
+    def index_file_set(id)
+      begin
+        fs = FileSet.find(id)
+        FileSet.new
+        Rails.logger.info "Reindexing #{fs.class}: #{fs.id}"
+        # fs.update_index
+      rescue => error
+        Rails.logger.error "ReindexWorksJob: Reindexing #{work.id} failed,  #{error.message}"
+      end
+    end
 end

--- a/app/jobs/reindex_file_sets_job.rb
+++ b/app/jobs/reindex_file_sets_job.rb
@@ -5,7 +5,7 @@ class ReindexFileSetsJob < ApplicationJob
     index_query_field = opts.dig(:index_query_field) || 'iiif_index_strategy_tesim'
     index_query_value = opts.dig(:index_query_value) || IndexerHelper.iiif_index_strategy
     row_count = opts.dig(:row_count) || 500
-    sleep_break = opts.dig(:row_count) || 10
+    sleep_break = opts.dig(:sleep_break) || 10
     if file_set_ids.empty?
       index_query = "-#{index_query_field}:#{index_query_value}"
       model_query = "has_model_ssim:FileSet"
@@ -37,7 +37,7 @@ class ReindexFileSetsJob < ApplicationJob
         fs = FileSet.find(id)
         FileSet.new
         Rails.logger.info "Reindexing #{fs.class}: #{fs.id}"
-        # fs.update_index
+        fs.update_index
       rescue => error
         Rails.logger.error "ReindexWorksJob: Reindexing #{work.id} failed,  #{error.message}"
       end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -1,18 +1,41 @@
 # frozen_string_literal: true
 
-# Triggers reindexing on all works
 class ReindexWorksJob < ApplicationJob
-  def perform
+
+  def perform(opts = {})
+    index_query_field = opts.dig(:index_query_field) || 'iiif_index_strategy_tesim'
+    index_query_value = opts.dig(:index_query_value) || IndexerHelper.iiif_index_strategy
+    index_file_sets = opts.dig(:index_file_sets) || true
+    async_fs_jobs = opts.dig(:async_fs_jobs) || false
+    row_count = opts.dig(:row_count) || 100
+    sleep_break = opts.dig(:row_count) || 10
     Hyrax.config.registered_curation_concern_types.each do |work_type|
-      work_type.constantize.find_each do |work|
-        Rails.logger.info "Reindexing #{work.class}: #{work.id}"
-        begin
-          work.update_index
-        rescue Samvera::NestingIndexer::Exceptions::ExceededMaximumNestingDepthError
-          Rails.logger.info "ReindexWorksJob: Children of #{work.class} #{work.id} not indexed; exceeds nested depth maximum."
-        rescue => error
-          Rails.logger.error "ReindexWorksJob: Reindexing #{work.id} failed,  #{error.message}"
+      index_query = "-#{index_query_field}:#{index_query_value}"
+      model_query = "has_model_ssim:#{work_type.constantize}"
+      loop do
+        results = ActiveFedora::SolrService.instance.conn.get(
+          ActiveFedora::SolrService.select_path,
+          params: { qt: "search", q: [model_query], fq: [index_query], fl: "id,file_set_ids_ssim", rows: row_count}
+        )
+
+        break if results["response"]["numFound"] == 0
+
+        results["response"]["docs"].each do |solr_hit|
+          work = work_type.constantize.find(solr_hit["id"])
+          work_type.constantize.class.new
+          begin
+            work.update_index
+          rescue Samvera::NestingIndexer::Exceptions::ExceededMaximumNestingDepthError
+            Rails.logger.info "ReindexWorksJob: Children of #{work.class} #{work.id} not indexed; exceeds nested depth maximum."
+          rescue => error
+            Rails.logger.error "ReindexWorksJob: Reindexing #{work.id} failed,  #{error.message}"
+          end
+          perform_method = async_fs_jobs ? 'perform_later' : 'perform_now'
+          ReindexFileSetsJob.send(perform_method.to_sym, (solr_hit["file_set_ids_ssim"])) if index_file_sets
         end
+
+        # Give the backend and the jobs a break...
+        sleep sleep_break
       end
     end
   end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -6,7 +6,13 @@ class ReindexWorksJob < ApplicationJob
     Hyrax.config.registered_curation_concern_types.each do |work_type|
       work_type.constantize.find_each do |work|
         Rails.logger.info "Reindexing #{work.class}: #{work.id}"
-        work.update_index
+        begin
+          work.update_index
+        rescue Samvera::NestingIndexer::Exceptions::ExceededMaximumNestingDepthError
+          Rails.logger.info "ReindexWorksJob: Children of #{work.class} #{work.id} not indexed; exceeds nested depth maximum."
+        rescue => error
+          Rails.logger.error "ReindexWorksJob: Reindexing #{work.id} failed,  #{error.message}"
+        end
       end
     end
   end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -8,7 +8,7 @@ class ReindexWorksJob < ApplicationJob
     index_file_sets = opts.dig(:index_file_sets) || true
     async_fs_jobs = opts.dig(:async_fs_jobs) || false
     row_count = opts.dig(:row_count) || 100
-    sleep_break = opts.dig(:row_count) || 10
+    sleep_break = opts.dig(:sleep_break) || 10
     Hyrax.config.registered_curation_concern_types.each do |work_type|
       index_query = "-#{index_query_field}:#{index_query_value}"
       model_query = "has_model_ssim:#{work_type.constantize}"

--- a/app/models/concerns/essi/ocr_behavior.rb
+++ b/app/models/concerns/essi/ocr_behavior.rb
@@ -10,6 +10,7 @@ module ESSI
       super.tap do |doc|
         doc[Solrizer.solr_name('ocr_searchable',
                                Solrizer::Descriptor.new(:boolean, :stored, :indexed))] = self.ocr_searchable?
+        doc[Solrizer.solr_name('iiif_index_strategy')] = IndexerHelper.iiif_index_strategy
       end
     end
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -40,7 +40,7 @@ class SolrDocument
   attribute :original_file_id, Solr::String, solr_name('original_file_id', :stored_sortable)
   attribute :pdf_downloadable, Solr::String, solr_name('pdf_downloadable', Solrizer::Descriptor.new(:boolean, :stored, :indexed))
   attribute :file_set_ids, Solr::Array, solr_name('file_set_ids', :symbol)
-  attribute :extracted_text, Solr::String, 'ocr_text_tesi'
+  attribute :extracted_text, Solr::String, 'all_text_tsimv'
 
   def series
     self[Solrizer.solr_name('series')]

--- a/config/essi_config.docker.yml
+++ b/config/essi_config.docker.yml
@@ -121,6 +121,7 @@ default: &default
     create_ocr_files: true
     index_ocr_files: true
     create_word_boundaries: true
+    nested_indexer_depth: 5
     allow_pdf_download: false
     link_banners: false
     bagit:

--- a/config/essi_config.example.yml
+++ b/config/essi_config.example.yml
@@ -121,6 +121,7 @@ default: &default
     create_ocr_files: true
     index_ocr_files: true
     create_word_boundaries: true
+    nested_indexer_depth: 5
     allow_pdf_download: false
     link_banners: false
     bagit:

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -39,7 +39,7 @@ IiifPrint.config do |config|
   end
 
   config.all_text_generator_function = lambda do |object:|
-    object.extracted_text.content if object.extracted_text.present?
+    IiifPrint::TextExtraction::AltoReader.new(object.extracted_text.content).text if object.extracted_text.present?
   end
 
   config.iiif_metadata_field_presentation_order = Hyrax.config.iiif_metadata_fields

--- a/config/initializers/samvera-nesting_indexer_initializer.rb
+++ b/config/initializers/samvera-nesting_indexer_initializer.rb
@@ -7,7 +7,7 @@ Samvera::NestingIndexer.configure do |config|
   # How many layers of nesting are allowed for collections
   # For maximum_nesting_depth of 3 the following will raise an exception
   # C1 <- C2 <- C3 <- W1
-  config.maximum_nesting_depth = 5
+  config.maximum_nesting_depth = ESSI.config.dig(:essi, :nested_indexer_depth) || 5
   config.adapter = ESSI::Adapters::NestingIndexAdapter
   config.solr_field_name_for_storing_parent_ids = Solrizer.solr_name('nesting_collection__parent_ids', :symbol)
   config.solr_field_name_for_storing_ancestors =  Solrizer.solr_name('nesting_collection__ancestors', :symbol)


### PR DESCRIPTION
### Parametrizes the nested indexer depth for control during reindexing
When reindexing all works and collections, we want to control the depth of the nested indexer to just the level of the objects being acted upon. The depth of the nested indexer is set in an initializer, which was hardcoded at 5 but is now configurable in secrets as `essi, :nested_indexer_depth` .  

NOTE that anytime this is set lower than 3 to 5, it is nearly guaranteed that the depth limit will be exceeded and will raise an exception, so it must be handled properly if the goal is to merely skip child indexing.  See the modified batch indexers also in this PR.  Lowering the limit should be done deliberately when the indexing code or caller is aware of the limit.

### Refactors re-indexing jobs to be based on Solr queries
The re-indexing jobs for works, FileSets, and Collections query Solr for documents that have yet to be updated for the purposes of any given re-index operation.  The field name and the value being checked can be passed into the `perform` method, but defaults are taken from configuration (described below.)  Other options can be passed in, such as the row count to control batch sizes and an optional sleep break duration between batches.  The works job can additionally be told whether or not to index member FileSets (via the new job added here) and whether or not to async those jobs. 

As they currently stand, once the jobs are queued they are intended to loop until there are no candidate documents per the given query.  Testing might bear out the need to control the amount of work in a single job run or when it is allowed to run.

### Adds a versioning field to Solr documents to track indexing status
This PR adds to the actual indexer classes to make them responsible for populating the field being checked, versus setting the value in the jobs.  Updating objects from within the jobs will indirectly result in the value being set, and creating/saving objects will also continue to set the value going forward for consistency. 

### Addresses large redundant Solr fields causing performance problems
Development of the reindexing jobs helped uncover a big problem hurting Solr response performance.  The queries to gather candidate documents were taking a very long time to return, which was tracked down to the Solr response writer streaming back the multiple redundant fields containing the full Alto OCR.  This PR removes one of those redundant fields that ESSI code introduced but is no longer needed.  But more importantly, it reduces the value set in the remaining fields to that of only the extracted text and not the full Alto OCR.