### PR TITLE
More improvements to reindexing jobs

### DIFF
--- a/app/indexers/essi/file_set_indexer.rb
+++ b/app/indexers/essi/file_set_indexer.rb
@@ -6,8 +6,11 @@ module ESSI
 
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc['is_page_of_ssi'] = object.parent.id if object.parent
-        solr_doc['parent_path_tesi'] = Rails.application.routes.url_helpers.polymorphic_path(object.parent) if object.parent
+        parent = object.parent
+        unless parent.nil?
+          solr_doc['is_page_of_ssi'] = parent.id
+          solr_doc['parent_path_tesi'] = Rails.application.routes.url_helpers.polymorphic_path(parent)
+        end
         solr_doc['word_boundary_tsi'] = IiifPrint::TextExtraction::AltoReader.new(object.extracted_text.content).json if object.extracted_text.present?
         solr_doc[Solrizer.solr_name('iiif_index_strategy')] = IndexerHelper.iiif_index_strategy
       end

--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -4,13 +4,14 @@
 class ReindexCollectionsJob < ApplicationJob
   def perform
     Collection.find_each do |col|
-      Rails.logger.info "Reindexing #{col.class}: #{col.id}"
+      reindex_logger = Logger.new(Rails.root.join('log', 'reindex_collections.log'))
       begin
+        reindex_logger.info "Reindexing #{col.class}: #{col.id} started..."
         col.update_index
       rescue Samvera::NestingIndexer::Exceptions::ExceededMaximumNestingDepthError
-        Rails.logger.info "ReindexCollectionsJob: Children of #{col.class} #{col.id} not indexed; exceeds nested depth maximum."
+        reindex_logger.error "ReindexCollectionsJob: Children of #{col.class} #{col.id} not indexed; exceeds nested depth maximum."
       rescue => error
-        Rails.logger.error "ReindexCollectionsJob: Reindexing #{col.id} failed,  #{error.message}"
+        reindex_logger.error "ReindexCollectionsJob: Reindexing #{col.id} failed,  #{error.message}"
       end
     end
   end

--- a/app/jobs/reindex_file_sets_job.rb
+++ b/app/jobs/reindex_file_sets_job.rb
@@ -2,7 +2,8 @@
 
 class ReindexFileSetsJob < ApplicationJob
   def perform(file_set_ids = [], opts = {})
-    @reindex_logger = Logger.new(Rails.root.join('log', 'reindex_file_sets.log'))
+    start_time = opts.dig(:start_time) || Time.now.strftime("%Y-%m-%d_%H%M%S")
+    @reindex_logger = Logger.new(Rails.root.join('log', "reindex_file_sets_#{start_time}.log"))
     index_query_field = opts.dig(:index_query_field) || 'iiif_index_strategy_tesim'
     index_query_value = opts.dig(:index_query_value) || IndexerHelper.iiif_index_strategy
     row_count = opts.dig(:row_count) || 500
@@ -37,10 +38,10 @@ class ReindexFileSetsJob < ApplicationJob
       begin
         fs = FileSet.find(id)
         FileSet.new
-        @reindex_logger.info "Reindexing #{fs.class}: #{fs.id} started..."
+        @reindex_logger.info "Reindexing FileSet: #{id}"
         fs.update_index
       rescue => error
-        @reindex_logger.error "ReindexFileSetsJob: Reindexing #{fs&.id}failed,  #{error.message}"
+        @reindex_logger.error "ReindexFileSetsJob: Reindexing FileSet #{id} failed : #{error.message}"
       end
     end
 end

--- a/app/jobs/reindex_file_sets_job.rb
+++ b/app/jobs/reindex_file_sets_job.rb
@@ -2,6 +2,7 @@
 
 class ReindexFileSetsJob < ApplicationJob
   def perform(file_set_ids = [], opts = {})
+    @reindex_logger = Logger.new(Rails.root.join('log', 'reindex_file_sets.log'))
     index_query_field = opts.dig(:index_query_field) || 'iiif_index_strategy_tesim'
     index_query_value = opts.dig(:index_query_value) || IndexerHelper.iiif_index_strategy
     row_count = opts.dig(:row_count) || 500
@@ -36,10 +37,10 @@ class ReindexFileSetsJob < ApplicationJob
       begin
         fs = FileSet.find(id)
         FileSet.new
-        Rails.logger.info "Reindexing #{fs.class}: #{fs.id}"
+        @reindex_logger.info "Reindexing #{fs.class}: #{fs.id} started..."
         fs.update_index
       rescue => error
-        Rails.logger.error "ReindexWorksJob: Reindexing #{work.id} failed,  #{error.message}"
+        @reindex_logger.error "ReindexFileSetsJob: Reindexing #{fs&.id}failed,  #{error.message}"
       end
     end
 end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -3,6 +3,7 @@
 class ReindexWorksJob < ApplicationJob
 
   def perform(opts = {})
+    reindex_logger = Logger.new(Rails.root.join('log', 'reindex_works.log'))
     index_query_field = opts.dig(:index_query_field) || 'iiif_index_strategy_tesim'
     index_query_value = opts.dig(:index_query_value) || IndexerHelper.iiif_index_strategy
     index_file_sets = opts.dig(:index_file_sets) || true
@@ -10,6 +11,8 @@ class ReindexWorksJob < ApplicationJob
     row_count = opts.dig(:row_count) || 100
     sleep_break = opts.dig(:sleep_break) || 10
     Hyrax.config.registered_curation_concern_types.each do |work_type|
+      # This helps ensure that we get all possible properties from the latest profile for each work type
+      work_type.constantize.new
       index_query = "-#{index_query_field}:#{index_query_value}"
       model_query = "has_model_ssim:#{work_type.constantize}"
       loop do
@@ -22,19 +25,24 @@ class ReindexWorksJob < ApplicationJob
 
         results["response"]["docs"].each do |solr_hit|
           work = work_type.constantize.find(solr_hit["id"])
+          # TODO This still seems to be necessary; does loading works with different profiles affect the available properties?
           work_type.constantize.class.new
           begin
+            reindex_logger.info "ReindexWorksJob: Reindexing #{work&.id} started..."
             work.update_index
           rescue Samvera::NestingIndexer::Exceptions::ExceededMaximumNestingDepthError
-            Rails.logger.info "ReindexWorksJob: Children of #{work.class} #{work.id} not indexed; exceeds nested depth maximum."
+            reindex_logger.error "ReindexWorksJob: Children of #{work.class} #{work.id} not indexed; exceeds nested depth maximum."
           rescue => error
-            Rails.logger.error "ReindexWorksJob: Reindexing #{work.id} failed,  #{error.message}"
+            reindex_logger.error "ReindexWorksJob: Reindexing #{work&.id} failed,  #{error.message}"
           end
-          perform_method = async_fs_jobs ? 'perform_later' : 'perform_now'
-          ReindexFileSetsJob.send(perform_method.to_sym, (solr_hit["file_set_ids_ssim"])) if index_file_sets
+          unless solr_hit["file_set_ids_ssim"].blank?
+            perform_method = async_fs_jobs ? 'perform_later' : 'perform_now'
+            ReindexFileSetsJob.send(perform_method.to_sym, (solr_hit["file_set_ids_ssim"])) if index_file_sets
+          end
         end
 
         # Give the backend and the jobs a break...
+        reindex_logger.info "ReindexWorksJob resting for #{sleep_break}"
         sleep sleep_break
       end
     end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -3,16 +3,16 @@
 class ReindexWorksJob < ApplicationJob
 
   def perform(opts = {})
-    reindex_logger = Logger.new(Rails.root.join('log', 'reindex_works.log'))
+    start_time = Time.now.strftime("%Y-%m-%d_%H%M%S")
+    reindex_logger = Logger.new(Rails.root.join('log', "reindex_works_#{start_time}.log"))
     index_query_field = opts.dig(:index_query_field) || 'iiif_index_strategy_tesim'
     index_query_value = opts.dig(:index_query_value) || IndexerHelper.iiif_index_strategy
     index_file_sets = opts.dig(:index_file_sets) || true
     async_fs_jobs = opts.dig(:async_fs_jobs) || false
     row_count = opts.dig(:row_count) || 100
     sleep_break = opts.dig(:sleep_break) || 10
-    Hyrax.config.registered_curation_concern_types.each do |work_type|
-      # This helps ensure that we get all possible properties from the latest profile for each work type
-      work_type.constantize.new
+    curation_concern_types = opts.dig(:work_types) || Hyrax.config.registered_curation_concern_types
+    curation_concern_types.each do |work_type|
       index_query = "-#{index_query_field}:#{index_query_value}"
       model_query = "has_model_ssim:#{work_type.constantize}"
       loop do
@@ -24,20 +24,20 @@ class ReindexWorksJob < ApplicationJob
         break if results["response"]["numFound"] == 0
 
         results["response"]["docs"].each do |solr_hit|
-          work = work_type.constantize.find(solr_hit["id"])
-          # TODO This still seems to be necessary; does loading works with different profiles affect the available properties?
-          work_type.constantize.class.new
           begin
-            reindex_logger.info "ReindexWorksJob: Reindexing #{work&.id} started..."
+            # This reloads the latest profile to ensure that we get all possible properties
+            work_type.constantize.new
+            work = work_type.constantize.find(solr_hit["id"])
+            reindex_logger.info "ReindexWorksJob: Reindexing #{work_type} #{solr_hit["id"]}"
             work.update_index
           rescue Samvera::NestingIndexer::Exceptions::ExceededMaximumNestingDepthError
-            reindex_logger.error "ReindexWorksJob: Children of #{work.class} #{work.id} not indexed; exceeds nested depth maximum."
+            reindex_logger.error "ReindexWorksJob: Children of #{work_type} #{solr_hit["id"]} not indexed; exceeds nested depth maximum."
           rescue => error
-            reindex_logger.error "ReindexWorksJob: Reindexing #{work&.id} failed,  #{error.message}"
+            reindex_logger.error "ReindexWorksJob: Reindexing #{work_type} #{solr_hit["id"]} failed :  #{error.message}"
           end
           unless solr_hit["file_set_ids_ssim"].blank?
             perform_method = async_fs_jobs ? 'perform_later' : 'perform_now'
-            ReindexFileSetsJob.send(perform_method.to_sym, (solr_hit["file_set_ids_ssim"])) if index_file_sets
+            ReindexFileSetsJob.send(perform_method.to_sym, solr_hit["file_set_ids_ssim"], {start_time: start_time}) if index_file_sets
           end
         end
 


### PR DESCRIPTION
Based on trial and error, this PR adds more ability and refinements to the reindexing jobs.  It adds more ability to track status and failures in versioned log files, and allows constraining single invocations to a particular work type (useful for parallel processing because it avoids two threads trying to work on the same set of IDs obtained through the Solr queries.)

Also, it was found through testing that FileSets were taking a long time to index due to duplicate LDP load operations in the FileSetIndexer.  Those were being caused by repetitious calls to the FileSet's parent when storing membership details in Solr fields.  This refactors to only access the parent once, which takes the average time from 9 seconds to 3.  