### PR TITLE
DRAFT add error catching for some reindexing points of failure

### DIFF
--- a/app/models/concerns/essi/ocr_behavior.rb
+++ b/app/models/concerns/essi/ocr_behavior.rb
@@ -3,7 +3,12 @@ module ESSI
     extend ActiveSupport::Concern
 
     def ocr_searchable?
-      self.ocr_state == 'searchable'
+      begin
+        self.ocr_state == 'searchable'
+      rescue => error
+        Rails.logger.error "Error reading ocr_state for #{self.class} #{self.id}: #{error.message}"
+        false
+      end
     end
 
     def to_solr(solr_doc = {})

--- a/app/models/concerns/essi/pdf_behavior.rb
+++ b/app/models/concerns/essi/pdf_behavior.rb
@@ -3,7 +3,12 @@ module ESSI
     extend ActiveSupport::Concern
 
     def pdf_downloadable?
-      [self.pdf_state, self.pdf_state.try(:first)].include? 'downloadable'
+      begin
+        [self.pdf_state, self.pdf_state.try(:first)].include? 'downloadable'
+      rescue => error
+        Rails.logger.error "Error reading pdf_state for #{self.class} #{self.id}: #{error.message}"
+        false
+      end
     end
 
     def to_solr(solr_doc = {})

--- a/app/models/concerns/structural_metadata.rb
+++ b/app/models/concerns/structural_metadata.rb
@@ -9,10 +9,19 @@ module StructuralMetadata
     super.tap do |doc|
       doc[ActiveFedora.index_field_mapper.solr_name("logical_order",
                                                     :stored_searchable)] =
-        [logical_order.order.to_json]
+        [safe_logical_order_json]
       doc[ActiveFedora.index_field_mapper.solr_name("logical_order_headings",
                                                     :stored_searchable)] =
         logical_order.object.each_section.map(&:label)
+    end
+  end
+
+  def safe_logical_order_json
+    begin
+      logical_order.order.to_json
+    rescue => error
+      Rails.logger.error "Error reading logical_order for #{self.class} #{self.id}: #{error.message}"
+      {}.to_json
     end
   end
 end


### PR DESCRIPTION
I think we've had errors in the past with works using an outdated flexible metadata schema, missing the `ocr_state` or `pdf_state` attribute that all members of their class are presumed to have during indexing.

There's currently a work that refuses to save due to reindexing failure of logical_order.