### PR TITLE
tweak member partial with more reliably present #to_s

### DIFF
--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -1,6 +1,6 @@
 <tr class="<%= dom_class(member) %> attributes">
   <td class="thumbnail">
-    <%= render_thumbnail_tag member, { alt: member.title_or_label } %>
+    <%= render_thumbnail_tag member, { alt: member.to_s } %>
   </td>
   <td class="attribute attribute-filename ensure-wrapped"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
   <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>


### PR DESCRIPTION
In a context of nested membership across model types, the #title_or_label method can produce a ruby error, because it's defined (well, delegated to the solr_document) for Collection and FileSet presenters, but not the work presenter.  This replaces the call with #to_s, which is provided by all the presenters, and which itself just delegates to the solr document's #title_or_label, anyway.

An alternative solution would be to add :title_or_label to the methods that the work show presenters delegate to the solr_document.  But this felt cleaner.

Failing spec is unrelated and resolved by #587 