### PR TITLE
[ESSI-1949] add members via a single save

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -93,7 +93,7 @@ Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesAc
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesOrderedMembersActor
 Hyrax::Actors::BaseActor.prepend Extensions::Hyrax::Actors::BaseActor::UndoAttributeArrayWrap
 Hyrax::Actors::FileSetActor.prepend Extensions::Hyrax::Actors::FileSetActor::CreateContent
-
+Hyrax::Actors::ApplyOrderActor.prepend Extensions::Hyrax::Actors::ApplyOrderActor::AddMembersSingleSave
 
 # .jp2 conversion settings
 Hydra::Derivatives.kdu_compress_path = ESSI.config.dig(:essi, :kdu_compress_path)

--- a/lib/extensions/hyrax/actors/apply_order_actor/add_members_single_save.rb
+++ b/lib/extensions/hyrax/actors/apply_order_actor/add_members_single_save.rb
@@ -1,4 +1,4 @@
-# unmodified from hyrax
+# modified from hyrax: #save! call moved outside of loop
 module Extensions
   module Hyrax
     module Actors
@@ -9,11 +9,11 @@ module Extensions
               work = ::ActiveFedora::Base.find(work_id)
               if can_edit_both_works?(env, work)
                 env.curation_concern.ordered_members << work
-                env.curation_concern.save!
               else
                 env.curation_concern.errors[:ordered_member_ids] << "Works can only be related to each other if user has ability to edit both."
               end
             end
+            env.curation_concern.save!
           end
         end
       end

--- a/lib/extensions/hyrax/actors/apply_order_actor/add_members_single_save.rb
+++ b/lib/extensions/hyrax/actors/apply_order_actor/add_members_single_save.rb
@@ -1,0 +1,22 @@
+# unmodified from hyrax
+module Extensions
+  module Hyrax
+    module Actors
+      module ApplyOrderActor
+        module AddMembersSingleSave
+          def add_new_work_ids_not_already_in_curation_concern(env, ordered_member_ids)
+            (ordered_member_ids - env.curation_concern.ordered_member_ids).each do |work_id|
+              work = ::ActiveFedora::Base.find(work_id)
+              if can_edit_both_works?(env, work)
+                env.curation_concern.ordered_members << work
+                env.curation_concern.save!
+              else
+                env.curation_concern.errors[:ordered_member_ids] << "Works can only be related to each other if user has ability to edit both."
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Saves once after adding all new ordered_members, rather than once per item.