### PR TITLE
External body spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,11 @@ jobs:
           MYSQL_DATABASE: essi_test
           MYSQL_USER: essi
           MYSQL_PASSWORD: essi
+      - image: bitnami/minio:latest
+        environment:
+          MINIO_ROOT_USER: essi-minio
+          MINIO_ROOT_PASSWORD: Essi12345
+          MINIO_DEFAULT_BUCKETS: 'essi-test'
 
     resource_class: medium+
     parallelism: 4

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -52,6 +52,17 @@ describe Hyrax::Actors::FileActor do
         file_actor.ingest_file(io)
         expect(file_set.reload.original_file.mime_type).to include "image/png"
       end
+      context 'when :store_in_external_storage is true' do
+        before do
+          allow(ESSI.config).to receive(:dig) \
+                                  .with(:essi, :store_in_external_storage) \
+                                  .and_return(true)
+        end
+        it 'saves an image file to the member file_set as an external file' do
+          file_actor.ingest_file(io)
+          expect(file_set.reload.original_file.mime_type).to include "message/external-body;access-type=URL;url="
+        end
+      end
       context 'when the file_set is for collection branding' do
         before do
           allow(file_set).to receive(:collection_branding?).and_return(true)

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -48,9 +48,16 @@ describe Hyrax::Actors::FileActor do
           .with(:essi, :store_original_files) \
           .and_return(true)
       end
-      it 'saves an image file to the member file_set' do
-        file_actor.ingest_file(io)
-        expect(file_set.reload.original_file.mime_type).to include "image/png"
+      context 'when :store_in_external_storage is false' do
+        before do
+          allow(ESSI.config).to receive(:dig) \
+                                  .with(:essi, :store_in_external_storage) \
+                                  .and_return(false)
+        end
+        it 'saves an image file to the member file_set' do
+          file_actor.ingest_file(io)
+          expect(file_set.reload.original_file.mime_type).to include "image/png"
+        end
       end
       context 'when :store_in_external_storage is true' do
         before do


### PR DESCRIPTION
Adds spec for enabled external storage. We may want to enable external storage for all tests via essi_config.example.yml?