### PR TITLE
Essi-2033 IIIF and external storage checks

### DIFF
--- a/app/services/essi/external_storage_service.rb
+++ b/app/services/essi/external_storage_service.rb
@@ -75,6 +75,14 @@ module ESSI
       end
     end
 
+    # Health check of external storage bucket
+    # @return boolean
+    def health
+      @external_storage_pool.with do |client|
+        client.head_bucket(bucket: @bucket).successful?
+      end
+    end
+
     def id_to_http_uri(id)
       "#{endpoint}/#{@bucket}/#{prefix_id(id)}"
     end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
 
     checks.register "cache", OkComputer::GenericCacheCheck.new
 
-    iiif_url = ESSI.config[:cantaloupe][:iiif_server_url]
+    iiif_url = ESSI.config[:cantaloupe][:iiif_server_url].chomp('/')
     checks.register "iiif", OkComputer::HttpCheck.new(iiif_url)
 
     solr_url = ESSI.config[:solr][:url]

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
     checks.register "fcrepo", EssiDevOps::FcrepoCheck.new(fcrepo_url, 10,
                                                         auth_options)
 
+    checks.register "external_storage", EssiDevOps::ExternalStorageCheck.new
+
     checks.register "image_sync", EssiDevOps::ImageSyncCheck.new if File.file?('/run/secrets/distributed_deployment')
 
     # TODO: Remove this when CheckCollection instances not setting

--- a/lib/essi_dev_ops/external_storage_check.rb
+++ b/lib/essi_dev_ops/external_storage_check.rb
@@ -1,0 +1,16 @@
+module EssiDevOps
+  # Checks health of external storage service
+  include OkComputer
+  class ExternalStorageCheck < Check
+    def check
+      if ESSI::ExternalStorageService.health
+        mark_message "External storage is up"
+      else
+        raise "External storage check failed"
+      end
+    rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
+      mark_failure
+      mark_message e
+    end
+  end
+end


### PR DESCRIPTION
Removes any trailing slash from the IIIF server url when configuring that OkComputer check. Our Cantaloupe 5 server is redirecting when it is present and that is not allowed by the check.

Adds a check for the external storage service. This is implemented as a HEAD request for the bucket.