### PR TITLE
Test with nodejs 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - checkout
       - node/install:
           install-yarn: true
-          node-version: '20.20'
+          node-version: '24'
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
 


### PR DESCRIPTION
#742 only bumped nodejs to 20.x which is EOL.  This PR brings it up to 24.x and in line with the docker image being built in #745 