### PR TITLE
More tweaks to the designated archival repository statement on the welcome page

### DIFF
--- a/app/views/hyrax/homepage/_home_content_welcome.html.erb
+++ b/app/views/hyrax/homepage/_home_content_welcome.html.erb
@@ -1,16 +1,16 @@
 <h1>Welcome to Digital Collections</h1>
 <p>
-  Digital Collections is a growing repository of digital image collections held at Indiana University campuses.  Please see our
+  Digital Collections is a growing repository of digital image collections held at Indiana University campuses.
+  This site is a
+  <%= link_to 'Designated Archival Repository', 'https://libraries.indiana.edu/designated-archival-repository',
+              title: "Learn more about why this site is a Designated Archival Repository."
+  %>, and some content may not meet current accessibility standards.
+  Please see our
   <%= link_to 'About', '/about',
       title: "Learn more about Digital Collections and tips for searching the site."
   %> page for more information about this service.
 </p>
-<p>
-  This site is a
-  <%= link_to 'Designated Archival Repository', 'https://libraries.indiana.edu/digital-materials-accessibility',
-      title: "Learn more about why this site is a Designated Archival Repository."
-  %>, and some content may not meet current accessibility standards.
-</p>
+
 <div class="collection-counts-wrapper">
   As of <%= Time.now.strftime("%B %d, %Y") %>, Digital Collections contains:
   <div class="collection-counts-item">


### PR DESCRIPTION
Previous PR #728 added new links for designated archival repository to the welcome page, but I overlooked the specs for the layout and also got the link URL wrong.