### PR TITLE
[ESSI-2130] apply Fedora/S3 file retrieval for OCR generation, characterization, PDF generation, download

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -10,16 +10,9 @@ class CharacterizeJob < ApplicationJob
   def perform(file_set, file_id, filepath = nil, derivation_path = nil, delete_characterization_path = false)
     raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
     unless filepath && File.exist?(filepath)
-      if file_set.content_location&.start_with?('s3://') # Ensure external file is available locally
-        ext_id = file_set.content_location.split('/').last
-        ext_resp = ESSI.external_storage.get(ext_id)
-        filepath = Hyrax::WorkingDirectory.send(:copy_stream_to_working_directory, ext_id, ext_id, ext_resp.body)
-        delete_characterization_path = true
-      else
-        filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id)
-        delete_characterization_path = false
-      end
+      delete_characterization_path = file_set.external?
     end
+    filepath = file_set.find_or_retrieve(file_id: file_id, filepath: filepath)
     Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filepath)
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.save!

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -16,7 +16,7 @@ class CharacterizeJob < ApplicationJob
         filepath = Hyrax::WorkingDirectory.send(:copy_stream_to_working_directory, ext_id, ext_id, ext_resp.body)
         delete_characterization_path = true
       else
-        filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id) unless filepath && File.exist?(filepath)
+        filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id)
         delete_characterization_path = false
       end
     end

--- a/app/jobs/create_ocr_job.rb
+++ b/app/jobs/create_ocr_job.rb
@@ -7,15 +7,7 @@ class CreateOCRJob < CreateDerivativesJob
   def perform(file_set, file_id, filepath = nil)
     return if file_set.video? && !Hyrax.config.enable_ffmpeg
 
-    unless filepath && File.exist?(filepath)
-      if file_set.content_location&.start_with?('s3://') # Ensure external file is available locally
-        ext_id = file_set.content_location.split('/').last
-        ext_resp = ESSI.external_storage.get(ext_id)
-        filepath = Hyrax::WorkingDirectory.send(:copy_stream_to_working_directory, ext_id, ext_id, ext_resp.body)
-      else
-        filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id)
-      end
-    end
+    filepath = file_set.find_or_retrieve(file_id: file_id, filepath: filepath)
 
     # using #create_derivatives instead of #create_ocr_derivatives to use IIIF Print
     # @see https://github.com/scientist-softserv/iiif_print/blob/d14246664048c708071c7ff4de2e9a34aa703465/app/services/iiif_print/pluggable_derivative_service.rb#L25

--- a/app/jobs/create_ocr_job.rb
+++ b/app/jobs/create_ocr_job.rb
@@ -6,11 +6,20 @@ class CreateOCRJob < CreateDerivativesJob
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
   def perform(file_set, file_id, filepath = nil)
     return if file_set.video? && !Hyrax.config.enable_ffmpeg
-    filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
+
+    unless filepath && File.exist?(filepath)
+      if file_set.content_location&.start_with?('s3://') # Ensure external file is available locally
+        ext_id = file_set.content_location.split('/').last
+        ext_resp = ESSI.external_storage.get(ext_id)
+        filepath = Hyrax::WorkingDirectory.send(:copy_stream_to_working_directory, ext_id, ext_id, ext_resp.body)
+      else
+        filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id)
+      end
+    end
 
     # using #create_derivatives instead of #create_ocr_derivatives to use IIIF Print
     # @see https://github.com/scientist-softserv/iiif_print/blob/d14246664048c708071c7ff4de2e9a34aa703465/app/services/iiif_print/pluggable_derivative_service.rb#L25
-    file_set.send(:file_set_derivatives_service).send(:create_derivatives, filename)
+    file_set.send(:file_set_derivatives_service).send(:create_derivatives, filepath)
 
     # Reload from Fedora and reindex for thumbnail and extracted text
     file_set.reload

--- a/app/services/essi/generate_pdf_service.rb
+++ b/app/services/essi/generate_pdf_service.rb
@@ -73,7 +73,15 @@ module ESSI
     def generate_width(file_set_id)
       begin
         file_set = FileSet.find(file_set_id)
-        filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_set.original_file.id, file_set.id)
+
+        if file_set.content_location&.start_with?('s3://') # Ensure external file is available locally
+          ext_id = file_set.content_location.split('/').last
+          ext_resp = ESSI.external_storage.get(ext_id)
+          filepath = Hyrax::WorkingDirectory.send(:copy_stream_to_working_directory, ext_id, ext_id, ext_resp.body)
+        else
+          filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_set.original_file.id, file_set.id)
+        end
+
         terms = Hydra::Works::CharacterizationService.run(file_set.original_file, filepath)
         CharacterizeJob.perform_later(file_set, file_set.original_file.id)
       rescue

--- a/app/services/essi/generate_pdf_service.rb
+++ b/app/services/essi/generate_pdf_service.rb
@@ -73,15 +73,7 @@ module ESSI
     def generate_width(file_set_id)
       begin
         file_set = FileSet.find(file_set_id)
-
-        if file_set.content_location&.start_with?('s3://') # Ensure external file is available locally
-          ext_id = file_set.content_location.split('/').last
-          ext_resp = ESSI.external_storage.get(ext_id)
-          filepath = Hyrax::WorkingDirectory.send(:copy_stream_to_working_directory, ext_id, ext_id, ext_resp.body)
-        else
-          filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_set.original_file.id, file_set.id)
-        end
-
+        filepath = file_set.find_or_retrieve
         terms = Hydra::Works::CharacterizationService.run(file_set.original_file, filepath)
         CharacterizeJob.perform_later(file_set, file_set.original_file.id)
       rescue

--- a/lib/extensions/hyrax/downloads_controller/external_storage.rb
+++ b/lib/extensions/hyrax/downloads_controller/external_storage.rb
@@ -6,8 +6,8 @@ module Extensions
         def show
           if params[:file] && params[:file] == 'extracted_text'
             super
-          elsif asset.content_location&.start_with?('s3://')
-            ext_id = asset.content_location.split('/').last
+          elsif asset.try(:external?)
+            ext_id = asset.external_id
             external_asset = ESSI.external_storage.get(ext_id)
             send_data external_asset.body.read, filename: ext_id
           else

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -36,4 +36,78 @@ RSpec.describe FileSet do
       end
     end
   end
+
+  let(:external_id) { "s3_id" }
+  let(:external_location) { "s3://#{external_id}" }
+
+  describe "#external?" do
+    context "when stored in S3" do
+      before { allow(file_set).to receive(:content_location).and_return(external_location) }
+      it "returns true" do
+        expect(file_set.external?).to eq true
+      end
+    end
+    context "when stored in Fedora" do
+      it "returns false" do
+        expect(file_set.external?).to eq false
+      end
+    end
+  end
+
+  describe "#external_id" do
+    context "when stored in S3" do
+      before { allow(file_set).to receive(:content_location).and_return(external_location) }
+      it "returns the S3 internal id" do
+        expect(file_set.external_id).to eq external_id
+      end
+    end
+    context "when stored in Fedora" do
+      it "returns nil" do
+        expect(file_set.external_id).to be_nil
+      end
+    end
+  end
+
+  describe "#find_or_retrieve" do
+    shared_examples "find_or_retrieve examples" do |argument_filepath|
+      context "when file is stored in S3" do
+        before { allow(file_set).to receive(:content_location).and_return(external_location) }
+        let(:output_filepath) { 'filepath_from_s3' }
+        before { allow(ESSI.external_storage).to receive(:find_or_retrieve).and_return(output_filepath) }
+        it "calls ESSI.external_storage.find_or_retrieve" do
+          expect(ESSI.external_storage).to receive(:find_or_retrieve)
+          file_set.find_or_retrieve(filepath: argument_filepath)
+        end
+        it "returns filepath" do
+          expect(file_set.find_or_retrieve(filepath: argument_filepath)).to eq output_filepath
+        end
+      end
+      context "when file is stored in Fedora" do
+        let(:output_filepath) { 'filepath_from_fedora' }
+        before { allow(Hyrax::WorkingDirectory).to receive(:find_or_retrieve).and_return(output_filepath) }
+        it "calls Hyrax::WorkingDirectory.find_or_retrieve" do
+          expect(Hyrax::WorkingDirectory).to receive(:find_or_retrieve)
+          file_set.find_or_retrieve(filepath: argument_filepath)
+        end
+        it "returns filepath" do
+          expect(file_set.find_or_retrieve(filepath: argument_filepath)).to eq output_filepath
+        end
+      end
+    end
+    context "when filepath provided" do
+      let(:argument_filepath) { '/tmp/existing_file.txt' }
+      context "when file present" do
+        before { allow(File).to receive(:exist?).with(argument_filepath).and_return(true) }
+        it "returns the filepath" do
+          expect(file_set.find_or_retrieve(filepath: argument_filepath)).to eq argument_filepath
+        end
+      end
+      context "when file absent" do
+        include_examples "find_or_retrieve examples", '/tmp/existing_file.txt'
+      end
+    end
+    context "when filepath not provided" do
+      include_examples "find_or_retrieve examples", nil
+    end
+  end
 end

--- a/spec/services/essi/external_storage_service_spec.rb
+++ b/spec/services/essi/external_storage_service_spec.rb
@@ -42,4 +42,83 @@ RSpec.describe ESSI::ExternalStorageService do
       expect(service.prefix_id(id)).to eq('ext-store/es/si/-e/xt/essi-ext-store-spec')
     end
   end
+
+  let(:file_set) { FactoryBot.build(:file_set) }
+  let(:external_id) { "s3_id" }
+  let(:external_location) { "s3://#{external_id}" }
+  describe "#external?" do
+    context "when stored in S3" do
+      before { allow(file_set).to receive(:content_location).and_return(external_location) }
+      it "returns true" do
+        expect(service.external?(file_set)).to eq true
+      end
+    end
+    context "when stored in Fedora" do
+      it "returns false" do
+        expect(service.external?(file_set)).to eq false
+      end
+    end
+  end
+
+  describe "#external_id" do
+    context "when stored in S3" do
+      before { allow(file_set).to receive(:content_location).and_return(external_location) }
+      it "returns the S3 internal id" do
+        expect(service.external_id(file_set)).to eq external_id
+      end
+    end
+    context "when stored in Fedora" do
+      it "returns nil" do
+        expect(file_set.external_id).to be_nil
+      end
+    end
+  end
+
+  describe "#find_or_retrieve" do
+    shared_examples "find_or_retrieve examples" do |argument_filepath|
+      context "when file is stored in S3" do
+        let(:output_filepath) { 'filepath_from_s3' }
+        before do
+          allow(file_set).to receive(:content_location).and_return("s3://server/external_id")
+          allow(service).to receive(:get).and_return(double(body: nil))
+          allow(Hyrax::WorkingDirectory).to receive(:copy_stream_to_working_directory).and_return(output_filepath)
+        end
+        it "retrieves external file content" do
+          expect(service).to receive(:get)
+          service.find_or_retrieve(file_set, filepath: argument_filepath)
+        end
+        it "copies stream to working directory" do
+          expect(Hyrax::WorkingDirectory).to receive(:copy_stream_to_working_directory)
+          service.find_or_retrieve(file_set, filepath: argument_filepath)
+        end
+        it "returns filepath" do
+          expect(service.find_or_retrieve(file_set, filepath: argument_filepath)).to eq output_filepath
+        end
+      end
+      context "when file is stored in Fedora" do
+        it "logs warning" do
+          expect(Rails.logger).to receive(:warn)
+          service.find_or_retrieve(file_set, filepath: argument_filepath)
+        end
+        it "returns nil" do
+          expect(service.find_or_retrieve(file_set, filepath: argument_filepath)).to be_nil
+        end
+      end
+    end
+    context "when filepath provided" do
+      let(:argument_filepath) { '/tmp/existing_file.txt' }
+      context "when file present" do
+        before { allow(File).to receive(:exist?).with(argument_filepath).and_return(true) }
+        it "returns the filepath" do
+          expect(service.find_or_retrieve(file_set, filepath: argument_filepath)).to eq argument_filepath
+        end
+      end
+      context "when file absent" do
+        include_examples "find_or_retrieve examples", '/tmp/existing_file.txt'
+      end
+    end
+    context "when filepath not provided" do
+      include_examples "find_or_retrieve examples", nil
+    end
+  end
 end


### PR DESCRIPTION
Currently, the CharacterizeJob and download action have logic to retrieve files from either Fedora or S3 storage, but corresponding updates are missing from CreateOCRJob and PDF generation.

First commit applies corresponding updates where they're missing; second commit condenses duplicate logic into new methods.