### PR TITLE
add more hint text for source metadata identifier behavior across worktypes

### DIFF
--- a/app/views/records/edit_fields/_source_metadata_identifier.html.erb
+++ b/app/views/records/edit_fields/_source_metadata_identifier.html.erb
@@ -10,5 +10,9 @@
       required: f.object.required?(key),
       hint: dynamic_hint(key) %>
 <% end %>
+<p class="help-block">
+  For the following work types, the value above is saved and can be used to retrieve remote metadata: Archival Material, Paged Resource, Bib Record<br/>
+  For the remaining work types, the value is saved but cannot be used to retrieve or refresh remote metadata: Image, Scientific
+</p>
 <%= check_box_tag :refresh_remote_metadata, 1, false %>
 <label for="refresh_metadata">Refresh metadata from <%= t('services.metadata') %></label>


### PR DESCRIPTION
Adds block of help text regarding how retrieving, refreshing metadata does not apply to Image or Scientific work types