### PR TITLE
Skip collections facet filtering to restore behavior in solr 6

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -181,6 +181,7 @@ IiifPrint::Metadata.prepend Extensions::IiifPrint::Metadata::FacetedValuesForCam
 
 # Patch iiif_print for solr 9
 IiifPrint::HighlightSearchParams.include Extensions::IiifPrint::HighlightSearchParams::HighlightSearchParamsCompatibility
+IiifPrint::CatalogSearchBuilder.include Extensions::IiifPrint::CatalogSearchBuilder::SkipCollectionsFacetFiltering
 
 # support for nested works generating file_set sequences in manifests
 IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFManifest::ManifestBuilder::DeepFileSetEnumerator::NestedEach

--- a/lib/extensions/iiif_print/catalog_search_builder/skip_collections_facet_filtering.rb
+++ b/lib/extensions/iiif_print/catalog_search_builder/skip_collections_facet_filtering.rb
@@ -1,0 +1,13 @@
+module Extensions
+  module IiifPrint
+    module CatalogSearchBuilder
+      module SkipCollectionsFacetFiltering
+        def self.included(base)
+          base.class_eval do
+            self.default_processor_chain -= [:filter_collection_facet_for_access]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Filtering of collections facets to collections a user has explicit grants to view was added to core hyrax in https://github.com/samvera/hyrax/pull/3102.  This functionality relies on solr's `facet.matches` query parameter which was added to solr after version 6.  Upgrading to solr 9 causes this functionality to turn on changing the existing behavior.  The risk of exposing private collection names in the facet (private collection view pages aren't visible) is less than losing the display of public collections that users (or the public group) haven't been explicitly added to.

Resolves part of https://iu-uits.atlassian.net/browse/ESSI-2077?focusedCommentId=2419906

I manually tested this locally and collections are showing up in facet when not logged in. Should this have unit tests added?