### PR TITLE
Refactoring PrederivationHelper to allow for derivatives not grouped in folders by ID

### DIFF
--- a/app/helpers/prederivation_helper.rb
+++ b/app/helpers/prederivation_helper.rb
@@ -1,33 +1,42 @@
 module PrederivationHelper
+
   def work_root_name(filename)
     filename.split('/').last.split('-').first
   end
 
   def derivatives_folder_for(filename, type: '')
-    derivatives_folder = ESSI.config.dig(:essi, :derivatives_folder)
-    return false unless derivatives_folder
-    folders = Array.wrap(derivatives_folder)
+    return false unless root_derivatives_folder
+    folders = Array.wrap(root_derivatives_folder)
     folders << type.downcase if path_includes_type?
     folders << work_root_name(filename) if path_includes_work_root_name?
     File.join(folders)
   end
 
   def pre_derived_file(filename, type: '', suffix: 'xml')
-    Rails.logger.info "Checking for a Pre-derived #{type} folder."
-    derivatives_folder = derivatives_folder_for(filename, type: type)
-    return false unless derivatives_folder && Dir.exists?(derivatives_folder.to_s)
-
-    Rails.logger.info "Checking for a Pre-derived #{type} file."
     if file_includes_type?
       pre_derived_filename = "#{File.basename(filename, '.*')}-#{type.downcase}.#{suffix}"
     else
       pre_derived_filename = "#{File.basename(filename, '.*')}.#{suffix}"
     end
-    pre_derived_file = File.join(derivatives_folder, pre_derived_filename)
+
+    Rails.logger.info "Checking for #{pre_derived_filename} in #{type} folders."
+
+    ungrouped_filename = File.join(root_derivatives_folder, type.downcase, 'ungrouped', pre_derived_filename)
+    if ungrouped_file_path?(ungrouped_filename)
+      pre_derived_file = ungrouped_filename
+    else
+      derivatives_folder = derivatives_folder_for(filename, type: type)
+      pre_derived_file = File.join(derivatives_folder, pre_derived_filename)
+    end
+
     return false unless File.exist?(pre_derived_file)
 
-    Rails.logger.info "Using Pre-derived #{type} file."
+    Rails.logger.info "Using #{pre_derived_file} as #{type} file."
     pre_derived_file
+  end
+
+  def root_derivatives_folder
+    ESSI.config.dig(:essi, :derivatives_folder)
   end
 
   def path_includes_type?
@@ -40,5 +49,10 @@ module PrederivationHelper
 
   def file_includes_type?
     ESSI.config.dig(:essi, :derivatives_type_suffix)
+  end
+
+  def ungrouped_file_path?(ungrouped_filename)
+    return false unless File.exist?(ungrouped_filename)
+    true
   end
 end

--- a/spec/services/hyrax/derivative_service_spec.rb
+++ b/spec/services/hyrax/derivative_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Hyrax::DerivativeService do
         end
         # simulate action of stubbed OCRRunner#create via Processor::OCR#encode_file
         it 'skips OCR generation in OCR Processor' do
-          expect(Rails.logger).to receive(:info).with("Checking for a Pre-derived OCR folder.")
+          expect(Rails.logger).to receive(:info).with("Checking for world-ocr.xml in OCR folders.")
           expect(Processors::OCR).to receive(:skip_derivatives?).and_return(true)
           expect(Rails.logger).to receive(:info).with("No pre-derived file provided; skipping OCR generation")
           Processors::OCR.new(image_file,


### PR DESCRIPTION
The `PrederivationHelper` helper expects files to be grouped into folders whose names are derived from the filenames (i.e. `VAA1234/VAA1234-0001.tif`) .  That's so that root level folders don't accumulate thousands of files that are hard to browse or could become a performance problem.  But, that ends up not working for the case where file naming is random, variable length, and contains no hint of a logical grouping (i.e. `P01234.tif`, `P0000001.tif` etc.)

This PR adds the ability to look for matching derivative files in generic "ungrouped" folders, so that resulting files (i.e. from `imageproc`) can just output to:
```
jp2/ungrouped
ptif/ungrouped
ocr/ungrouped
characterization/ungrouped
```
It still maintains the ability to process files that are logically grouped into folders and the files inherently infer the folder names.