### PR TITLE
DRAFT [ESSI-1949] cleanup nil member handling

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -93,7 +93,7 @@ Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithRemoteFilesAc
 Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesOrderedMembersActor
 Hyrax::Actors::BaseActor.prepend Extensions::Hyrax::Actors::BaseActor::UndoAttributeArrayWrap
 Hyrax::Actors::FileSetActor.prepend Extensions::Hyrax::Actors::FileSetActor::CreateContent
-
+Hyrax::Actors::ApplyOrderActor.prepend Extensions::Hyrax::Actors::ApplyOrderActor::CleanupMissingId
 
 # .jp2 conversion settings
 Hydra::Derivatives.kdu_compress_path = ESSI.config.dig(:essi, :kdu_compress_path)

--- a/lib/extensions/hyrax/actors/apply_order_actor/cleanup_missing_id.rb
+++ b/lib/extensions/hyrax/actors/apply_order_actor/cleanup_missing_id.rb
@@ -1,0 +1,18 @@
+# unmodified from hyrax
+module Extensions
+  module Hyrax
+    module Actors
+      module ApplyOrderActor
+        module CleanupMissingId
+          def cleanup_ids_to_remove_from_curation_concern(curation_concern, ordered_member_ids)
+            (curation_concern.ordered_member_ids - ordered_member_ids).each do |old_id|
+              work = ::ActiveFedora::Base.find(old_id)
+              curation_concern.ordered_members.delete(work)
+              curation_concern.members.delete(work)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/actors/apply_order_actor/cleanup_missing_id.rb
+++ b/lib/extensions/hyrax/actors/apply_order_actor/cleanup_missing_id.rb
@@ -1,4 +1,4 @@
-# unmodified from hyrax
+# modified from hyrax: skip any nil ids
 module Extensions
   module Hyrax
     module Actors
@@ -6,6 +6,7 @@ module Extensions
         module CleanupMissingId
           def cleanup_ids_to_remove_from_curation_concern(curation_concern, ordered_member_ids)
             (curation_concern.ordered_member_ids - ordered_member_ids).each do |old_id|
+              next unless old_id
               work = ::ActiveFedora::Base.find(old_id)
               curation_concern.ordered_members.delete(work)
               curation_concern.members.delete(work)


### PR DESCRIPTION
_In draft status because we might prefer this process to fail, so that we can catch it and fix the invalid `ordered_members` contents?_