### PR TITLE
Essi-1860 thumbnail alt text

### DIFF
--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,5 +1,5 @@
 <div class="grid-item">
-  <%= render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
+  <%= render_thumbnail_tag(document, { alt: document.title_or_label }, :counter => document_counter_with_offset(document_counter)) %>
   <div class="caption details">
     <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
   </div>

--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,6 +1,6 @@
 <%# modified from hyrax, to format collections as per works %>
 <div class="grid-item grid-collection">
-  <%= render_thumbnail_tag(document, {}, counter: document_counter_with_offset(document_counter)) %>
+  <%= render_thumbnail_tag(document, { alt: document.title_or_label }, counter: document_counter_with_offset(document_counter)) %>
   <div class="caption details">
     <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
   </div>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,6 +1,6 @@
 <div class="col-md-2">
   <div class="list-thumbnail">
-    <%= render_thumbnail_tag document, {}, suppress_link: true %>
+    <%= render_thumbnail_tag document, { alt: document.title_or_label }, suppress_link: true %>
   </div>
 </div> 
 

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -1,0 +1,11 @@
+<tr class="<%= dom_class(member) %> attributes">
+  <td class="thumbnail">
+    <%= render_thumbnail_tag member %>
+  </td>
+  <td class="attribute attribute-filename ensure-wrapped"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
+  <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>
+  <td class="attribute attribute-permission"><%= member.permission_badge %></td>
+  <td>
+    <%= render 'actions', member: member %>
+  </td>
+</tr>

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -1,6 +1,6 @@
 <tr class="<%= dom_class(member) %> attributes">
   <td class="thumbnail">
-    <%= render_thumbnail_tag member %>
+    <%= render_thumbnail_tag member, { alt: member.title_or_label } %>
   </td>
   <td class="attribute attribute-filename ensure-wrapped"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
   <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>

--- a/app/views/hyrax/collections/_collection_row.html.erb
+++ b/app/views/hyrax/collections/_collection_row.html.erb
@@ -7,7 +7,7 @@
 <td>
   <div class="media">
     <%= link_to [hyrax, document], class: "media-left" do %>
-      <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+      <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true } %>
     <% end %>
     <div class="media-body">
       <p class="media-heading">

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -10,7 +10,7 @@
       <% link_destination = [main_app, document] %>
       <% link_destination << { query: params['cq'] } if params['cq'].present? %>
       <%= link_to link_destination, class: "media-left" do %>
-        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
         <p class="media-heading">

--- a/app/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_parent_collection_row.html.erb
@@ -11,7 +11,7 @@
   <td>
     <div class="media">
       <%= link_to [hyrax, :dashboard, document], class: "media-left" do %>
-        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">
         <p class="media-heading">

--- a/app/views/hyrax/dashboard/collections/_subcollection_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_subcollection_row.html.erb
@@ -11,7 +11,7 @@
 <td>
   <div class="media">
     <%= link_to [hyrax, :dashboard, document], class: "media-left" do %>
-      <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+      <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true } %>
     <% end %>
     <div class="media-body">
       <p class="media-heading">


### PR DESCRIPTION
Displays the object title or label as the alt text when rendering thumbnail links.

Should fix essi-1895 and essi-1898