### PR TITLE
Render orphan filesets

### DIFF
--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -1,6 +1,6 @@
 <h2>File Details</h2>
 <dl class="dl-horizontal file-show-term file-show-details">
-  <% if current_ability&.can?(:edit, @presenter.parent.id) %>
+  <% if @presenter.parent&.id && current_ability&.can?(:edit, @presenter.parent.id) %>
   <dt>Depositor</dt>
   <dd itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person"><span itemprop="name"><%= link_to_profile @presenter.depositor %></span></dd>
   <% end %>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -13,7 +13,7 @@
 
       <%# TODO: render 'show_descriptions' See https://github.com/samvera/hyrax/issues/1481 %>
       <%= render 'show_details' %>
-      <% if current_ability&.can?(:edit, @presenter.parent.id) %>
+      <% if @presenter.parent&.id && current_ability&.can?(:edit, @presenter.parent.id) %>
         <%= render 'hyrax/users/activity_log', events: @presenter.events %>
       <% end %>
     </div><!-- /columns second -->

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -184,3 +184,6 @@ IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFMan
 
 # support for memoizing the member_presenter_factory
 Hyrax::WorkShowPresenter.prepend Extensions::Hyrax::WorkShowPresenter::MemberPresenterFactoryMemoization
+
+# support for rendering an orphan FileSet
+Hyrax::FileSetsController.prepend Extensions::Hyrax::FileSetsController::RenderOrphanFileSet

--- a/lib/extensions/hyrax/file_sets_controller/render_orphan_file_set.rb
+++ b/lib/extensions/hyrax/file_sets_controller/render_orphan_file_set.rb
@@ -1,0 +1,20 @@
+# unmodified from hyrax 2.9.6
+module Extensions
+  module Hyrax
+    module FileSetsController
+      module RenderOrphanFileSet
+
+        # unmodified from hyrax
+        def add_breadcrumb_for_action
+          case action_name
+          when 'edit'.freeze
+            add_breadcrumb I18n.t("hyrax.file_set.browse_view"), main_app.hyrax_file_set_path(params["id"])
+          when 'show'.freeze
+            add_breadcrumb presenter.parent.to_s, main_app.polymorphic_path(presenter.parent)
+            add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/file_sets_controller/render_orphan_file_set.rb
+++ b/lib/extensions/hyrax/file_sets_controller/render_orphan_file_set.rb
@@ -1,16 +1,16 @@
-# unmodified from hyrax 2.9.6
+# modified from hyrax 2.9.6
 module Extensions
   module Hyrax
     module FileSetsController
       module RenderOrphanFileSet
 
-        # unmodified from hyrax
+        # modified from hyrax to handle missing parent without ruby error
         def add_breadcrumb_for_action
           case action_name
           when 'edit'.freeze
             add_breadcrumb I18n.t("hyrax.file_set.browse_view"), main_app.hyrax_file_set_path(params["id"])
           when 'show'.freeze
-            add_breadcrumb presenter.parent.to_s, main_app.polymorphic_path(presenter.parent)
+            add_breadcrumb presenter.parent.to_s, main_app.polymorphic_path(presenter.parent) if presenter.parent
             add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
           end
         end


### PR DESCRIPTION
Trying to render the Show page for a FileSet missing a parent generates ruby errors in the controller and view partials, which prevents looking at such a file in the UI.  This patches the controller and partials to continue rendering the page.

Note that, in principle, a FileSet is meant to always have a parent -- but it can be an orphan as a result of various circumstances, one of them being mid-import in newer versions of bulkrax that can generate an object then run a separate job later to create its relationships.