### PR TITLE
[ESSI-2106] patch works disappearing from search results after bulkrax update

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -183,6 +183,9 @@ IiifPrint::Metadata.prepend Extensions::IiifPrint::Metadata::FacetedValuesForCam
 IiifPrint::HighlightSearchParams.include Extensions::IiifPrint::HighlightSearchParams::HighlightSearchParamsCompatibility
 IiifPrint::CatalogSearchBuilder.include Extensions::IiifPrint::CatalogSearchBuilder::SkipCollectionsFacetFiltering
 
+# Patch iiif_print for broken is_child filtering
+IiifPrint::CatalogSearchBuilder.prepend Extensions::IiifPrint::CatalogSearchBuilder::FixIsChildFiltering
+
 # support for nested works generating file_set sequences in manifests
 IIIFManifest::ManifestBuilder::DeepFileSetEnumerator.prepend Extensions::IIIFManifest::ManifestBuilder::DeepFileSetEnumerator::NestedEach
 

--- a/lib/extensions/iiif_print/catalog_search_builder/fix_is_child_filtering.rb
+++ b/lib/extensions/iiif_print/catalog_search_builder/fix_is_child_filtering.rb
@@ -2,14 +2,15 @@ module Extensions
   module IiifPrint
     module CatalogSearchBuilder
       module FixIsChildFiltering
-        # unmodified from iiif_print b804f16
+        # modified from iiif_print b804f16
+        # drops broken filter for else case, iiif_print issue #389
         def show_parents_only(solr_parameters)
           query = if blacklight_params["include_child_works"] == 'true'
                     ::ActiveFedora::SolrQueryBuilder.construct_query(is_child_bsi: 'true')
                   else
-                    ::ActiveFedora::SolrQueryBuilder.construct_query(is_child_bsi: nil)
+                    nil # ::ActiveFedora::SolrQueryBuilder.construct_query(is_child_bsi: nil)
                   end
-          solr_parameters[:fq] += [query]
+          solr_parameters[:fq] += [query] if query
         end
       end
     end

--- a/lib/extensions/iiif_print/catalog_search_builder/fix_is_child_filtering.rb
+++ b/lib/extensions/iiif_print/catalog_search_builder/fix_is_child_filtering.rb
@@ -1,0 +1,17 @@
+module Extensions
+  module IiifPrint
+    module CatalogSearchBuilder
+      module FixIsChildFiltering
+        # unmodified from iiif_print b804f16
+        def show_parents_only(solr_parameters)
+          query = if blacklight_params["include_child_works"] == 'true'
+                    ::ActiveFedora::SolrQueryBuilder.construct_query(is_child_bsi: 'true')
+                  else
+                    ::ActiveFedora::SolrQueryBuilder.construct_query(is_child_bsi: nil)
+                  end
+          solr_parameters[:fq] += [query]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Patch for iiif_print issue: https://github.com/notch8/iiif_print/issues/389

Before patch, on current main: after saving a work with an `is_child` value assigned (of `true` or `false`), resulting in some value being indexed in the solr field `is_child_bsi`, the work stops appearing in catalog search results.  It only appears when the `is_child` value in `nil`, resulting in no `is_child_bsi` solr index value.

After patch: work should start showing up in catalog search results, again.

Note that although bug is also present in `IiifPrint::HomepageSearchBuilder`, we're only using `IiifPrint::CatalogSearchBuilder`.