### PR TITLE
[ESSI-2027] use context-specific manifest metadata labels

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -24,7 +24,6 @@ IIIFManifest::ManifestBuilder::ImageBuilder.prepend Extensions::IIIFManifest::Ma
 Hyrax::Forms::FileManagerForm.include Extensions::Hyrax::Forms::FileManagerForm::ViewingMetadata
 Hyrax::FileSetPresenter.include Extensions::Hyrax::FileSetPresenter::ViewingHint
 
-# TODO: determine if needed?
 # iiif manifest support for parent work when using IIIF Print
 # this is responsible for displaying the parent metadata above the child metadata in the UV metadata pane
 Hyrax::WorkShowPresenter.prepend Extensions::Hyrax::WorkShowPresenter::ManifestMetadata
@@ -172,6 +171,10 @@ IiifPrint::IiifSearchDecorator.include Extensions::IiifPrint::IiifSearchDecorato
 
 # Patch iiif_print FileSet job calls
 IiifPrint::Data.include Extensions::IiifPrint::Data::InheritPermissionsJobCalls
+
+# Patch iiif_print manifest metadata
+IiifPrint.include Extensions::IiifPrint::ManifestMetadata
+IiifPrint::IiifManifestPresenterBehavior.include Extensions::IiifPrint::IiifManifestPresenterBehavior::ManifestMetadata
 
 # support for nested works generating file_set sequences in manifests
 IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFManifest::ManifestBuilder::DeepFileSetEnumerator::NestedEach

--- a/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
+++ b/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
@@ -15,16 +15,8 @@ module Extensions
           iiif_manifest_presenter.manifest_metadata(fields: sorted_manifest_fields)
         end
 
-        def static_iiif_metadata_fields
-          ::Hyrax.config.iiif_metadata_fields
-        end
-
         def public_view_properties
           @public_view_properties ||= dynamic_schema_service.view_properties.reject { |k,v| v[:admin_only] }
-        end
-
-        def label_for(field)
-          public_view_properties.dig(field, :label) || I18n.t("simple_form.labels.defaults.#{field}", default: field.to_s.humanize)
         end
 
         Field = Struct.new(:name, :value, :indexing, keyword_init: true)

--- a/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
+++ b/lib/extensions/hyrax/work_show_presenter/manifest_metadata.rb
@@ -12,7 +12,7 @@ module Extensions
           # Using IIIF Print's approach to display parent metadata
           iiif_manifest_presenter = ::Hyrax::IiifManifestPresenter.new(self)
           iiif_manifest_presenter.ability = current_ability
-          iiif_manifest_presenter.manifest_metadata
+          iiif_manifest_presenter.manifest_metadata(fields: sorted_manifest_fields)
         end
 
         def static_iiif_metadata_fields
@@ -25,6 +25,18 @@ module Extensions
 
         def label_for(field)
           public_view_properties.dig(field, :label) || I18n.t("simple_form.labels.defaults.#{field}", default: field.to_s.humanize)
+        end
+
+        Field = Struct.new(:name, :value, :indexing, keyword_init: true)
+
+        def manifest_fields
+          @manifest_fields ||= dynamic_schema_service.send(:properties).map do |prop|
+            Field.new(name: prop[0], value: prop[1][:display_label], indexing: prop[1][:indexing])
+          end
+        end
+
+        def sorted_manifest_fields
+          @sorted_manifest_fields ||= ::IiifPrint.fields_for_allinson_flex(fields: manifest_fields)
         end
       end
     end

--- a/lib/extensions/iiif_print/iiif_manifest_presenter_behavior/manifest_metadata.rb
+++ b/lib/extensions/iiif_print/iiif_manifest_presenter_behavior/manifest_metadata.rb
@@ -1,0 +1,17 @@
+module Extensions
+  module IiifPrint
+    module IiifManifestPresenterBehavior
+      module ManifestMetadata
+        def self.included(base)
+          base.class_eval do
+            # unmodified from iiif_print
+            def manifest_metadata
+              # ensure we are using a SolrDocument
+              @manifest_metadata ||= IiifPrint.manifest_metadata_from(work: model.solr_document, presenter: self)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/iiif_print/iiif_manifest_presenter_behavior/manifest_metadata.rb
+++ b/lib/extensions/iiif_print/iiif_manifest_presenter_behavior/manifest_metadata.rb
@@ -4,10 +4,10 @@ module Extensions
       module ManifestMetadata
         def self.included(base)
           base.class_eval do
-            # unmodified from iiif_print
-            def manifest_metadata
+            # modified from iiif_print to optionally receive fields
+            def manifest_metadata(fields: ::IiifPrint.default_metadata_fields)
               # ensure we are using a SolrDocument
-              @manifest_metadata ||= IiifPrint.manifest_metadata_from(work: model.solr_document, presenter: self)
+              @manifest_metadata ||= ::IiifPrint.manifest_metadata_from(work: model.solr_document, presenter: self, fields: fields)
             end
           end
         end

--- a/lib/extensions/iiif_print/manifest_metadata.rb
+++ b/lib/extensions/iiif_print/manifest_metadata.rb
@@ -1,0 +1,16 @@
+module Extensions
+  module IiifPrint
+    module ManifestMetadata
+      def self.included(base)
+        base.class_eval do
+          # unmodified from iiif_print
+          def self.manifest_metadata_from(work:, presenter:)
+            current_ability = presenter.try(:ability) || presenter.try(:current_ability)
+            base_url = presenter.try(:base_url) || presenter.try(:request)&.base_url
+            ::IiifPrint.manifest_metadata_for(work: work, current_ability: current_ability, base_url: base_url)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/iiif_print/manifest_metadata.rb
+++ b/lib/extensions/iiif_print/manifest_metadata.rb
@@ -3,11 +3,15 @@ module Extensions
     module ManifestMetadata
       def self.included(base)
         base.class_eval do
-          # unmodified from iiif_print
-          def self.manifest_metadata_from(work:, presenter:)
+          # modified from iiif_print to receive fields
+          def self.manifest_metadata_from(work:, presenter:, fields: default_metadata_fields)
             current_ability = presenter.try(:ability) || presenter.try(:current_ability)
             base_url = presenter.try(:base_url) || presenter.try(:request)&.base_url
-            ::IiifPrint.manifest_metadata_for(work: work, current_ability: current_ability, base_url: base_url)
+            ::IiifPrint.manifest_metadata_for(work: work, current_ability: current_ability, base_url: base_url, fields: fields)
+          end
+
+          def self.default_metadata_fields
+            defined?(::AllinsonFlex) ? fields_for_allinson_flex : default_fields
           end
         end
       end


### PR DESCRIPTION
`iiif_print` looks up the allinson_flex Profile records directly, which makes it context-unaware.  This results in always using the default label, which can result in an inconsistency with the Show page where context-aware dynamic_schema lookup is used.

This  patches `iiif_print` behavior to be context-aware, until such time as the issue is patched upstream.

_This does not currently recreate [the special handling of the collection property](https://github.com/scientist-softserv/iiif_print/blob/main/lib/iiif_print.rb#L262-L264); we should test whether that needs to be added._

Raised corresponding issue upstream at:
https://github.com/scientist-softserv/iiif_print/issues/378