### PR TITLE
[ESSI-2021] drop indexing now provided by allinson_flex

### DIFF
--- a/app/indexers/concerns/essi/indexes_num_pages.rb
+++ b/app/indexers/concerns/essi/indexes_num_pages.rb
@@ -4,12 +4,6 @@ module ESSI
   module IndexesNumPages
     extend ActiveSupport::Concern
 
-    included do
-      self.new(nil).rdf_service.class_eval do
-        self.stored_and_facetable_fields += %i[num_pages]
-      end
-    end
-
     # added to properly drop "m" from number_of_pages indexing
     def generate_solr_document
       super.tap do |solr_doc|


### PR DESCRIPTION
We do need the 2nd part of this module to provide the indexing needing to sort by page count, but the first part is both:
- redundant, as allinson_flex can configure indexing and faceting
- brittle, as it can error out on a worktype that does not unconditionally provide the `num_pages` attribute

You can test this locally by removing `num_pages` from a specific worktype -- say, BibRecord -- and try saving an instance of that worktype.  Without this fix, you should get a ruby error; with this fix, it should successfully save.