### PR TITLE
Display "more >>>" links for facets missing them (limited to first 10)

### DIFF
--- a/app/controllers/concerns/essi/dynamic_catalog_behavior.rb
+++ b/app/controllers/concerns/essi/dynamic_catalog_behavior.rb
@@ -35,6 +35,7 @@ module ESSI
             if prop.indexing.include?("facetable")
               name = solr_name(prop.name.to_s, :facetable)
               facet_args = { label: label }
+              facet_args.merge!({ limit: true }) # @todo read value from property config, if supplied
               if prop.indexing.include?("admin_only")
                 facet_args[:if] = lambda { |context, _field_config, _document| context.try(:current_user)&.admin? }
               end


### PR DESCRIPTION
Blacklight facet behavior is problematic when limit is undefined, or explicitly false or nil.  Our other facets in `app/controllers/catalog_controller.rb` all have `limit: true` (which is functionally equivalent to `limit: 10`), so this change adds that setting for allinson_flex facets.