### PR TITLE
[ESSI-875] patch Entry#multiple? to stop forcing rights_statement multi-valued

### DIFF
--- a/lib/extensions/bulkrax/entry/multiple_check.rb
+++ b/lib/extensions/bulkrax/entry/multiple_check.rb
@@ -1,14 +1,14 @@
-# unmodified from bulkrax 5.5.1
+# modified from bulkrax 5.5.1
 module Extensions
   module Bulkrax
     module Entry
       module MultipleCheck
+        # modified to remove hard assertion that rights_statement is necessarily multi-valued
         def multiple?(field)
           @multiple_bulkrax_fields ||=
             %W[
               file
               remote_files
-              rights_statement
               #{related_parents_parsed_mapping}
               #{related_children_parsed_mapping}
             ]

--- a/lib/extensions/bulkrax/entry/multiple_check.rb
+++ b/lib/extensions/bulkrax/entry/multiple_check.rb
@@ -1,0 +1,24 @@
+# unmodified from bulkrax 5.5.1
+module Extensions
+  module Bulkrax
+    module Entry
+      module MultipleCheck
+        def multiple?(field)
+          @multiple_bulkrax_fields ||=
+            %W[
+              file
+              remote_files
+              rights_statement
+              #{related_parents_parsed_mapping}
+              #{related_children_parsed_mapping}
+            ]
+            
+          return true if @multiple_bulkrax_fields.include?(field)
+          return false if field == 'model'
+              
+          field_supported?(field) && factory_class&.properties&.[](field)&.[]('multiple')
+        end
+      end
+    end
+  end
+end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -65,6 +65,7 @@ Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::RemoveUpdateF
 # bulkrax/allinson_flex integration support
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::AllinsonFlexFields
 Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::SingularizeRightsStatement
+Bulkrax::Entry.prepend Extensions::Bulkrax::Entry::MultipleCheck
 Bulkrax::CsvEntry.prepend Extensions::Bulkrax::Entry::DynamicSchemaField
 Bulkrax::MetsXmlEntry.prepend Extensions::Bulkrax::Entry::DynamicSchemaField
 Bulkrax::ObjectFactory.prepend Extensions::Bulkrax::ObjectFactory::CreateWithDynamicSchema


### PR DESCRIPTION
Similar in spirit to our existing `SingularizeRightsStatement` patch, just stops a hard assertion that `rights_statement` is _necessarily_ multi-valued, and instead just _checks_ whether it's multi-valued, like it does for every other property that's not specific to bulkrax import (file, remote_files, parents, children).