### PR TITLE
[ESSI-1932] consolidate FileSet Inherit, Copy job calls into work actor 

### DIFF
--- a/app/actors/essi/actors/create_with_remote_files_ordered_members_structure_actor.rb
+++ b/app/actors/essi/actors/create_with_remote_files_ordered_members_structure_actor.rb
@@ -9,7 +9,7 @@ module ESSI
 
       def update(env)
         structure = env.attributes.delete(:structure)&.deep_symbolize_keys
-        super(env) && save_structure(env,structure)
+        super(env) && save_structure(env,structure) && copy_visibility(env) && inherit_permissions(env)
       end
 
       private

--- a/lib/extensions/bulkrax/object_factory/create_with_dynamic_schema.rb
+++ b/lib/extensions/bulkrax/object_factory/create_with_dynamic_schema.rb
@@ -7,7 +7,7 @@ module Extensions
           attrs = create_attributes
           init_attrs = { dynamic_schema_id: attrs[:dynamic_schema_id] } if attrs[:dynamic_schema_id].present? && klass.new.respond_to?(:dynamic_schema_id)
           @object = klass.new(init_attrs)
-          object.reindex_extent = ::Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+          object.reindex_extent = ::Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX if defined?(::Hyrax::Adapters::NestingIndexAdapter) && object.respond_to?(:reindex_extent=)
           run_callbacks :save do
             run_callbacks :create do
               klass == ::Collection ? create_collection(attrs) : work_actor.create(environment(attrs))

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -92,6 +92,8 @@ Hyrax::CurationConcern.actor_factory.insert Hyrax::Actors::TransactionalRequest,
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesActor, ESSI::Actors::CreateWithRemoteFilesOrderedMembersStructureActor
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesOrderedMembersActor
 Hyrax::Actors::BaseActor.prepend Extensions::Hyrax::Actors::BaseActor::UndoAttributeArrayWrap
+Hyrax::Actors::FileSetActor.prepend Extensions::Hyrax::Actors::FileSetActor::CreateContent
+
 
 # .jp2 conversion settings
 Hydra::Derivatives.kdu_compress_path = ESSI.config.dig(:essi, :kdu_compress_path)

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -172,6 +172,9 @@ Hydra::Derivatives::Processors::Jpeg2kImage.prepend Extensions::Hydra::Derivativ
 IiifPrint::BlacklightIiifSearch::AnnotationDecorator.include Extensions::IiifPrint::BlacklightIiifSearch::AnnotationDecorator::AnnotationDecoratorCompatibility
 IiifPrint::IiifSearchDecorator.include Extensions::IiifPrint::IiifSearchDecorator::SearchDecoratorCompatibility
 
+# Patch iiif_print FileSet job calls
+IiifPrint::Data.include Extensions::IiifPrint::Data::InheritPermissionsJobCalls
+
 # support for nested works generating file_set sequences in manifests
 IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFManifest::ManifestBuilder::DeepFileSetEnumerator::NestedEach
 

--- a/lib/extensions/hyrax/actors/file_set_actor/create_content.rb
+++ b/lib/extensions/hyrax/actors/file_set_actor/create_content.rb
@@ -1,0 +1,35 @@
+# unmodified from hyrax
+module Extensions
+  module Hyrax
+    module Actors
+      module FileSetActor
+        module CreateContent
+          # Spawns asynchronous IngestJob unless ingesting from URL
+          # Called from FileSetsController, AttachFilesToWorkJob, IngestLocalFileJob, ImportUrlJob
+          # @param [Hyrax::UploadedFile, File] file the file uploaded by the user
+          # @param [Symbol, #to_s] relation
+          # @return [IngestJob, FalseClass] false on failure, otherwise the queued job
+          def create_content(file, relation = :original_file, from_url: false)
+            # If the file set doesn't have a title or label assigned, set a default.
+            file_set.label ||= label_for(file)
+            file_set.title = [file_set.label] if file_set.title.blank?
+            return false unless file_set.save # Need to save to get an id
+            if from_url
+              # If ingesting from URL, don't spawn an IngestJob; instead
+              # reach into the FileActor and run the ingest with the file instance in
+              # hand. Do this because we don't have the underlying UploadedFile instance
+              file_actor = build_file_actor(relation)
+              file_actor.ingest_file(wrapper!(file: file, relation: relation))
+              # Copy visibility and permissions from parent (work) to
+              # FileSets even if they come in from BrowseEverything
+              VisibilityCopyJob.perform_later(file_set.parent)
+              InheritPermissionsJob.perform_later(file_set.parent)
+            else
+              IngestJob.perform_later(wrapper!(file: file, relation: relation))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/actors/file_set_actor/create_content.rb
+++ b/lib/extensions/hyrax/actors/file_set_actor/create_content.rb
@@ -1,4 +1,4 @@
-# unmodified from hyrax
+# modified to apply helper jobs to individual FileSet
 module Extensions
   module Hyrax
     module Actors
@@ -20,10 +20,6 @@ module Extensions
               # hand. Do this because we don't have the underlying UploadedFile instance
               file_actor = build_file_actor(relation)
               file_actor.ingest_file(wrapper!(file: file, relation: relation))
-              # Copy visibility and permissions from parent (work) to
-              # FileSets even if they come in from BrowseEverything
-              VisibilityCopyJob.perform_later(file_set.parent)
-              InheritPermissionsJob.perform_later(file_set.parent)
             else
               IngestJob.perform_later(wrapper!(file: file, relation: relation))
             end

--- a/lib/extensions/iiif_print/data/inherit_permissions_job_calls.rb
+++ b/lib/extensions/iiif_print/data/inherit_permissions_job_calls.rb
@@ -1,0 +1,27 @@
+# unmodified from iiif_print
+module Extensions
+  module IiifPrint
+    module Data
+      module InheritPermissionsJobCalls
+        def self.included(base)
+          base.class_eval do
+            # Handler for after_create_fileset, to be called by block subscribing to
+            #   and overriding default Hyrax `:after_create_fileset` handler, via
+            #   app integrating iiif_print.
+            def self.handle_after_create_fileset(file_set, user)
+              handle_queued_derivative_attachments(file_set)
+              # Hyrax queues this job by default, and since iiif_print
+              #   overrides the single subscriber Hyrax uses to do so, we
+              #   must call this here:
+              ::FileSetAttachedEventJob.perform_later(file_set, user)
+              work = file_set.member_of[0]
+              # Hyrax CreateWithRemoteFilesActor has glaring omission re: this job,
+              #   so we call it here, once we have a fileset to copy permissions to.
+              ::InheritPermissionsJob.perform_later(work) unless work.nil?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/iiif_print/data/inherit_permissions_job_calls.rb
+++ b/lib/extensions/iiif_print/data/inherit_permissions_job_calls.rb
@@ -1,4 +1,5 @@
-# unmodified from iiif_print
+# modified from iiif_print
+# removes FileSet job calls handled elsewhere
 module Extensions
   module IiifPrint
     module Data
@@ -14,10 +15,6 @@ module Extensions
               #   overrides the single subscriber Hyrax uses to do so, we
               #   must call this here:
               ::FileSetAttachedEventJob.perform_later(file_set, user)
-              work = file_set.member_of[0]
-              # Hyrax CreateWithRemoteFilesActor has glaring omission re: this job,
-              #   so we call it here, once we have a fileset to copy permissions to.
-              ::InheritPermissionsJob.perform_later(work) unless work.nil?
             end
           end
         end


### PR DESCRIPTION
Currently, there are duplicate job calls made to:
* `InheritPermissionsJob`
* `VisibilityCopyJob`

across multiple places:
* `CreateWithRemoteFilesOrderedMembersStructureActor#create` (but not `#update`) 
* `IiifPrint::Data.handle_after_create_fileset` (applied to the `:after_create_fileset` callback)
* `FileSetActor#create_content`, specifically in the `from_url` branch case

The latter two call contexts produce, not only redundancy, but exponentially poor performance.  The jobs are called from each `FileSet`, but then run on the work, and loop through _all_ child FileSets.

The set of changes applied here:
* Adds coverage in the `#update` case, alongside the existing `#create` case, in the work-level context
* Removes the jobs calls from the latter two, FileSet-specific, contexts
* adds a safety catch for a possibly missing #reindex_extent method

Labeled for `configuration change` to indicate that we may wish to incorporate re-sequencing the job queue priority order, specifically lowering priority of the `default` queue, in conjunction with deployment.
