### PR TITLE
Essi-1860 UV a11y remediation

### DIFF
--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,6 +1,7 @@
 <div class="viewer-wrapper">
   <iframe
     id="uv-iframe"
+    title="IIIF Viewer displaying <%= presenter.title.join(';') %>"
     src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %><%= uv_search_param %>"
     allowfullscreen="true"
     frameborder="0"

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,0 +1,8 @@
+<div class="viewer-wrapper">
+  <iframe
+    id="uv-iframe"
+    src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %><%= uv_search_param %>"
+    allowfullscreen="true"
+    frameborder="0"
+  ></iframe>
+</div>

--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<html lang="<%= t("hyrax.document_language", default: '') %>">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -5,7 +5,8 @@
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>Universal Viewer</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=yes" />
     <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" type="text/css" href="uv.css">
     <script type="text/javascript" src="lib/offline.js"></script>


### PR DESCRIPTION
This should resolve 4 remediation issues (essi-1904 essi-1905 essi-1906 essi-1907).

I noticed our `app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb` file is now sourced from the iiif-print gem.

I did not perceive any difference in the zoom behavior of UV after setting `user-scalable=yes`