### PR TITLE
[ESSI-1927] Accessibility fix. Sets UV maximum-scale to 3.

### DIFF
--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -6,7 +6,7 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>Universal Viewer</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=yes" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes" />
     <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" type="text/css" href="uv.css">
     <script type="text/javascript" src="lib/offline.js"></script>


### PR DESCRIPTION
According to [MDN Webdocs](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag), viewport maximum-scale should be set to 3 or higher for accessibility reasons. 