### PR TITLE
[ESSI-2023] add FileSet indexing re: parentage, collection branding use

### DIFF
--- a/app/indexers/essi/file_set_indexer.rb
+++ b/app/indexers/essi/file_set_indexer.rb
@@ -7,10 +7,21 @@ module ESSI
     def generate_solr_document
       super.tap do |solr_doc|
         parent = object.parent
-        unless parent.nil?
+        collection_branding_info = object.collection_branding_info
+        if parent
+          solr_doc['parented_bsi'] = true
+          solr_doc['collection_branding_bsi'] = false
           solr_doc['is_page_of_ssi'] = parent.id
           solr_doc['parent_path_tesi'] = Rails.application.routes.url_helpers.polymorphic_path(parent)
+        elsif collection_branding_info
+          solr_doc['parented_bsi'] = false
+          solr_doc['collection_branding_bsi'] = true
+          solr_doc['is_collection_brand_of_ssi'] = collection_branding_info.collection_id
+        else
+          solr_doc['parented_bsi'] = false
+          solr_doc['collection_branding_bsi'] = false
         end
+
         solr_doc['word_boundary_tsi'] = IiifPrint::TextExtraction::AltoReader.new(object.extracted_text.content).json if object.extracted_text.present?
         solr_doc[Solrizer.solr_name('iiif_index_strategy')] = IndexerHelper.iiif_index_strategy
 

--- a/app/models/collection_branding_info.rb
+++ b/app/models/collection_branding_info.rb
@@ -42,7 +42,9 @@ class CollectionBrandingInfo < ApplicationRecord
       user = User.find_by_user_key(user_key)
       attach_file_set(uploaded_file, user)
     end
-    super()
+    result = super()
+    file_set&.save
+    return result
   end
 
   def file_set_image_path

--- a/spec/factories/collection_branding_infos.rb
+++ b/spec/factories/collection_branding_infos.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
       target_url { '' }
       height { 0 }
       width { 0 }
-      file_set_id { '1' }
+      file_set_id { nil }
       image_path { '/fake/path/to/image' }
     end
    initialize_with { CollectionBrandingInfo.new(collection_id: collection_id, filename: filename, role: role, alt_txt: alt_text, target_url: target_url, local_path: local_path, file_set_id: file_set_id, image_path: image_path) }
@@ -24,7 +24,7 @@ FactoryBot.define do
       target_url { 'http://example.com/' }
       height { 0 }
       width { 0 }
-      file_set_id { '1' }
+      file_set_id { nil }
       image_path { '/fake/path/to/image' }
     end
    initialize_with { CollectionBrandingInfo.new(collection_id: collection_id, filename: filename, role: role, alt_txt: alt_text, target_url: target_url, local_path: local_path, file_set_id: file_set_id, image_path: image_path) }

--- a/spec/models/collection_branding_info_spec.rb
+++ b/spec/models/collection_branding_info_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CollectionBrandingInfo, type: :model do
   let(:banner) { FactoryBot.build(:collection_branding_banner) }
-  let(:file_set) { double(id: 'file_set_id', uri: 'file_set_uri') }
+  let(:file_set) { FactoryBot.create(:file_set, id: 'file_set_id', uri: 'file_set_uri') }
   let(:version) { double(uri: 'version_uri') }
   let(:versions) { double(any?: true, all: self, last: version) }
 


### PR DESCRIPTION
Note that during a FileSet's creation, whether in the UI or bulkrax upload, it is initially saved as an orphan, and parent information is added in a subsequent re-save.  (I initially logged a warning when a file was saved in an orphan state, but removed that line as it would provide more noise than signal.)