### PR TITLE
reassign spec Collection create/build to FactoryBot

### DIFF
--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   let(:user) { FactoryBot.create(:user) }
   let(:collection_type) { double(:brandable, true) }
   let(:collection_type_gid) { FactoryBot.create(:user_collection_type).gid }
-  let(:collection) { FactoryBot.create(:collection,
+  let(:collection) { FactoryBot.create(:collection_lw,
                                        title: ['Test collection'],
                                        collection_type_gid: collection_type_gid,
                                        visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
   let(:user) { FactoryBot.create(:user) }
   let(:collection_type) { double(:brandable, true) }
   let(:collection_type_gid) { FactoryBot.create(:user_collection_type).gid }
-  let(:collection) { Collection.create(title: ['Test collection'],
+  let(:collection) { FactoryBot.create(:collection,
+                                       title: ['Test collection'],
                                        collection_type_gid: collection_type_gid,
                                        visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
   let(:banner) { FactoryBot.build(:collection_branding_banner) }
 
-  describe "#show" do
+  describe "#show", :clean do
     before do
       sign_in user
       allow(collection).to receive(:brandable?).and_return(true)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,10 +3,12 @@ require 'rails_helper'
 RSpec.describe Collection do
   let(:collection_type) { double(:brandable, true) }
   let(:collection_type_gid) { FactoryBot.create(:user_collection_type).gid }
-  let(:collection) { Collection.create(title: ['Persisted collection'],
+  let(:collection) { FactoryBot.create(:collection,
+                                       title: ['Persisted collection'],
                                        collection_type_gid: collection_type_gid,
                                        visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
-  let(:new_collection) { Collection.new(title: ['Unpersisted collection'],
+  let(:new_collection) { FactoryBot.build(:collection,
+                                          title: ['Unpersisted collection'],
                                           collection_type_gid: collection_type_gid,
                                           visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
   let(:fs1) { FactoryBot.create(:file_set) }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Collection do
   let(:collection_type) { double(:brandable, true) }
   let(:collection_type_gid) { FactoryBot.create(:user_collection_type).gid }
-  let(:collection) { FactoryBot.create(:collection,
+  let(:collection) { FactoryBot.create(:collection_lw,
                                        title: ['Persisted collection'],
                                        collection_type_gid: collection_type_gid,
                                        visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
-  let(:new_collection) { FactoryBot.build(:collection,
+  let(:new_collection) { FactoryBot.build(:collection_lw,
                                           title: ['Unpersisted collection'],
                                           collection_type_gid: collection_type_gid,
                                           visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }


### PR DESCRIPTION
It looks like we're _sometimes_ getting [the "Persisted collection" from the Collection model spec](https://github.com/IU-Libraries-Joint-Development/essi/blob/v1.4.12/spec/models/collection_spec.rb#L6) or the ["Test collection" from the Collection controller spec](https://github.com/IU-Libraries-Joint-Development/essi/blob/v1.4.12/spec/controllers/hyrax/dashboard/collections_controller_spec.rb#L8) persisting afterwards, into the Collection authority spec, and [creating a test failure](https://app.circleci.com/pipelines/github/IU-Libraries-Joint-Development/essi/2452/workflows/e3270262-8b6e-4cc8-88d4-bedc37696827/jobs/2706).

This attempts to resolve that by changing direct `Collection #create, #new` calls to `FactoryBot #create, #build`.  (But I am kinda surprised the `:clean` settings in the Collection model spec weren't reliably working?)