### PR TITLE
[ESSI-1928] Hidden content focusable

### DIFF
--- a/app/assets/stylesheets/digital_collections/_layout.scss
+++ b/app/assets/stylesheets/digital_collections/_layout.scss
@@ -232,6 +232,11 @@ a:hover, a:focus {
   margin: auto;
 }
 
+.home_all_collections {
+  display: table;
+  margin: 1em auto;
+}
+
 .campus {
   background-color: #fff;
   margin: 1em;

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -1,0 +1,16 @@
+<div>
+  <div class="featured-item-title">
+    <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>
+    <h3>
+      <%= link_to [main_app, featured] do %>
+        <%= render_thumbnail_tag(featured, {width: 90}, {suppress_link: true}) + featured.title.first %>
+      <% end %>
+    </h3>
+  </div>
+  <div class="featured-field featured-item-depositor">
+    <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.depositor_label') %>:</span> <%= link_to_profile featured.depositor(t('hyrax.homepage.featured_works.document.depositor_missing')) %>
+  </div>
+  <div class="featured-field featured-item-keywords">
+    <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.keyword_label') %>:</span> <%= link_to_facet_list(featured.keyword, 'keyword', t('hyrax.homepage.featured_works.document.keyword_missing')) %>
+  </div>
+</div>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -3,7 +3,7 @@
     <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>
     <h3>
       <%= link_to [main_app, featured] do %>
-        <%= render_thumbnail_tag(featured, {width: 90}, {suppress_link: true}) + featured.title.first %>
+        <%= render_thumbnail_tag(featured, {width: 90, alt: "Thumbnail for " + featured.title.first}, {suppress_link: true}) + featured.title.first %>
       <% end %>
     </h3>
   </div>

--- a/app/views/hyrax/homepage/_featured_works.html.erb
+++ b/app/views/hyrax/homepage/_featured_works.html.erb
@@ -1,0 +1,19 @@
+<h2 class="sr-only"><%= t('hyrax.homepage.featured_works.title') %></h2>
+<% if @featured_work_list.empty? %>
+  <p><%= t('hyrax.homepage.featured_works.no_works') %></p>
+<% elsif can? :update, FeaturedWork %>
+  <%= form_for [hyrax, @featured_work_list] do |f| %>
+    <div class="panel-group dd" id="dd">
+      <ol id="featured_works">
+        <%= f.fields_for :featured_works do |featured| %>
+          <%= render 'sortable_featured', f: featured %>
+        <% end %>
+      </ol>
+    </div>
+    <%= f.submit("Save order", class: 'btn btn-default') %>
+  <% end %>
+<% else %>
+  <ol class="list-group list-group-striped" id="featured_works">
+    <%= render partial: 'featured', collection: @featured_work_list.featured_works %>
+  </ol>
+<% end %>

--- a/app/views/hyrax/homepage/_featured_works.html.erb
+++ b/app/views/hyrax/homepage/_featured_works.html.erb
@@ -1,19 +1,21 @@
-<h2 class="sr-only"><%= t('hyrax.homepage.featured_works.title') %></h2>
-<% if @featured_work_list.empty? %>
-  <p><%= t('hyrax.homepage.featured_works.no_works') %></p>
-<% elsif can? :update, FeaturedWork %>
-  <%= form_for [hyrax, @featured_work_list] do |f| %>
-    <div class="panel-group dd" id="dd">
-      <ol id="featured_works">
-        <%= f.fields_for :featured_works do |featured| %>
-          <%= render 'sortable_featured', f: featured %>
+<% if !@featured_work_list.empty? %>
+    <div class="col-lg-6">
+        <h2><%= t('hyrax.homepage.featured_works.title') %></h2>
+        <% if can? :update, FeaturedWork %>
+        <%= form_for [hyrax, @featured_work_list] do |f| %>
+            <div class="panel-group dd" id="dd">
+            <ol id="featured_works">
+                <%= f.fields_for :featured_works do |featured| %>
+                <%= render 'sortable_featured', f: featured %>
+                <% end %>
+            </ol>
+            </div>
+            <%= f.submit("Save order", class: 'btn btn-default') %>
         <% end %>
-      </ol>
+        <% else %>
+        <ol class="list-group list-group-striped" id="featured_works">
+            <%= render partial: 'featured', collection: @featured_work_list.featured_works %>
+        </ol>
+        <% end %>
     </div>
-    <%= f.submit("Save order", class: 'btn btn-default') %>
-  <% end %>
-<% else %>
-  <ol class="list-group list-group-striped" id="featured_works">
-    <%= render partial: 'featured', collection: @featured_work_list.featured_works %>
-  </ol>
 <% end %>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -6,23 +6,21 @@
     <%= render 'home_content_campuses' %>
   </div>
 </div>
-<div class="home_featured_tabs">
-  <ul id="homeTabs" class="nav nav-buttons" role="tablist">
-    <li class="active" role="tab"><a href="#featured_container" data-toggle="tab" id="featureTab" class="button"><%= t('hyrax.homepage.featured_works.tab_label') %></a></li>
-    <li role="tab"><a href="#recently_uploaded" data-toggle="tab" id="recentTab" class="button"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a></li>
-  </ul>
-  <div class="tab-content">
-    <div class="tab-pane fade in active" id="featured_container" role="tabpanel" aria-labelledby="featureTab">
-      <%= render 'featured_works' %>
-    </div>
-    <div class="tab-pane fade" id="recently_uploaded" role="tabpanel" aria-labelledby="recentTab">
-      <%= render 'recently_uploaded', recent_documents: @recent_documents %>
-    </div>
+
+<div class="home_all_collections">
+  <%= 
+    link_to t('hyrax.homepage.admin_sets.link'),
+              main_app.search_catalog_path(
+                f: { human_readable_type_sim: ["Collection"]},
+                sort: "num_works_isi desc"
+              ),
+              class: 'button' 
+  %>
+</div>
+
+<div class="container-fluid">
+  <div class="row">
+    <%= render 'featured_works' %>
+    <%= render 'recently_uploaded', recent_documents: @recent_documents %>
   </div>
-</div><!-- /.col-xs-6 -->
-<div class="centered">
-  <%= link_to t('hyrax.homepage.admin_sets.link'),
-              main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]},
-                                           sort: "num_works_isi desc"),
-              class: 'button' %>
 </div>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,0 +1,18 @@
+<li class="recent-item">
+    <div class="row">
+      <div class="col-sm-12">
+        <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
+        <h3>
+          <%= link_to [main_app, recent_document] do %>
+            <%= render_thumbnail_tag(recent_document, {width: 90}, {suppress_link: true}) + recent_document.to_s %>
+          <% end %>
+        </h3>
+        <p class="recent-field">
+          <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.depositor_label') %>:</span> <%= link_to_profile recent_document.depositor(t('hyrax.homepage.recently_uploaded.document.depositor_missing')) %>
+        </p>
+        <p class="recent-field">
+          <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.keyword_label') %>:</span> <%= link_to_facet_list(recent_document.keyword, 'keyword', t('hyrax.homepage.recently_uploaded.document.keyword_missing')).html_safe %>
+        </p>
+      </div>
+    </div>
+</li>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,7 @@
         <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
         <h3>
           <%= link_to [main_app, recent_document] do %>
-            <%= render_thumbnail_tag(recent_document, {width: 90}, {suppress_link: true}) + recent_document.to_s %>
+            <%= render_thumbnail_tag(recent_document, {width: 90, alt: "Thumbnail for " + recent_document.to_s}, {suppress_link: true}) + recent_document.to_s %>
           <% end %>
         </h3>
         <p class="recent-field">

--- a/app/views/hyrax/homepage/_recently_uploaded.html.erb
+++ b/app/views/hyrax/homepage/_recently_uploaded.html.erb
@@ -1,0 +1,10 @@
+<h2 class="sr-only"><%= t('hyrax.homepage.recently_uploaded.title') %></h2>
+<% if recent_documents.blank? %>
+  <p><%= t('.no_public') %></p>
+<% else %>
+  <div id="recent_docs">
+    <ol class="list-group list-group-striped recent_uploads">
+      <%= render partial: "recent_document", collection: recent_documents %>
+    </ol>
+  </div>
+<% end %>

--- a/app/views/hyrax/homepage/_recently_uploaded.html.erb
+++ b/app/views/hyrax/homepage/_recently_uploaded.html.erb
@@ -1,10 +1,14 @@
-<h2 class="sr-only"><%= t('hyrax.homepage.recently_uploaded.title') %></h2>
-<% if recent_documents.blank? %>
-  <p><%= t('.no_public') %></p>
-<% else %>
-  <div id="recent_docs">
-    <ol class="list-group list-group-striped recent_uploads">
-      <%= render partial: "recent_document", collection: recent_documents %>
-    </ol>
+<% if !recent_documents.blank? %>
+  <% if !@featured_work_list.empty? %>
+  <div class="col-lg-6">
+  <% else %>
+  <div>
+  <% end %>
+    <h2><%= t('hyrax.homepage.recently_uploaded.title') %></h2>
+    <div id="recent_docs">
+      <ol class="list-group list-group-striped recent_uploads">
+        <%= render partial: "recent_document", collection: recent_documents %>
+      </ol>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
This PR will make a noticeable change to the home page.

1. Moves "View All Collections" Button up to just below Campus Collection options.
2. Removes Featured Works and Recently Uploaded buttons
3. Displays Featured Works - if any - as left column on large screens
4. Displays Recently Uploaded as right column on large screens if Featured Works
5. Both sections expand to full width on medium screens and smaller 
6. Adds alt text to works thumbnails in both sections

Resolves SiteImprove Issues:

- Role with implied hidden content has keyboard focus
- Image missing a text alternative