### PR TITLE
[ESSI-1879] nested filesets in iiif manifests

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -175,5 +175,5 @@ IiifPrint::IiifSearchDecorator.include Extensions::IiifPrint::IiifSearchDecorato
 # support for nested works generating file_set sequences in manifests
 IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFManifest::ManifestBuilder::DeepFileSetEnumerator::NestedEach
 
-# prep support for memoizing the member_presenter_factory
+# support for memoizing the member_presenter_factory
 Hyrax::WorkShowPresenter.prepend Extensions::Hyrax::WorkShowPresenter::MemberPresenterFactoryMemoization

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -172,5 +172,5 @@ Hydra::Derivatives::Processors::Jpeg2kImage.prepend Extensions::Hydra::Derivativ
 IiifPrint::BlacklightIiifSearch::AnnotationDecorator.include Extensions::IiifPrint::BlacklightIiifSearch::AnnotationDecorator::AnnotationDecoratorCompatibility
 IiifPrint::IiifSearchDecorator.include Extensions::IiifPrint::IiifSearchDecorator::SearchDecoratorCompatibility
 
-# prep support for nested works generating file_set sequences in manifests
+# support for nested works generating file_set sequences in manifests
 IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFManifest::ManifestBuilder::DeepFileSetEnumerator::NestedEach

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -171,3 +171,6 @@ Hydra::Derivatives::Processors::Jpeg2kImage.prepend Extensions::Hydra::Derivativ
 # Workarounds to make previous IIIF search-related Solr fields compatible with iiif_print until they are reindexed
 IiifPrint::BlacklightIiifSearch::AnnotationDecorator.include Extensions::IiifPrint::BlacklightIiifSearch::AnnotationDecorator::AnnotationDecoratorCompatibility
 IiifPrint::IiifSearchDecorator.include Extensions::IiifPrint::IiifSearchDecorator::SearchDecoratorCompatibility
+
+# prep support for nested works generating file_set sequences in manifests
+IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFManifest::ManifestBuilder::DeepFileSetEnumerator::NestedEach

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -174,3 +174,6 @@ IiifPrint::IiifSearchDecorator.include Extensions::IiifPrint::IiifSearchDecorato
 
 # support for nested works generating file_set sequences in manifests
 IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFManifest::ManifestBuilder::DeepFileSetEnumerator::NestedEach
+
+# prep support for memoizing the member_presenter_factory
+Hyrax::WorkShowPresenter.prepend Extensions::Hyrax::WorkShowPresenter::MemberPresenterFactoryMemoization

--- a/lib/extensions/hyrax/work_show_presenter/member_presenter_factory_memoization.rb
+++ b/lib/extensions/hyrax/work_show_presenter/member_presenter_factory_memoization.rb
@@ -1,0 +1,12 @@
+module Extensions
+  module Hyrax
+    module WorkShowPresenter
+      module MemberPresenterFactoryMemoization
+        # unmodified from hyrax
+        def member_presenter_factory
+          ::Hyrax::MemberPresenterFactory.new(solr_document, current_ability, request)
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/work_show_presenter/member_presenter_factory_memoization.rb
+++ b/lib/extensions/hyrax/work_show_presenter/member_presenter_factory_memoization.rb
@@ -2,9 +2,9 @@ module Extensions
   module Hyrax
     module WorkShowPresenter
       module MemberPresenterFactoryMemoization
-        # unmodified from hyrax
+        # modified from hyrax to add memoization
         def member_presenter_factory
-          ::Hyrax::MemberPresenterFactory.new(solr_document, current_ability, request)
+          @member_presenter_factory ||= ::Hyrax::MemberPresenterFactory.new(solr_document, current_ability, request)
         end
       end
     end

--- a/lib/extensions/iiif_manifest/manifest_builder/deep_file_set_enumerator/nested_each.rb
+++ b/lib/extensions/iiif_manifest/manifest_builder/deep_file_set_enumerator/nested_each.rb
@@ -1,24 +1,32 @@
-# unmodified from iiif_manifest
+# modified from iiif_manifest
 module Extensions
   module IIIFManifest
     module ManifestBuilder
       module DeepFileSetEnumerator
         module NestedEach
-          # lists all direct file_set members, then recurs through work members
+          # modified from iiif_manifest
+          # lists all direct file_set members and member works' file_sets, interspersed
           def each(&block)
-            file_set_presenters.each do |file_set_presenter|
-              yield file_set_presenter
-            end
-            work_presenters.each do |work_presenter|
-              self.class.new(work_presenter).each(&block)
+            member_presenters.each do |member_presenter|
+              if member_presenter.id.in? file_set_presenters.map(&:id)
+                yield file_set_presenters.find { |fp| fp.id == member_presenter.id }
+              elsif member_presenter.id.in? work_presenters.map(&:id)
+                self.class.new(work_presenters.find { |wp| wp.id == member_presenter.id } ).each(&block)
+              end
             end
           end
 
           private
+            # modified from iiif_manifest with memoization
             def file_set_presenters
               @file_set_presenters ||= work.try(:file_set_presenters) || []
             end
 
+            def member_presenters
+              @member_presenters ||= work.try(:member_presenters) || []
+            end
+
+            # modified from iiif_manifest with memoization
             def work_presenters
               @work_presenters ||= work.try(:work_presenters) || []
             end

--- a/lib/extensions/iiif_manifest/manifest_builder/deep_file_set_enumerator/nested_each.rb
+++ b/lib/extensions/iiif_manifest/manifest_builder/deep_file_set_enumerator/nested_each.rb
@@ -1,0 +1,29 @@
+# unmodified from iiif_manifest
+module Extensions
+  module IIIFManifest
+    module ManifestBuilder
+      module DeepFileSetEnumerator
+        module NestedEach
+          # lists all direct file_set members, then recurs through work members
+          def each(&block)
+            file_set_presenters.each do |file_set_presenter|
+              yield file_set_presenter
+            end
+            work_presenters.each do |work_presenter|
+              self.class.new(work_presenter).each(&block)
+            end
+          end
+
+          private
+            def file_set_presenters
+              @file_set_presenters ||= work.try(:file_set_presenters) || []
+            end
+
+            def work_presenters
+              @work_presenters ||= work.try(:work_presenters) || []
+            end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It turns out that [IIIFManifest::ManifestBuilder::DeepCanvasBuilderFactory#file_set_presenters](https://github.com/samvera/iiif_manifest/blob/v0.5.0/lib/iiif_manifest/manifest_builder/deep_canvas_builder_factory.rb#L7) calls a DeepFileSetEnumerator that [explicitly lists all direct member FileSets, _then_ loops through member works](https://github.com/samvera/iiif_manifest/blob/v0.5.0/lib/iiif_manifest/manifest_builder/deep_canvas_builder_factory.rb#L18-L25).  So, that explains why we're seeing exactly that behavior.

These commits provide a proof-of-concept change to produce the expected and desired behavior of FileSet descendants getting listed in the manifest sequentially, regardless of their depth in the tree. 

Unrelated failing test is resolved via #587 
Needs view partial fix provided by #588 to properly render a mix of nested work/fileset objects
