### PR TITLE
[ESSI-2241] provide ldap config for member_allowlist

### DIFF
--- a/config/initializers/ldap_groups_lookup.rb
+++ b/config/initializers/ldap_groups_lookup.rb
@@ -14,5 +14,6 @@ LDAPGroupsLookup.config = {
   },
   tree: ESSI.config[:ldap][:tree],
   account_ou: ESSI.config[:ldap][:account_ou],
-  group_ou: ESSI.config[:ldap][:group_ou]
+  group_ou: ESSI.config[:ldap][:group_ou],
+  member_allowlist: ESSI.config[:ldap][:member_allowlist]
 }


### PR DESCRIPTION
The concordant config change is adding `member_allowlist` under the `ldap` section, set to:
`['OU=Managed']`
to override the default value ['OU=Groups'] that is used when no config value is found.