### PR TITLE
[ESSI-2119] more error logging

### DIFF
--- a/app/models/archival_material.rb
+++ b/app/models/archival_material.rb
@@ -8,6 +8,7 @@ class ArchivalMaterial < ActiveFedora::Base
   include ESSI::OCRBehavior
   include ESSI::PDFBehavior
   include ESSI::PDFDefaultDownloadable
+  include ESSI::SolrErrorBehavior
 
   self.indexer = ArchivalMaterialIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/archival_material.rb
+++ b/app/models/archival_material.rb
@@ -9,6 +9,7 @@ class ArchivalMaterial < ActiveFedora::Base
   include ESSI::PDFBehavior
   include ESSI::PDFDefaultDownloadable
   include ESSI::SolrErrorBehavior
+  include ESSI::OrderedMembersNilValues
 
   self.indexer = ArchivalMaterialIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/bib_record.rb
+++ b/app/models/bib_record.rb
@@ -7,6 +7,7 @@ class BibRecord < ActiveFedora::Base
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
   include ESSI::SolrErrorBehavior
+  include ESSI::OrderedMembersNilValues
 
   self.indexer = BibRecordIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/bib_record.rb
+++ b/app/models/bib_record.rb
@@ -6,6 +6,7 @@ class BibRecord < ActiveFedora::Base
   include ExtraLockable
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
+  include ESSI::SolrErrorBehavior
 
   self.indexer = BibRecordIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -6,6 +6,7 @@ class Collection < ActiveFedora::Base
   include ::ESSI::CollectionBehavior
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
+  include ESSI::SolrErrorBehavior
 
   self.indexer = ESSI::CollectionIndexer
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -7,6 +7,7 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
   include ESSI::SolrErrorBehavior
+  include ESSI::OrderedMembersNilValues
 
   self.indexer = ESSI::CollectionIndexer
 

--- a/app/models/concerns/essi/ordered_members_nil_values.rb
+++ b/app/models/concerns/essi/ordered_members_nil_values.rb
@@ -1,0 +1,11 @@
+module ESSI
+  module OrderedMembersNilValues
+    extend ActiveSupport::Concern
+
+    def ordered_members
+      result = super
+      Rails.logger.error("Nil values present in ordered_members of #{self.class.to_s} #{self.id}") if result.to_a.any?(&:nil?)
+      result
+    end
+  end
+end

--- a/app/models/concerns/essi/solr_error_behavior.rb
+++ b/app/models/concerns/essi/solr_error_behavior.rb
@@ -1,0 +1,14 @@
+module ESSI
+  module SolrErrorBehavior
+    extend ActiveSupport::Concern
+
+    def to_solr(solr_doc = {})
+      begin
+        super
+      rescue => e
+        Rails.logger.error("Error in #to_solr for #{self.class.to_s} #{self.id}: #{e.inspect}")
+        raise e
+      end
+    end
+  end
+end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -4,6 +4,7 @@ class FileSet < ActiveFedora::Base
   include ESSI::RemoteLookupMetadata
   include ::Hyrax::FileSetBehavior
   include ESSI::SolrErrorBehavior
+  include ESSI::OrderedMembersNilValues
 
   directly_contains_one :preservation_master_file, through: :files, type: ::RDF::URI('http://pcdm.org/use#PreservationMasterFile'), class_name: 'Hydra::PCDM::File'
 

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -3,6 +3,7 @@ class FileSet < ActiveFedora::Base
   include ESSI::FileSetMetadata
   include ESSI::RemoteLookupMetadata
   include ::Hyrax::FileSetBehavior
+  include ESSI::SolrErrorBehavior
 
   directly_contains_one :preservation_master_file, through: :files, type: ::RDF::URI('http://pcdm.org/use#PreservationMasterFile'), class_name: 'Hydra::PCDM::File'
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -6,6 +6,7 @@ class Image < ActiveFedora::Base
   include ExtraLockable
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
+  include ESSI::SolrErrorBehavior
 
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -7,6 +7,7 @@ class Image < ActiveFedora::Base
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
   include ESSI::SolrErrorBehavior
+  include ESSI::OrderedMembersNilValues
 
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/paged_resource.rb
+++ b/app/models/paged_resource.rb
@@ -8,6 +8,7 @@ class PagedResource < ActiveFedora::Base
   include ESSI::OCRBehavior
   include ESSI::PDFBehavior
   include ESSI::SolrErrorBehavior
+  include ESSI::OrderedMembersNilValues
 
   self.indexer = PagedResourceIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/paged_resource.rb
+++ b/app/models/paged_resource.rb
@@ -7,6 +7,7 @@ class PagedResource < ActiveFedora::Base
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
   include ESSI::PDFBehavior
+  include ESSI::SolrErrorBehavior
 
   self.indexer = PagedResourceIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/scientific.rb
+++ b/app/models/scientific.rb
@@ -7,6 +7,7 @@ class Scientific < ActiveFedora::Base
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
   include ESSI::SolrErrorBehavior
+  include ESSI::OrderedMembersNilValues
 
   self.indexer = ScientificIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/scientific.rb
+++ b/app/models/scientific.rb
@@ -6,6 +6,7 @@ class Scientific < ActiveFedora::Base
   include ExtraLockable
   include ESSI::NumPagesBehavior
   include ESSI::OCRBehavior
+  include ESSI::SolrErrorBehavior
 
   self.indexer = ScientificIndexer
   # Change this to restrict which works can be added as a child.


### PR DESCRIPTION
Investigating the broken works for ESSI-2119 ran across a couple of cases where uncaught errors can arise.  The changes here don't catch them, but do add outermost wrappers to log them when they arise:

`#to_solr` has a pretty deep stack of `super` calls, with errors possible at each step.  This adds a new outermost `#to_solr` to log any errors.

`#ordered_members` isn't supposed to ever contain `nil` values, but sometimes it does, which breaks (among other things) `#ordered_works` calls.  This adds a module to log an error for `nil` values, any time they are found during an `#ordered_members` call.