### PR TITLE
Workarounds to make previous IIIF search fields compatible with iiif_print

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -26,6 +26,7 @@ class CatalogController < ApplicationController
       iiif_index_strategy: 'iiif_print_v1.0',
       full_text_field: 'all_text_tsimv',
       object_relation_field: 'is_page_of_ssim',
+      extra_relation_field: 'is_page_of_ssi',
       supported_params: %w[q page],
       autocomplete_handler: 'iiif_suggest',
       suggester_name: 'iiifSuggester'

--- a/app/models/iiif_search_builder.rb
+++ b/app/models/iiif_search_builder.rb
@@ -10,7 +10,9 @@ class IiifSearchBuilder < Blacklight::SearchBuilder
   def ocr_search_params(solr_parameters = {})
     solr_parameters[:facet] = false
     solr_parameters[:hl] = true
-    solr_parameters[:'hl.fl'] = blacklight_config.iiif_search[:full_text_field]
+    # Until reindexing for iiif_print is complete, we don't know which text field a match will occur in.
+    # Fortunately, Solr allows globbing when defining what field names to markup by the snippet processor.
+    solr_parameters[:'hl.fl'] = '*text*'
     solr_parameters[:'hl.fragsize'] = 100
     solr_parameters[:'hl.snippets'] = 10
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ test:
   <<: *default
   timeout: 20000
   variables:
-    innodb_lock_wait_timeout: 120
+    innodb_lock_wait_timeout: 180
 
 production:
   <<: *default

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -167,3 +167,7 @@ Hydra::Works::CharacterizationService.prepend Extensions::Hydra::Works::Characte
 
 # Patch ShellBasedProcessor to handle IO::EAGAINWaitReadable
 Hydra::Derivatives::Processors::Jpeg2kImage.prepend Extensions::Hydra::Derivatives::Processors::WaitReadable
+
+# Workarounds to make previous IIIF search-related Solr fields compatible with iiif_print until they are reindexed
+IiifPrint::BlacklightIiifSearch::AnnotationDecorator.include Extensions::IiifPrint::BlacklightIiifSearch::AnnotationDecorator::AnnotationDecoratorCompatibility
+IiifPrint::IiifSearchDecorator.include Extensions::IiifPrint::IiifSearchDecorator::SearchDecoratorCompatibility

--- a/lib/extensions/iiif_print/blacklight_iiif_search/annotation_decorator/annotation_decorator_compatibility.rb
+++ b/lib/extensions/iiif_print/blacklight_iiif_search/annotation_decorator/annotation_decorator_compatibility.rb
@@ -1,0 +1,30 @@
+# customize behavior for IiifSearch
+module Extensions
+  module IiifPrint
+    module BlacklightIiifSearch
+      module AnnotationDecorator
+        module AnnotationDecoratorCompatibility
+          def self.included(base)
+            base.class_eval do
+              ##
+              # This method is a workaround to compensate for index state where FileSets were indexed for the
+              # blacklight_iiif_search gem; for those the object relation field is single value with a different name.
+              # So not only do we have to know which one to check, we also can't call array methods on it.
+              #
+              # The purpose of this string is to figure out what to eliminate from the overall query to isolate
+              # just the search terms.  So if this part doesn't match the query created in IiifSearchDecorator,
+              # everything in the entire original query will then be incorrectly seen as terms and potentially even be
+              # matched and highlighted.
+              #
+              # @return [String] Returns a string containing additional query terms based on the parent document's id.
+              def additional_query_terms
+                parent_id = document['is_page_of_ssim'].nil? ? document['is_page_of_ssi'] : document['is_page_of_ssim'].first
+                " AND (is_page_of_ssim:\"#{parent_id}\" OR is_page_of_ssi:\"#{parent_id}\" OR id:\"#{parent_id}\")"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/iiif_print/iiif_search_decorator/search_decorator_compatibility.rb
+++ b/lib/extensions/iiif_print/iiif_search_decorator/search_decorator_compatibility.rb
@@ -1,0 +1,29 @@
+# Overriding the solr_params method to include the object relation field used before iiif_print.
+module Extensions
+  module IiifPrint
+    module IiifSearchDecorator
+      module SearchDecoratorCompatibility
+        def self.included(base)
+          base.class_eval do
+            ##
+            # @return [Hash] A hash containing the modified Solr search parameters
+            #
+            def solr_params
+              return { q: 'nil:nil' } unless q
+
+              search_fields = ''
+              search_fields << "#{iiif_config[:object_relation_field]}:\"#{parent_document.id}\""
+              search_fields << " OR #{iiif_config[:extra_relation_field]}:\"#{parent_document.id}\""
+              search_fields << " OR id:\"#{parent_document.id}\""
+              {
+                q: "#{q} AND (#{search_fields})",
+                rows: rows,
+                page: page
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Overriding certain decorator methods to make previous FileSet index state compatible with iiif_print until they are reindexed. 