### PR TITLE
[ESSI-2129] [ESSI-2133] store max height, width characterized

### DIFF
--- a/lib/extensions/hydra/works/characterization_service/precharacterization.rb
+++ b/lib/extensions/hydra/works/characterization_service/precharacterization.rb
@@ -18,7 +18,16 @@ module Extensions
             extracted_md = extract_metadata(content)
           end
           terms = parse_metadata(extracted_md)
+          terms = revise_metadata(terms)
           store_metadata(terms)
+        end
+
+        # for pyramidal tiffs characterized at multiple resolutions, use max
+        def revise_metadata(terms)
+          [:width, :height].each do |k|
+            terms[k] = [terms[k].map(&:to_i).max.to_s] if terms[k]&.size > 1
+          end
+          terms
         end
   
         def precharacterization(filename)


### PR DESCRIPTION
Characterization can _potentially_ produce multiple values for width and height, for pyramidal tiffs.  In the event that it does: we only want the maximal values, so this adds a step in parsing the output of characterization before storing it, to ensure that's what we get.

(Note that I think characterization output from `fits.sh` is _only_ outputting the minimal resolution, but I think we want this change to add robustness when we do start getting the maximal resolution.)