### PR TITLE
[ESSI-1280] remote metadata lookup

### DIFF
--- a/config/context.yml
+++ b/config/context.yml
@@ -30,7 +30,7 @@
   coverage:
     "@id": dc:coverage
   creator:
-    "@id": dc:creator
+    "@id": dcterms:creator
   date:
     "@id": dc:date
   description:
@@ -48,7 +48,7 @@
   source:
     "@id": dc:source
   subject:
-    "@id": dc:subject
+    "@id": dcterms:subject
   type:
     "@id": dc:type
   date_created:
@@ -61,7 +61,7 @@
   purl:
     "@id": dc:identifier
   date_published:
-    "@id": dcterms:issued
+    "@id": dcterms:date
   modified:
     "@id": dcterms:modified
   replaces:


### PR DESCRIPTION
Resolves the expected vs actual predicates for two properties that are configured as dc/terms rather than dc/elements, currently blocking successful remote metadata import:
* creator: http://purl.org/dc/elements/1.1/creator vs http://purl.org/dc/terms/creator
* subject: http://purl.org/dc/elements/1.1/subject vs http://purl.org/dc/terms/subject
* date_published (date_created): http://purl.org/dc/terms/issued vs http://purl.org/dc/terms/date
