### PR TITLE
[ESSI-1947] refactor banner lookup fedora query to solr query, add memoization

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -18,7 +18,8 @@
     </div>
   </nav>
   <%= render '/campus' %>
-  <%= render 'shared/collection_banner'  if @presenter.respond_to?(:collection) && @presenter.collection%>
+  <% @collection_presenter = @presenter.try(:collection_banner_presenter) %>
+  <%= render 'shared/collection_banner' if @collection_presenter %>
   <%= render 'shared/collection_banner_for_collection' if @presenter.try(:collection?) && @presenter.model_name == 'Collection' %>
 
 </header>

--- a/app/views/shared/_collection_banner_link.html.erb
+++ b/app/views/shared/_collection_banner_link.html.erb
@@ -1,4 +1,3 @@
-<% @collection_presenter = Hyrax::CollectionPresenter.new(@presenter.collection, current_ability) %>
 <%= link_to collection_path(@collection_presenter.id) do %>
   <div class="row extended-banner extended-banner-linked hyc-banner-row">
     <div class="col-md-12">

--- a/app/views/shared/_collection_title_link.html.erb
+++ b/app/views/shared/_collection_title_link.html.erb
@@ -1,5 +1,3 @@
-<% @collection_presenter = Hyrax::CollectionPresenter.new(@presenter.collection, current_ability) %>
-
 <div class="row extended-banner extended-banner-title-linked hyc-banner-row">
   <% unless @collection_presenter.banner_file.blank? %>
     <div class="col-md-12 hyc-banner-container" style="background-image:url(<%= @collection_presenter.banner_file %>)">

--- a/lib/extensions/hyrax/file_set_presenter/collection_banner.rb
+++ b/lib/extensions/hyrax/file_set_presenter/collection_banner.rb
@@ -2,8 +2,8 @@ module Extensions
   module Hyrax
     module FileSetPresenter
       module CollectionBanner
-        def collection
-          @collection ||= parent&.collection
+        def collection_banner_presenter
+          @collection_banner_presenter ||= parent&.collection_banner_presenter
         end
       end
     end

--- a/lib/extensions/hyrax/file_set_presenter/collection_banner.rb
+++ b/lib/extensions/hyrax/file_set_presenter/collection_banner.rb
@@ -3,8 +3,7 @@ module Extensions
     module FileSetPresenter
       module CollectionBanner
         def collection
-          # return fileset collection if any, else nil
-          FileSet.find(id)&.parent&.member_of_collections&.first
+          @collection ||= parent&.collection
         end
       end
     end

--- a/lib/extensions/hyrax/work_show_presenter/collection_banner.rb
+++ b/lib/extensions/hyrax/work_show_presenter/collection_banner.rb
@@ -3,10 +3,11 @@ module Extensions
     module WorkShowPresenter
       module CollectionBanner
         def collection
-          # return work collection if any, else nil
+          return @collection if @collection
           return false if member_of_collection_ids.empty?
-
-          Collection.find(member_of_collection_ids.first)
+          solr_hit = Collection.search_with_conditions(id: member_of_collection_ids.first).first
+          @collection = SolrDocument.new(solr_hit) if solr_hit
+          return @collection
         end
       end
     end

--- a/lib/extensions/hyrax/work_show_presenter/collection_banner.rb
+++ b/lib/extensions/hyrax/work_show_presenter/collection_banner.rb
@@ -2,12 +2,8 @@ module Extensions
   module Hyrax
     module WorkShowPresenter
       module CollectionBanner
-        def collection
-          return @collection if @collection
-          return false if member_of_collection_ids.empty?
-          solr_hit = Collection.search_with_conditions(id: member_of_collection_ids.first).first
-          @collection = SolrDocument.new(solr_hit) if solr_hit
-          return @collection
+        def collection_banner_presenter
+          @collection_banner_presenter ||= member_of_collection_presenters.first
         end
       end
     end

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Hyrax::FileSetPresenter do
   end
 
   context 'When initialized' do
-    it '.collection is available' do
-      expect(subject).to respond_to(:collection)
+    it '.collection_banner_presenter is available' do
+      expect(subject).to respond_to(:collection_banner_presenter)
     end
     it '.campus_logo is available' do
       expect(subject).to respond_to(:campus_logo)

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Hyrax::WorkShowPresenter do
   end
 
   context 'When initialized' do
-    it '.collection is available' do
-      expect(subject).to respond_to(:collection)
+    it '.collection_banner_presenter is available' do
+      expect(subject).to respond_to(:collection_banner_presenter)
     end
     it '.campus_logo is available' do
       expect(subject).to respond_to(:campus_logo)


### PR DESCRIPTION
Two performance issues addressed here, in the FIleSetPresenter and WorkShowPresenter logic for collection lookup:
* both currently  make Fedora lookups to build a collection presenter, where a solr lookup suffices and is more performant
* a lack of memoization leads to the WorkShowPresenter collection lookup getting called twice, where once should suffice.
