### PR TITLE
Set SSL ENV needed for ruby to find SSL certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ ENV RUBY_VERSION=2.7.8 \
 # OpenSSL 1.1.1 compatibility version for Ruby 2.7.8
 ENV OPENSSL_VERSION=1.1.1w \
     OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source/openssl-1.1.1w.tar.gz \
-    OPENSSL_DOWNLOAD_SHA256=cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
+    OPENSSL_DOWNLOAD_SHA256=cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8 \
+    SSL_CERT_DIR=/etc/ssl/certs \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 RUN set -eux; \
         # Compile OpenSSL 1.1.1 from source


### PR DESCRIPTION
Faraday isn't able to make any SSL connections due to ruby not being able to find the system certificates.  Setting these environment variables seemed to resolve it for me locally.  This should fix dcadmin-devel which can't start up since it tries to make an SSL call to solr while it is booting.